### PR TITLE
Rename action `.run()` methods to `.rest()`

### DIFF
--- a/enterprise/server/action_mcp_v1.cc
+++ b/enterprise/server/action_mcp_v1.cc
@@ -376,8 +376,8 @@ EnterpriseMCP::EnterpriseMCP(
   this->mcp_metadata_ = std::move(mcp_metadata_option.value());
 }
 
-auto EnterpriseMCP::run(sourcemeta::one::HTTPRequest &request,
-                        sourcemeta::one::HTTPResponse &response) -> void {
+auto EnterpriseMCP::rest(sourcemeta::one::HTTPRequest &request,
+                         sourcemeta::one::HTTPResponse &response) -> void {
   const auto origin_header{request.header("origin")};
   if (!origin_header.empty() && origin_header != this->allowed_origin_) {
     write_envelope(request, response, this->allowed_origin_,

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_actions.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_actions.h
@@ -25,8 +25,8 @@ public:
   auto operator=(EnterpriseMCP &&) -> EnterpriseMCP & = delete;
   ~EnterpriseMCP() = default;
 
-  auto run(sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void;
+  auto rest(sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void;
 
 private:
   std::filesystem::path base_;

--- a/src/actions/action_default_v1.h
+++ b/src/actions/action_default_v1.h
@@ -28,9 +28,9 @@ public:
     });
   }
 
-  auto run(const std::span<std::string_view>,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
+  auto rest(const std::span<std::string_view>,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
     auto path{request.path()};
     if (!this->base_path().empty()) {
       if (!path.starts_with(this->base_path()) ||

--- a/src/actions/action_health_check_v1.h
+++ b/src/actions/action_health_check_v1.h
@@ -25,9 +25,9 @@ public:
     });
   }
 
-  auto run(const std::span<std::string_view>,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
+  auto rest(const std::span<std::string_view>,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() != "get" && request.method() != "head") {
       sourcemeta::one::json_error(
           request, response, sourcemeta::one::STATUS_METHOD_NOT_ALLOWED,

--- a/src/actions/action_jsonschema_evaluate_v1.h
+++ b/src/actions/action_jsonschema_evaluate_v1.h
@@ -45,9 +45,9 @@ public:
         this->base(), router.base_path(), request_schema);
   }
 
-  auto run(const std::span<std::string_view> matches,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
+  auto rest(const std::span<std::string_view> matches,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
     ActionJSONSchemaEvaluate_v1::serve_post(
         matches, request, response, this->base(), this->response_schema_,
         this->error_schema_, this->request_schema_template_,

--- a/src/actions/action_jsonschema_serve_v1.h
+++ b/src/actions/action_jsonschema_serve_v1.h
@@ -93,9 +93,9 @@ public:
     }
   }
 
-  auto run(const std::span<std::string_view> matches,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
+  auto rest(const std::span<std::string_view> matches,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
     serve(this->base(), matches.front(), request, response,
           this->error_schema_);
   }

--- a/src/actions/action_jsonschema_trace_v1.h
+++ b/src/actions/action_jsonschema_trace_v1.h
@@ -47,9 +47,9 @@ public:
         this->base(), router.base_path(), request_schema);
   }
 
-  auto run(const std::span<std::string_view> matches,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
+  auto rest(const std::span<std::string_view> matches,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
     ActionJSONSchemaEvaluate_v1::serve_post(
         matches, request, response, this->base(), this->response_schema_,
         this->error_schema_, this->request_schema_template_,

--- a/src/actions/action_mcp_v1.h
+++ b/src/actions/action_mcp_v1.h
@@ -20,10 +20,10 @@ public:
       : sourcemeta::one::Action{base, router.base_path()},
         EnterpriseMCP{base, router, identifier} {}
 
-  auto run(const std::span<std::string_view>,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
-    EnterpriseMCP::run(request, response);
+  auto rest(const std::span<std::string_view>,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
+    EnterpriseMCP::rest(request, response);
   }
 };
 
@@ -76,9 +76,9 @@ public:
     this->mcp_metadata_ = std::move(mcp_metadata_option.value());
   }
 
-  auto run(const std::span<std::string_view>,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
+  auto rest(const std::span<std::string_view>,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::one::STATUS_NO_CONTENT);
       response.write_header("Access-Control-Allow-Origin",

--- a/src/actions/action_not_found_v1.h
+++ b/src/actions/action_not_found_v1.h
@@ -25,9 +25,9 @@ public:
     });
   }
 
-  auto run(const std::span<std::string_view>,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
+  auto rest(const std::span<std::string_view>,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
     sourcemeta::one::json_error(
         request, response, sourcemeta::one::STATUS_NOT_FOUND, "not-found",
         "There is nothing at this URL", this->error_schema_);

--- a/src/actions/action_schema_search_v1.h
+++ b/src/actions/action_schema_search_v1.h
@@ -34,9 +34,9 @@ public:
     });
   }
 
-  auto run(const std::span<std::string_view>,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
+  auto rest(const std::span<std::string_view>,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
 
     if (request.method() != "get") {
       sourcemeta::one::json_error(

--- a/src/actions/action_serve_explorer_artifact_v1.h
+++ b/src/actions/action_serve_explorer_artifact_v1.h
@@ -31,9 +31,9 @@ public:
     });
   }
 
-  auto run(const std::span<std::string_view> matches,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
+  auto rest(const std::span<std::string_view> matches,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
     auto absolute_path{this->base() / "explorer"};
     if (!matches.empty() && !matches.front().empty()) {
       absolute_path /= matches.front();

--- a/src/actions/action_serve_schema_artifact_v1.h
+++ b/src/actions/action_serve_schema_artifact_v1.h
@@ -31,9 +31,9 @@ public:
     });
   }
 
-  auto run(const std::span<std::string_view> matches,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
+  auto rest(const std::span<std::string_view> matches,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
     if (matches.empty()) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::one::STATUS_INTERNAL_SERVER_ERROR,

--- a/src/actions/action_serve_static_v1.h
+++ b/src/actions/action_serve_static_v1.h
@@ -29,9 +29,9 @@ public:
     });
   }
 
-  auto run(const std::span<std::string_view> matches,
-           sourcemeta::one::HTTPRequest &request,
-           sourcemeta::one::HTTPResponse &response) -> void override {
+  auto rest(const std::span<std::string_view> matches,
+            sourcemeta::one::HTTPRequest &request,
+            sourcemeta::one::HTTPResponse &response) -> void override {
     if (this->file_root_.empty()) {
       if (request.method() != "get" && request.method() != "head") {
         sourcemeta::one::json_error(

--- a/src/actions/dispatch.cc
+++ b/src/actions/dispatch.cc
@@ -88,5 +88,5 @@ auto sourcemeta::one::ActionDispatcher::dispatch(
         CONSTRUCTORS[context](this->base_, this->router_, identifier);
   });
 
-  slot.instance->run(matches, request, response);
+  slot.instance->rest(matches, request, response);
 }

--- a/src/actions/include/sourcemeta/one/actions.h
+++ b/src/actions/include/sourcemeta/one/actions.h
@@ -49,8 +49,8 @@ public:
   auto operator=(const Action &) -> Action & = delete;
   auto operator=(Action &&) -> Action & = delete;
 
-  virtual auto run(const std::span<std::string_view> matches,
-                   HTTPRequest &request, HTTPResponse &response) -> void = 0;
+  virtual auto rest(const std::span<std::string_view> matches,
+                    HTTPRequest &request, HTTPResponse &response) -> void = 0;
 
   [[nodiscard]] auto base() const noexcept -> const std::filesystem::path & {
     return this->base_;

--- a/test/unit/actions/actions_schema_directory_test.cc
+++ b/test/unit/actions/actions_schema_directory_test.cc
@@ -10,8 +10,8 @@ public:
              const std::string_view base_path)
       : sourcemeta::one::Action{base, base_path} {}
 
-  auto run(const std::span<std::string_view>, sourcemeta::one::HTTPRequest &,
-           sourcemeta::one::HTTPResponse &) -> void override {}
+  auto rest(const std::span<std::string_view>, sourcemeta::one::HTTPRequest &,
+            sourcemeta::one::HTTPResponse &) -> void override {}
 };
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
