### PR TITLE
Respond with 405 and `Allow` to invalid methods on schemas

### DIFF
--- a/src/actions/action_default_v1.h
+++ b/src/actions/action_default_v1.h
@@ -162,14 +162,15 @@ public:
     } else {
       // RFC 9110 §15.5.6: when the path resolves to an existing resource
       // the response must be 405 with Allow listing what is supported.
-      // Paths that resolve to nothing keep the 404 so a probing client
-      // cannot use the 405 to enumerate the catalog.
       // https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.6
+      const auto schema_json{
+          this->artifact_resolve_path(path, Tree::Schemas, "schema")};
       const auto schema_html{
           this->artifact_resolve_path(path, Tree::Explorer, "schema-html")};
       const auto directory_html{
           this->artifact_resolve_path(path, Tree::Explorer, "directory-html")};
-      if ((!path.ends_with("/") && schema_html.has_value()) ||
+      if (schema_json.has_value() ||
+          (!path.ends_with("/") && schema_html.has_value()) ||
           directory_html.has_value()) {
         sourcemeta::one::json_error(
             request, response, sourcemeta::core::HTTP_STATUS_METHOD_NOT_ALLOWED,

--- a/src/actions/action_default_v1.h
+++ b/src/actions/action_default_v1.h
@@ -160,10 +160,28 @@ public:
                                         this->error_schema_);
       }
     } else {
-      sourcemeta::one::json_error(
-          request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
-          "sourcemeta:one/not-found", "There is nothing at this URL",
-          this->error_schema_, "*");
+      // RFC 9110 §15.5.6: when the path resolves to an existing resource
+      // the response must be 405 with Allow listing what is supported.
+      // Paths that resolve to nothing keep the 404 so a probing client
+      // cannot use the 405 to enumerate the catalog.
+      // https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.6
+      const auto schema_html{
+          this->artifact_resolve_path(path, Tree::Explorer, "schema-html")};
+      const auto directory_html{
+          this->artifact_resolve_path(path, Tree::Explorer, "directory-html")};
+      if ((!path.ends_with("/") && schema_html.has_value()) ||
+          directory_html.has_value()) {
+        sourcemeta::one::json_error(
+            request, response, sourcemeta::core::HTTP_STATUS_METHOD_NOT_ALLOWED,
+            "sourcemeta:one/method-not-allowed",
+            "This HTTP method is invalid for this URL", this->error_schema_,
+            "*", "GET, HEAD");
+      } else {
+        sourcemeta::one::json_error(
+            request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
+            "sourcemeta:one/not-found", "There is nothing at this URL",
+            this->error_schema_, "*");
+      }
     }
   }
 

--- a/test/e2e/empty/hurl/mcp-2025-11-25.all.hurl
+++ b/test/e2e/empty/hurl/mcp-2025-11-25.all.hurl
@@ -112,7 +112,6 @@ header "Access-Control-Max-Age" == "3600"
 header "Allow" == "POST, OPTIONS"
 header "MCP-Protocol-Version" == "2025-03-26"
 
-
 # MCP Streamable HTTP §Sending Messages, item 2: client MUST list both
 # application/json and text/event-stream in Accept. Server enforces this
 # defensively. The parser is q-aware (q=0 means "not acceptable") and

--- a/test/e2e/headless/hurl/fetch.all.hurl
+++ b/test/e2e/headless/hurl/fetch.all.hurl
@@ -276,6 +276,10 @@ Content-Type: application/problem+json
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: Link, ETag
 Allow: GET, HEAD
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+last_response_405: body
+schema_path_405: header "Link" regex "<([^>]+)>"
 [Asserts]
 header "Referrer-Policy" not exists
 header "Content-Security-Policy" not exists
@@ -287,6 +291,14 @@ jsonpath "$.type" == "sourcemeta:one/method-not-allowed"
 jsonpath "$.title" == "Method Not Allowed"
 jsonpath "$.detail" == "This HTTP method is invalid for this URL"
 
