### PR TITLE
Case-insensitive `.json` handling in MCP resource reading

### DIFF
--- a/enterprise/e2e/path/hurl/mcp-2025-11-25-resources.all.hurl
+++ b/enterprise/e2e/path/hurl/mcp-2025-11-25-resources.all.hurl
@@ -439,6 +439,81 @@ HTTP 200
 [Asserts]
 jsonpath "$.valid" == true
 
+# The `.json` suffix is stripped case-insensitively, so any mixed-case
+# variant resolves to the same schema as the bare URI
+
+POST {{base}}/v1/catalog/self/v1/mcp
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{
+  "jsonrpc": "2.0",
+  "id": 33,
+  "method": "resources/read",
+  "params": {
+    "uri": "{{base}}/v1/catalog/self/v1/schemas/mcp/error.JSON"
+  }
+}
+```
+HTTP 200
+Content-Type: application/json
+Access-Control-Allow-Origin: {{base}}
+Link: </v1/catalog/self/v1/schemas/mcp/response>; rel="describedby"
+[Captures]
+last_response: body
+schema_path: header "Link" regex "</v1/catalog([^>]+)>"
+[Asserts]
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 33
+jsonpath "$.result.contents" count == 1
+jsonpath "$.result.contents[0].uri" == "{{base}}/v1/catalog/self/v1/schemas/mcp/error.JSON"
+jsonpath "$.result.contents[0].mimeType" == "application/schema+json"
+jsonpath "$.result.contents[0].text" == "{{schema_text}}"
+
+POST {{base}}/v1/catalog/self/v1/api/schemas/evaluate{{schema_path}}
+```
+{{last_response}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+POST {{base}}/v1/catalog/self/v1/mcp
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{
+  "jsonrpc": "2.0",
+  "id": 34,
+  "method": "resources/read",
+  "params": {
+    "uri": "{{base}}/v1/catalog/self/v1/schemas/mcp/error.Json"
+  }
+}
+```
+HTTP 200
+Content-Type: application/json
+Access-Control-Allow-Origin: {{base}}
+Link: </v1/catalog/self/v1/schemas/mcp/response>; rel="describedby"
+[Captures]
+last_response: body
+schema_path: header "Link" regex "</v1/catalog([^>]+)>"
+[Asserts]
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 34
+jsonpath "$.result.contents" count == 1
+jsonpath "$.result.contents[0].uri" == "{{base}}/v1/catalog/self/v1/schemas/mcp/error.Json"
+jsonpath "$.result.contents[0].mimeType" == "application/schema+json"
+jsonpath "$.result.contents[0].text" == "{{schema_text}}"
+
+POST {{base}}/v1/catalog/self/v1/api/schemas/evaluate{{schema_path}}
+```
+{{last_response}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
 GET {{base}}/v1/catalog/self/v1/schemas/mcp/response?bundle=1
 HTTP 200
 [Captures]

--- a/enterprise/server/CMakeLists.txt
+++ b/enterprise/server/CMakeLists.txt
@@ -15,5 +15,6 @@ target_link_libraries(sourcemeta_one_enterprise_server PRIVATE sourcemeta::core:
 target_link_libraries(sourcemeta_one_enterprise_server PRIVATE sourcemeta::core::uri)
 target_link_libraries(sourcemeta_one_enterprise_server PRIVATE sourcemeta::one::shared)
 target_link_libraries(sourcemeta_one_enterprise_server PRIVATE sourcemeta::core::mcp)
+target_link_libraries(sourcemeta_one_enterprise_server PRIVATE sourcemeta::core::text)
 target_link_libraries(sourcemeta_one_enterprise_server PRIVATE sourcemeta::one::metapack)
 target_link_libraries(sourcemeta_one_enterprise_server PRIVATE sourcemeta::blaze::output)

--- a/enterprise/server/action_mcp_v1.cc
+++ b/enterprise/server/action_mcp_v1.cc
@@ -5,6 +5,7 @@
 #include <sourcemeta/core/jsonrpc.h>
 #include <sourcemeta/core/mcp.h>
 #include <sourcemeta/core/numeric.h>
+#include <sourcemeta/core/text.h>
 #include <sourcemeta/core/uri.h>
 
 #include <sourcemeta/one/http.h>
@@ -135,10 +136,8 @@ auto ActionMCP_v1::on_resources_read(const sourcemeta::core::JSON &request_json)
           "Resource not found", std::move(data));
     }
     const auto path{request.path().value_or("")};
-    std::string_view schema_path{path};
-    if (schema_path.ends_with(".json")) {
-      schema_path.remove_suffix(5);
-    }
+    const auto schema_path{
+        sourcemeta::core::remove_suffix_ignore_case(path, ".json")};
     if (schema_path.empty()) {
       return sourcemeta::core::mcp_make_error_resource_not_found(id, uri);
     }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
