### PR TITLE
Disallow JSON-RPC `id` on MCP notifications

### DIFF
--- a/src/self/v1/schemas/mcp/notifications/cancelled.json
+++ b/src/self/v1/schemas/mcp/notifications/cancelled.json
@@ -28,6 +28,7 @@
     "method": {
       "const": "notifications/cancelled"
     },
+    "id": false,
     "params": {
       "type": "object",
       "properties": {

--- a/src/self/v1/schemas/mcp/notifications/initialized.json
+++ b/src/self/v1/schemas/mcp/notifications/initialized.json
@@ -17,6 +17,7 @@
     "method": {
       "const": "notifications/initialized"
     },
+    "id": false,
     "params": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