+POST {{base}}/self/v1/api/schemas/evaluate{{schema_path_405}}
+```
+{{last_response_405}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
 # A write method on a non-`.json` path that resolves to nothing must
 # stay 404 so the 405 cannot be used to enumerate the catalog.
 PATCH {{base}}/test/schemas/xxx
@@ -294,6 +306,10 @@ HTTP 404
 Content-Type: application/problem+json
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+last_response_404: body
+schema_path_404: header "Link" regex "<([^>]+)>"
 [Asserts]
 header "Referrer-Policy" not exists
 header "Content-Security-Policy" not exists
@@ -305,6 +321,14 @@ jsonpath "$.status" == 404
 jsonpath "$.type" == "sourcemeta:one/not-found"
 jsonpath "$.title" == "Not Found"
 jsonpath "$.detail" == "There is nothing at this URL"
+
+POST {{base}}/self/v1/api/schemas/evaluate{{schema_path_404}}
+```
+{{last_response_404}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
 
 GET {{base}}/test/no-base/no-id.json
 HTTP 200

--- a/test/e2e/headless/hurl/fetch.all.hurl
+++ b/test/e2e/headless/hurl/fetch.all.hurl
@@ -265,6 +265,47 @@ jsonpath "$.type" == "sourcemeta:one/not-found"
 jsonpath "$.title" == "Not Found"
 jsonpath "$.detail" == "There is nothing at this URL"
 
+# RFC 9110 §15.5.6: write methods on a non-`.json` path that still
+# resolves to an existing schema (the `.json` suffix is optional for
+# GETs in html-off configurations) must respond 405 with Allow, not
+# 404. Confirms the existence probe inspects the bare schema artifact
+# and not just the html overlays.
+DELETE {{base}}/test/schemas/string
+HTTP 405
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Allow: GET, HEAD
+[Asserts]
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Vary" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.status" == 405
+jsonpath "$.type" == "sourcemeta:one/method-not-allowed"
+jsonpath "$.title" == "Method Not Allowed"
+jsonpath "$.detail" == "This HTTP method is invalid for this URL"
+
+# A write method on a non-`.json` path that resolves to nothing must
+# stay 404 so the 405 cannot be used to enumerate the catalog.
+PATCH {{base}}/test/schemas/xxx
+HTTP 404
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+[Asserts]
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Allow" not exists
+header "Vary" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.status" == 404
+jsonpath "$.type" == "sourcemeta:one/not-found"
+jsonpath "$.title" == "Not Found"
+jsonpath "$.detail" == "There is nothing at this URL"
+
 GET {{base}}/test/no-base/no-id.json
 HTTP 200
 Content-Type: application/schema+json

--- a/test/e2e/html/hurl/html.all.hurl
+++ b/test/e2e/html/hurl/html.all.hurl
@@ -396,7 +396,6 @@ header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) 
 variable "page1_script_v" == "{{page2_script_v}}"
 variable "page1_style_v" == "{{page2_style_v}}"
 
-
 # RFC 9110 §15.5.6: write methods on a path that resolves to a
 # directory-html resource must respond 405 with Allow listing what the
 # server does accept, rather than the catch-all 404 that would mask the

--- a/test/e2e/html/hurl/html.all.hurl
+++ b/test/e2e/html/hurl/html.all.hurl
@@ -429,6 +429,38 @@ HTTP 200
 [Asserts]
 jsonpath "$.valid" == true
 
+# The `.json` variant of an existing schema path takes a different
+# code path (the schema-serve action rather than the default fallback)
+# but the contract for an unsupported method is identical.
+PATCH {{base}}/test/doc/string-1.json
+HTTP 405
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Allow: GET, HEAD
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+last_response: body
+schema_path: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Vary" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.type" == "sourcemeta:one/method-not-allowed"
+jsonpath "$.title" == "Method Not Allowed"
+jsonpath "$.status" == 405
+jsonpath "$.detail" == "This HTTP method is invalid for this URL"
+
+POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
+```
+{{last_response}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
 # Same for a path that resolves to a schema-html resource.
 PATCH {{base}}/test/doc/string-1
 HTTP 405
@@ -461,6 +493,36 @@ jsonpath "$.valid" == true
 
 # But a write method on a path that does not resolve to anything must
 # stay 404, so the 405 cannot be used to enumerate the catalog.
+DELETE {{base}}/xxxxxxx.json
+HTTP 404
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+last_response: body
+schema_path: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Allow" not exists
+header "Vary" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.type" == "sourcemeta:one/not-found"
+jsonpath "$.title" == "Not Found"
+jsonpath "$.status" == 404
+jsonpath "$.detail" == "There is nothing at this URL"
+
+POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
+```
+{{last_response}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# Same for a non-`.json` unknown path through the default fallback.
 DELETE {{base}}/xxxxxxx
 HTTP 404
 Content-Type: application/problem+json

--- a/test/e2e/html/hurl/html.all.hurl
+++ b/test/e2e/html/hurl/html.all.hurl
@@ -395,3 +395,98 @@ page2_style_v: xpath "substring-after(//link[@rel='stylesheet']/@href, '?v=')"
 header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
 variable "page1_script_v" == "{{page2_script_v}}"
 variable "page1_style_v" == "{{page2_style_v}}"
+
+
+# RFC 9110 §15.5.6: write methods on a path that resolves to a
+# directory-html resource must respond 405 with Allow listing what the
+# server does accept, rather than the catch-all 404 that would mask the
+# resource's existence.
+DELETE {{base}}/test/doc
+HTTP 405
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Allow: GET, HEAD
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+last_response: body
+schema_path: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Vary" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.type" == "sourcemeta:one/method-not-allowed"
+jsonpath "$.title" == "Method Not Allowed"
+jsonpath "$.status" == 405
+jsonpath "$.detail" == "This HTTP method is invalid for this URL"
+
+POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
+```
+{{last_response}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# Same for a path that resolves to a schema-html resource.
+PATCH {{base}}/test/doc/string-1
+HTTP 405
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Allow: GET, HEAD
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+last_response: body
+schema_path: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Vary" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.type" == "sourcemeta:one/method-not-allowed"
+jsonpath "$.title" == "Method Not Allowed"
+jsonpath "$.status" == 405
+jsonpath "$.detail" == "This HTTP method is invalid for this URL"
+
+POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
+```
+{{last_response}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# But a write method on a path that does not resolve to anything must
+# stay 404, so the 405 cannot be used to enumerate the catalog.
+DELETE {{base}}/xxxxxxx
+HTTP 404
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+last_response: body
+schema_path: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Allow" not exists
+header "Vary" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.type" == "sourcemeta:one/not-found"
+jsonpath "$.title" == "Not Found"
+jsonpath "$.status" == 404
+jsonpath "$.detail" == "There is nothing at this URL"
+
+POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
+```
+{{last_response}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true

--- a/test/e2e/no-api/hurl/fetch.all.hurl
+++ b/test/e2e/no-api/hurl/fetch.all.hurl
@@ -74,7 +74,8 @@ header "Vary" == "Accept-Encoding"
 # resolves to an existing schema (the `.json` suffix is optional for
 # GETs when html and api are off) must respond 405 with Allow, not
 # 404. Confirms the existence probe inspects the bare schema artifact
-# even when no html overlays exist.
+# even when no html overlays exist. The api is disabled in this
+# configuration so the response carries no Link.
 DELETE {{base}}/test/schemas/string
 HTTP 405
 Content-Type: application/problem+json
@@ -86,6 +87,28 @@ header "Referrer-Policy" not exists
 header "Content-Security-Policy" not exists
 header "X-Frame-Options" not exists
 header "Vary" not exists
+header "Link" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.status" == 405
+jsonpath "$.type" == "sourcemeta:one/method-not-allowed"
+jsonpath "$.title" == "Method Not Allowed"
+jsonpath "$.detail" == "This HTTP method is invalid for this URL"
+
+# The same path with an explicit `.json` suffix takes a different code
+# path (the schema-serve action rather than the default fallback), but
+# the contract for an unsupported method is identical.
+DELETE {{base}}/test/schemas/string.json
+HTTP 405
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Allow: GET, HEAD
+[Asserts]
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Vary" not exists
+header "Link" not exists
 header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
 jsonpath "$.status" == 405
 jsonpath "$.type" == "sourcemeta:one/method-not-allowed"
@@ -105,6 +128,26 @@ header "Content-Security-Policy" not exists
 header "X-Frame-Options" not exists
 header "Allow" not exists
 header "Vary" not exists
+header "Link" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.status" == 404
+jsonpath "$.type" == "sourcemeta:one/not-found"
+jsonpath "$.title" == "Not Found"
+jsonpath "$.detail" == "There is nothing at this URL"
+
+# Same for the `.json` variant of a path that does not resolve.
+PATCH {{base}}/test/schemas/xxx.json
+HTTP 404
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+[Asserts]
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Allow" not exists
+header "Vary" not exists
+header "Link" not exists
 header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
 jsonpath "$.status" == 404
 jsonpath "$.type" == "sourcemeta:one/not-found"

--- a/test/e2e/no-api/hurl/fetch.all.hurl
+++ b/test/e2e/no-api/hurl/fetch.all.hurl
@@ -69,3 +69,44 @@ header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) 
 bytes count == 0
 header "ETag" exists
 header "Vary" == "Accept-Encoding"
+
+# RFC 9110 §15.5.6: write methods on a non-`.json` path that still
+# resolves to an existing schema (the `.json` suffix is optional for
+# GETs when html and api are off) must respond 405 with Allow, not
+# 404. Confirms the existence probe inspects the bare schema artifact
+# even when no html overlays exist.
+DELETE {{base}}/test/schemas/string
+HTTP 405
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Allow: GET, HEAD
+[Asserts]
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Vary" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.status" == 405
+jsonpath "$.type" == "sourcemeta:one/method-not-allowed"
+jsonpath "$.title" == "Method Not Allowed"
+jsonpath "$.detail" == "This HTTP method is invalid for this URL"
+
+# A write method on a non-`.json` path that resolves to nothing must
+# stay 404 so the 405 cannot be used to enumerate the catalog.
+PATCH {{base}}/test/schemas/xxx
+HTTP 404
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+[Asserts]
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Allow" not exists
+header "Vary" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.status" == 404
+jsonpath "$.type" == "sourcemeta:one/not-found"
+jsonpath "$.title" == "Not Found"
+jsonpath "$.detail" == "There is nothing at this URL"


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
