### PR TITLE
Properly handle `Expect` and `100-continue`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -204,6 +204,10 @@ Format](https://json-schema.org/draft/2020-12/json-schema-core#name-output-struc
 
     The request body exceeds the 4 MB cap. See [RFC 9110 §15.5.14](https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.14).
 
+=== "417"
+
+    The `Expect` header carries an expectation other than `100-continue`. See [RFC 9110 §10.1.1](https://datatracker.ietf.org/doc/html/rfc9110#section-10.1.1).
+
 ### Trace
 
 *This endpoint takes a JSON instance as a request body and evaluates it against
@@ -257,6 +261,10 @@ insight into the validation engine's behavior and logic flow.
 === "413"
 
     The request body exceeds the 4 MB cap. See [RFC 9110 §15.5.14](https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.14).
+
+=== "417"
+
+    The `Expect` header carries an expectation other than `100-continue`. See [RFC 9110 §10.1.1](https://datatracker.ietf.org/doc/html/rfc9110#section-10.1.1).
 
 ### Metadata
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -202,7 +202,7 @@ Format](https://json-schema.org/draft/2020-12/json-schema-core#name-output-struc
 
 === "413"
 
-    The request body exceeds the 4 MB cap. See [RFC 9110 §15.5.14](https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.14).
+    The request body is too large. See [RFC 9110 §15.5.14](https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.14).
 
 === "417"
 
@@ -260,7 +260,7 @@ insight into the validation engine's behavior and logic flow.
 
 === "413"
 
-    The request body exceeds the 4 MB cap. See [RFC 9110 §15.5.14](https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.14).
+    The request body is too large. See [RFC 9110 §15.5.14](https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.14).
 
 === "417"
 

--- a/enterprise/e2e/html/hurl/mcp-2025-11-25-resources.all.hurl
+++ b/enterprise/e2e/html/hurl/mcp-2025-11-25-resources.all.hurl
@@ -444,7 +444,7 @@ jsonpath "$.result.resources[20].uri" == "{{base}}/self/v1/schemas/api/error"
 jsonpath "$.result.resources[20].name" == "Sourcemeta One API Error"
 jsonpath "$.result.resources[20].description" == "The error response format returned by the Sourcemeta One API endpoints"
 jsonpath "$.result.resources[20].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[20].size" == 5179
+jsonpath "$.result.resources[20].size" == 5405
 jsonpath "$.result.resources[20].annotations.priority" == 0
 jsonpath "$.result.resources[21].uri" == "{{base}}/self/v1/schemas/api/list/response"
 jsonpath "$.result.resources[21].name" == "Sourcemeta One List API Response"
@@ -534,7 +534,7 @@ jsonpath "$.result.resources[35].uri" == "{{base}}/self/v1/schemas/mcp/error"
 jsonpath "$.result.resources[35].name" == "Sourcemeta One MCP Error Response"
 jsonpath "$.result.resources[35].description" == "The error response Sourcemeta One returns when an MCP request fails"
 jsonpath "$.result.resources[35].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[35].size" == 5710
+jsonpath "$.result.resources[35].size" == 5870
 jsonpath "$.result.resources[35].annotations.priority" == 0
 jsonpath "$.result.resources[36].uri" == "{{base}}/self/v1/schemas/mcp/initialize/request"
 jsonpath "$.result.resources[36].name" == "Sourcemeta One MCP Initialize Request"

--- a/enterprise/e2e/html/hurl/mcp-2025-11-25-resources.all.hurl
+++ b/enterprise/e2e/html/hurl/mcp-2025-11-25-resources.all.hurl
@@ -444,7 +444,7 @@ jsonpath "$.result.resources[20].uri" == "{{base}}/self/v1/schemas/api/error"
 jsonpath "$.result.resources[20].name" == "Sourcemeta One API Error"
 jsonpath "$.result.resources[20].description" == "The error response format returned by the Sourcemeta One API endpoints"
 jsonpath "$.result.resources[20].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[20].size" == 5405
+jsonpath "$.result.resources[20].size" == 5395
 jsonpath "$.result.resources[20].annotations.priority" == 0
 jsonpath "$.result.resources[21].uri" == "{{base}}/self/v1/schemas/api/list/response"
 jsonpath "$.result.resources[21].name" == "Sourcemeta One List API Response"
@@ -534,7 +534,7 @@ jsonpath "$.result.resources[35].uri" == "{{base}}/self/v1/schemas/mcp/error"
 jsonpath "$.result.resources[35].name" == "Sourcemeta One MCP Error Response"
 jsonpath "$.result.resources[35].description" == "The error response Sourcemeta One returns when an MCP request fails"
 jsonpath "$.result.resources[35].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[35].size" == 5870
+jsonpath "$.result.resources[35].size" == 5860
 jsonpath "$.result.resources[35].annotations.priority" == 0
 jsonpath "$.result.resources[36].uri" == "{{base}}/self/v1/schemas/mcp/initialize/request"
 jsonpath "$.result.resources[36].name" == "Sourcemeta One MCP Initialize Request"

--- a/enterprise/e2e/html/hurl/mcp-2025-11-25-validation.all.hurl
+++ b/enterprise/e2e/html/hurl/mcp-2025-11-25-validation.all.hurl
@@ -594,7 +594,7 @@ header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) 
 jsonpath "$.jsonrpc" == "2.0"
 jsonpath "$.id" == null
 jsonpath "$.error.code" == -32005
-jsonpath "$.error.message" == "Request body exceeds the 4 MB limit"
+jsonpath "$.error.message" == "Request body is too large"
 jsonpath "$.error.data" not exists
 
 POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}

--- a/enterprise/e2e/html/hurl/mcp-2025-11-25-validation.all.hurl
+++ b/enterprise/e2e/html/hurl/mcp-2025-11-25-validation.all.hurl
@@ -521,3 +521,88 @@ header "Content-Security-Policy" not exists
 header "X-Frame-Options" not exists
 header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
 jsonpath "$.valid" == true
+
+# RFC 9110 §10.1.1: any expectation other than `100-continue` is
+# unsupported. The fast-fail emits 417 before the body is touched
+POST {{base}}/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Expect: please-do-something-weird
+Content-Type: application/json
+```
+{ "jsonrpc": "2.0", "id": 1, "method": "ping" }
+```
+HTTP 417
+Cache-Control: no-store
+Content-Type: application/json
+Access-Control-Allow-Origin: http://localhost:8000
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+MCP-Protocol-Version: 2025-11-25
+[Captures]
+last_response: body
+schema_path: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "Vary" not exists
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == null
+jsonpath "$.error.code" == -32009
+jsonpath "$.error.message" == "The Expect header carries an unsupported expectation"
+jsonpath "$.error.data" not exists
+
+POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
+```
+{{last_response}}
+```
+HTTP 200
+Cache-Control: no-store
+[Asserts]
+header "Vary" not exists
+jsonpath "$.valid" == true
+
+# RFC 9110 §15.5.14: when a client declares a `Content-Length` that
+# already exceeds the 4 MB cap, fast-fail with 413 before scheduling
+# the read
+POST {{base}}/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Length: 5000000
+Content-Type: application/json
+```
+{ "jsonrpc": "2.0", "id": 1, "method": "ping" }
+```
+HTTP 413
+Cache-Control: no-store
+Content-Type: application/json
+Access-Control-Allow-Origin: http://localhost:8000
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+MCP-Protocol-Version: 2025-11-25
+[Captures]
+last_response: body
+schema_path: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "Vary" not exists
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == null
+jsonpath "$.error.code" == -32005
+jsonpath "$.error.message" == "Request body exceeds the 4 MB limit"
+jsonpath "$.error.data" not exists
+
+POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
+```
+{{last_response}}
+```
+HTTP 200
+Cache-Control: no-store
+[Asserts]
+header "Vary" not exists
+jsonpath "$.valid" == true

--- a/enterprise/e2e/path/hurl/mcp-2025-11-25-resources.all.hurl
+++ b/enterprise/e2e/path/hurl/mcp-2025-11-25-resources.all.hurl
@@ -68,7 +68,7 @@ jsonpath "$.result.resources[7].uri" == "{{base}}/v1/catalog/self/v1/schemas/api
 jsonpath "$.result.resources[7].name" == "Sourcemeta One API Error"
 jsonpath "$.result.resources[7].description" == "The error response format returned by the Sourcemeta One API endpoints"
 jsonpath "$.result.resources[7].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[7].size" == 5416
+jsonpath "$.result.resources[7].size" == 5406
 jsonpath "$.result.resources[7].annotations.priority" == 0
 jsonpath "$.result.resources[8].uri" == "{{base}}/v1/catalog/self/v1/schemas/api/list/response"
 jsonpath "$.result.resources[8].name" == "Sourcemeta One List API Response"
@@ -158,7 +158,7 @@ jsonpath "$.result.resources[22].uri" == "{{base}}/v1/catalog/self/v1/schemas/mc
 jsonpath "$.result.resources[22].name" == "Sourcemeta One MCP Error Response"
 jsonpath "$.result.resources[22].description" == "The error response Sourcemeta One returns when an MCP request fails"
 jsonpath "$.result.resources[22].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[22].size" == 5881
+jsonpath "$.result.resources[22].size" == 5871
 jsonpath "$.result.resources[22].annotations.priority" == 0
 jsonpath "$.result.resources[23].uri" == "{{base}}/v1/catalog/self/v1/schemas/mcp/initialize/request"
 jsonpath "$.result.resources[23].name" == "Sourcemeta One MCP Initialize Request"

--- a/enterprise/e2e/path/hurl/mcp-2025-11-25-resources.all.hurl
+++ b/enterprise/e2e/path/hurl/mcp-2025-11-25-resources.all.hurl
@@ -68,7 +68,7 @@ jsonpath "$.result.resources[7].uri" == "{{base}}/v1/catalog/self/v1/schemas/api
 jsonpath "$.result.resources[7].name" == "Sourcemeta One API Error"
 jsonpath "$.result.resources[7].description" == "The error response format returned by the Sourcemeta One API endpoints"
 jsonpath "$.result.resources[7].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[7].size" == 5190
+jsonpath "$.result.resources[7].size" == 5416
 jsonpath "$.result.resources[7].annotations.priority" == 0
 jsonpath "$.result.resources[8].uri" == "{{base}}/v1/catalog/self/v1/schemas/api/list/response"
 jsonpath "$.result.resources[8].name" == "Sourcemeta One List API Response"
@@ -158,7 +158,7 @@ jsonpath "$.result.resources[22].uri" == "{{base}}/v1/catalog/self/v1/schemas/mc
 jsonpath "$.result.resources[22].name" == "Sourcemeta One MCP Error Response"
 jsonpath "$.result.resources[22].description" == "The error response Sourcemeta One returns when an MCP request fails"
 jsonpath "$.result.resources[22].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[22].size" == 5721
+jsonpath "$.result.resources[22].size" == 5881
 jsonpath "$.result.resources[22].annotations.priority" == 0
 jsonpath "$.result.resources[23].uri" == "{{base}}/v1/catalog/self/v1/schemas/mcp/initialize/request"
 jsonpath "$.result.resources[23].name" == "Sourcemeta One MCP Initialize Request"

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_actions.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_actions.h
@@ -200,13 +200,12 @@ public:
 
     // RFC 9110 §15.5.14: when the client declares a `Content-Length`
     // beyond the cap, fast-fail with 413 before scheduling the read.
-    if (sourcemeta::one::content_length_exceeds(
-            request, static_cast<std::size_t>(4) * 1024 * 1024)) {
-      this->write_envelope(
-          request, response, sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
-          sourcemeta::core::jsonrpc_make_error(
-              nullptr, -32005, "Request body exceeds the 4 MB limit"),
-          negotiated_version.value());
+    if (sourcemeta::one::request_body_too_large(request)) {
+      this->write_envelope(request, response,
+                           sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
+                           sourcemeta::core::jsonrpc_make_error(
+                               nullptr, -32005, "Request body is too large"),
+                           negotiated_version.value());
       return;
     }
 
@@ -220,7 +219,7 @@ public:
                 callback_request, callback_response,
                 sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
                 sourcemeta::core::jsonrpc_make_error(
-                    nullptr, -32005, "Request body exceeds the 4 MB limit"),
+                    nullptr, -32005, "Request body is too large"),
                 version);
             return;
           }

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_actions.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_actions.h
@@ -185,6 +185,31 @@ public:
       return;
     }
 
+    // RFC 9110 §10.1.1: refuse unrecognised expectations with 417 before
+    // touching the body. uWS already auto-acknowledged `100-continue`
+    // upstream, so anything left here is a value we cannot honour.
+    if (sourcemeta::one::expect_header_unrecognised(request)) {
+      this->write_envelope(
+          request, response, sourcemeta::core::HTTP_STATUS_EXPECTATION_FAILED,
+          sourcemeta::core::jsonrpc_make_error(
+              nullptr, -32009,
+              "The Expect header carries an unsupported expectation"),
+          negotiated_version.value());
+      return;
+    }
+
+    // RFC 9110 §15.5.14: when the client declares a `Content-Length`
+    // beyond the cap, fast-fail with 413 before scheduling the read.
+    if (sourcemeta::one::content_length_exceeds(
+            request, static_cast<std::size_t>(4) * 1024 * 1024)) {
+      this->write_envelope(
+          request, response, sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
+          sourcemeta::core::jsonrpc_make_error(
+              nullptr, -32005, "Request body exceeds the 4 MB limit"),
+          negotiated_version.value());
+      return;
+    }
+
     request.body(
         [this, version = negotiated_version.value()](
             sourcemeta::one::HTTPRequest &callback_request,

--- a/src/actions/action_jsonschema_evaluate_v1.h
+++ b/src/actions/action_jsonschema_evaluate_v1.h
@@ -188,6 +188,29 @@ public:
       return;
     }
 
+    // RFC 9110 §10.1.1: refuse unrecognised expectations with 417 before
+    // touching the body. uWS already auto-acknowledged `100-continue`
+    // upstream, so anything left here is a value we cannot honour.
+    if (sourcemeta::one::expect_header_unrecognised(request)) {
+      sourcemeta::one::json_error(
+          request, response, sourcemeta::core::HTTP_STATUS_EXPECTATION_FAILED,
+          "sourcemeta:one/expectation-failed",
+          "The Expect header carries an unsupported expectation", error_schema,
+          "*");
+      return;
+    }
+
+    // RFC 9110 §15.5.14: when the client declares a `Content-Length`
+    // beyond the cap, fast-fail with 413 before scheduling the read.
+    if (sourcemeta::one::content_length_exceeds(
+            request, static_cast<std::size_t>(4) * 1024 * 1024)) {
+      sourcemeta::one::json_error(
+          request, response, sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
+          "sourcemeta:one/payload-too-large",
+          "The request body exceeds the 4 MB limit", error_schema, "*");
+      return;
+    }
+
     request.body(
         [response_schema, error_schema, schema_uri = std::move(schema_uri),
          &self, request_schema, perform = std::move(perform)](

--- a/src/actions/action_jsonschema_evaluate_v1.h
+++ b/src/actions/action_jsonschema_evaluate_v1.h
@@ -202,12 +202,11 @@ public:
 
     // RFC 9110 §15.5.14: when the client declares a `Content-Length`
     // beyond the cap, fast-fail with 413 before scheduling the read.
-    if (sourcemeta::one::content_length_exceeds(
-            request, static_cast<std::size_t>(4) * 1024 * 1024)) {
+    if (sourcemeta::one::request_body_too_large(request)) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
-          "sourcemeta:one/payload-too-large",
-          "The request body exceeds the 4 MB limit", error_schema, "*");
+          "sourcemeta:one/payload-too-large", "The request body is too large",
+          error_schema, "*");
       return;
     }
 
@@ -222,7 +221,7 @@ public:
                 callback_request, callback_response,
                 sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
                 "sourcemeta:one/payload-too-large",
-                "The request body exceeds the 4 MB limit", error_schema, "*");
+                "The request body is too large", error_schema, "*");
             return;
           }
 

--- a/src/actions/action_mcp_v1.h
+++ b/src/actions/action_mcp_v1.h
@@ -161,6 +161,31 @@ public:
       return;
     }
 
+    // RFC 9110 §10.1.1: refuse unrecognised expectations with 417 before
+    // touching the body. uWS already auto-acknowledged `100-continue`
+    // upstream, so anything left here is a value we cannot honour.
+    if (sourcemeta::one::expect_header_unrecognised(request)) {
+      this->write_envelope(
+          request, response, sourcemeta::core::HTTP_STATUS_EXPECTATION_FAILED,
+          sourcemeta::core::jsonrpc_make_error(
+              nullptr, -32009,
+              "The Expect header carries an unsupported expectation"),
+          negotiated_version.value());
+      return;
+    }
+
+    // RFC 9110 §15.5.14: when the client declares a `Content-Length`
+    // beyond the cap, fast-fail with 413 before scheduling the read.
+    if (sourcemeta::one::content_length_exceeds(
+            request, static_cast<std::size_t>(4) * 1024 * 1024)) {
+      this->write_envelope(
+          request, response, sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
+          sourcemeta::core::jsonrpc_make_error(
+              nullptr, -32005, "Request body exceeds the 4 MB limit"),
+          negotiated_version.value());
+      return;
+    }
+
     request.body(
         [this, version = negotiated_version.value()](
             sourcemeta::one::HTTPRequest &callback_request,

--- a/src/actions/action_mcp_v1.h
+++ b/src/actions/action_mcp_v1.h
@@ -176,13 +176,12 @@ public:
 
     // RFC 9110 §15.5.14: when the client declares a `Content-Length`
     // beyond the cap, fast-fail with 413 before scheduling the read.
-    if (sourcemeta::one::content_length_exceeds(
-            request, static_cast<std::size_t>(4) * 1024 * 1024)) {
-      this->write_envelope(
-          request, response, sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
-          sourcemeta::core::jsonrpc_make_error(
-              nullptr, -32005, "Request body exceeds the 4 MB limit"),
-          negotiated_version.value());
+    if (sourcemeta::one::request_body_too_large(request)) {
+      this->write_envelope(request, response,
+                           sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
+                           sourcemeta::core::jsonrpc_make_error(
+                               nullptr, -32005, "Request body is too large"),
+                           negotiated_version.value());
       return;
     }
 
@@ -196,7 +195,7 @@ public:
                 callback_request, callback_response,
                 sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
                 sourcemeta::core::jsonrpc_make_error(
-                    nullptr, -32005, "Request body exceeds the 4 MB limit"),
+                    nullptr, -32005, "Request body is too large"),
                 version);
             return;
           }

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -4,6 +4,8 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME http
 target_link_libraries(sourcemeta_one_http INTERFACE sourcemeta::core::json)
 target_link_libraries(sourcemeta_one_http INTERFACE sourcemeta::core::time)
 target_link_libraries(sourcemeta_one_http INTERFACE sourcemeta::core::http)
+target_link_libraries(sourcemeta_one_http INTERFACE sourcemeta::core::numeric)
+target_link_libraries(sourcemeta_one_http INTERFACE sourcemeta::core::text)
 target_link_libraries(sourcemeta_one_http INTERFACE sourcemeta::core::uri)
 target_link_libraries(sourcemeta_one_http INTERFACE sourcemeta::core::gzip)
 target_link_libraries(sourcemeta_one_http INTERFACE sourcemeta::one::shared)

--- a/src/http/include/sourcemeta/one/http_helpers.h
+++ b/src/http/include/sourcemeta/one/http_helpers.h
@@ -4,11 +4,13 @@
 #include <sourcemeta/core/http.h>
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/numeric.h>
+#include <sourcemeta/core/text.h>
 #include <sourcemeta/core/time.h>
 
 #include <sourcemeta/one/http_request.h>
 #include <sourcemeta/one/http_response.h>
 
+#include <algorithm>   // std::ranges::equal
 #include <cassert>     // assert
 #include <chrono>      // std::chrono::system_clock
 #include <cstddef>     // std::size_t
@@ -42,10 +44,17 @@ inline auto write_link_header(HTTPResponse &response,
 // unsupported. uWS auto-acknowledges `100-continue` via router
 // middleware before our handler runs, so by the time we read the
 // `Expect` header here, the only values that can still appear are
-// either empty or something we cannot honour.
+// either empty or something we cannot honour. The expectation
+// token is case-insensitive per the same section, so case-fold
+// the inbound value before the compare.
 inline auto expect_header_unrecognised(const HTTPRequest &request) -> bool {
   const auto expect{request.header("expect")};
-  return !expect.empty() && expect != "100-continue";
+  return !expect.empty() &&
+         !std::ranges::equal(expect, std::string_view{"100-continue"},
+                             [](const char left, const char right) {
+                               return sourcemeta::core::to_lowercase(left) ==
+                                      right;
+                             });
 }
 
 // RFC 9110 §8.6 + §15.5.14: if the client declares a `Content-Length`

--- a/src/http/include/sourcemeta/one/http_helpers.h
+++ b/src/http/include/sourcemeta/one/http_helpers.h
@@ -8,17 +8,19 @@
 #include <sourcemeta/one/http_request.h>
 #include <sourcemeta/one/http_response.h>
 
-#include <cassert>     // assert
-#include <chrono>      // std::chrono::system_clock
-#include <cstddef>     // std::size_t
-#include <format>      // std::format
-#include <mutex>       // std::mutex, std::lock_guard
-#include <optional>    // std::optional
-#include <print>       // std::print
-#include <sstream>     // std::ostringstream
-#include <string>      // std::string
-#include <string_view> // std::string_view
-#include <thread>      // std::this_thread
+#include <cassert>      // assert
+#include <charconv>     // std::from_chars
+#include <chrono>       // std::chrono::system_clock
+#include <cstddef>      // std::size_t
+#include <format>       // std::format
+#include <mutex>        // std::mutex, std::lock_guard
+#include <optional>     // std::optional
+#include <print>        // std::print
+#include <sstream>      // std::ostringstream
+#include <string>       // std::string
+#include <string_view>  // std::string_view
+#include <system_error> // std::errc
+#include <thread>       // std::this_thread
 
 namespace sourcemeta::one {
 
@@ -35,6 +37,39 @@ inline auto write_link_header(HTTPResponse &response,
   response.write_header("Link",
                         sourcemeta::core::http_format_link(
                             {.target = schema_path, .rel = "describedby"}));
+}
+
+// RFC 9110 §10.1.1: any expectation other than `100-continue` is
+// unsupported. uWS auto-acknowledges `100-continue` via router
+// middleware before our handler runs, so by the time we read the
+// `Expect` header here, the only values that can still appear are
+// either empty or something we cannot honour.
+inline auto expect_header_unrecognised(const HTTPRequest &request) -> bool {
+  const auto expect{request.header("expect")};
+  return !expect.empty() && expect != "100-continue";
+}
+
+// RFC 9110 §8.6 + §15.5.14: if the client declares a `Content-Length`
+// that already exceeds the inbound body cap, refuse before reading
+// the body. uWS has already sent its automatic `100 Continue` for
+// `Expect: 100-continue` requests, but well-behaved clients abort
+// their upload on a mid-stream 4xx, so the fast-fail still saves
+// both sides bandwidth versus reading bytes until the cap trips.
+inline auto content_length_exceeds(const HTTPRequest &request,
+                                   const std::size_t max_size) -> bool {
+  const auto content_length{request.header("content-length")};
+  if (content_length.empty()) {
+    return false;
+  }
+  std::size_t declared{0};
+  const auto [pointer, error_code] =
+      std::from_chars(content_length.data(),
+                      content_length.data() + content_length.size(), declared);
+  if (error_code != std::errc{} ||
+      pointer != content_length.data() + content_length.size()) {
+    return false;
+  }
+  return declared > max_size;
 }
 
 inline auto send_response(const sourcemeta::core::HTTPStatus &status,

--- a/src/http/include/sourcemeta/one/http_helpers.h
+++ b/src/http/include/sourcemeta/one/http_helpers.h
@@ -3,24 +3,23 @@
 
 #include <sourcemeta/core/http.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/numeric.h>
 #include <sourcemeta/core/time.h>
 
 #include <sourcemeta/one/http_request.h>
 #include <sourcemeta/one/http_response.h>
 
-#include <cassert>      // assert
-#include <charconv>     // std::from_chars
-#include <chrono>       // std::chrono::system_clock
-#include <cstddef>      // std::size_t
-#include <format>       // std::format
-#include <mutex>        // std::mutex, std::lock_guard
-#include <optional>     // std::optional
-#include <print>        // std::print
-#include <sstream>      // std::ostringstream
-#include <string>       // std::string
-#include <string_view>  // std::string_view
-#include <system_error> // std::errc
-#include <thread>       // std::this_thread
+#include <cassert>     // assert
+#include <chrono>      // std::chrono::system_clock
+#include <cstddef>     // std::size_t
+#include <format>      // std::format
+#include <mutex>       // std::mutex, std::lock_guard
+#include <optional>    // std::optional
+#include <print>       // std::print
+#include <sstream>     // std::ostringstream
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <thread>      // std::this_thread
 
 namespace sourcemeta::one {
 
@@ -56,19 +55,9 @@ inline auto expect_header_unrecognised(const HTTPRequest &request) -> bool {
 // their upload on a mid-stream 4xx, so the fast-fail still saves
 // both sides bandwidth versus reading bytes until the cap trips.
 inline auto request_body_too_large(const HTTPRequest &request) -> bool {
-  const auto content_length{request.header("content-length")};
-  if (content_length.empty()) {
-    return false;
-  }
-  std::size_t declared{0};
-  const auto [pointer, error_code] =
-      std::from_chars(content_length.data(),
-                      content_length.data() + content_length.size(), declared);
-  if (error_code != std::errc{} ||
-      pointer != content_length.data() + content_length.size()) {
-    return false;
-  }
-  return declared > MAX_REQUEST_BODY_BYTES;
+  const auto declared{
+      sourcemeta::core::to_uint64_t(request.header("content-length"))};
+  return declared.has_value() && declared.value() > MAX_REQUEST_BODY_BYTES;
 }
 
 inline auto send_response(const sourcemeta::core::HTTPStatus &status,

--- a/src/http/include/sourcemeta/one/http_helpers.h
+++ b/src/http/include/sourcemeta/one/http_helpers.h
@@ -55,8 +55,7 @@ inline auto expect_header_unrecognised(const HTTPRequest &request) -> bool {
 // `Expect: 100-continue` requests, but well-behaved clients abort
 // their upload on a mid-stream 4xx, so the fast-fail still saves
 // both sides bandwidth versus reading bytes until the cap trips.
-inline auto content_length_exceeds(const HTTPRequest &request,
-                                   const std::size_t max_size) -> bool {
+inline auto request_body_too_large(const HTTPRequest &request) -> bool {
   const auto content_length{request.header("content-length")};
   if (content_length.empty()) {
     return false;
@@ -69,7 +68,7 @@ inline auto content_length_exceeds(const HTTPRequest &request,
       pointer != content_length.data() + content_length.size()) {
     return false;
   }
-  return declared > max_size;
+  return declared > MAX_REQUEST_BODY_BYTES;
 }
 
 inline auto send_response(const sourcemeta::core::HTTPStatus &status,

--- a/src/http/include/sourcemeta/one/http_request.h
+++ b/src/http/include/sourcemeta/one/http_request.h
@@ -109,8 +109,7 @@ public:
   // - callback: Invoked with (response, body, too_big) on completion
   // - on_error: Invoked with (response, exception_ptr) on any exception,
   //   including exceptions thrown by the main callback
-  // - max_size: Maximum body size in bytes. Defaults to the universal
-  //   cap. See `MAX_REQUEST_BODY_BYTES` above for the rationale.
+  // - max_size: Maximum body size in bytes.
   // Note: If the request is aborted, the callback is not invoked
   template <typename Callback, typename ErrorCallback>
   // NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/src/http/include/sourcemeta/one/http_request.h
+++ b/src/http/include/sourcemeta/one/http_request.h
@@ -8,6 +8,7 @@
 #include <sourcemeta/one/http_uwebsockets.h>
 
 #include <chrono>      // std::chrono::system_clock
+#include <cstddef>     // std::size_t
 #include <exception>   // std::exception_ptr, std::current_exception
 #include <memory>      // std::shared_ptr, std::make_shared
 #include <optional>    // std::optional
@@ -16,6 +17,12 @@
 #include <utility>     // std::move
 
 namespace sourcemeta::one {
+
+// 4 MB inbound body cap. Accommodates realistic JSON Schema instances
+// and evaluate bodies while still rejecting pathological inputs. RFC
+// 9110 §15.5.14 maps oversize bodies to 413 Content Too Large.
+inline constexpr std::size_t MAX_REQUEST_BODY_BYTES{
+    static_cast<std::size_t>(4) * 1024 * 1024};
 
 class HTTPRequest {
 public:
@@ -102,16 +109,13 @@ public:
   // - callback: Invoked with (response, body, too_big) on completion
   // - on_error: Invoked with (response, exception_ptr) on any exception,
   //   including exceptions thrown by the main callback
-  // - max_size: Maximum body size in bytes. 4 MB accommodates realistic
-  //   JSON Schema instances and evaluate bodies while still rejecting
-  //   pathological inputs. RFC 9110 §15.5.14 maps oversize bodies to
-  //   413 Content Too Large.
+  // - max_size: Maximum body size in bytes. Defaults to the universal
+  //   cap. See `MAX_REQUEST_BODY_BYTES` above for the rationale.
   // Note: If the request is aborted, the callback is not invoked
   template <typename Callback, typename ErrorCallback>
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
   auto body(Callback callback, ErrorCallback on_error,
-            std::size_t max_size = static_cast<std::size_t>(4) * 1024 * 1024)
-      -> void {
+            std::size_t max_size = MAX_REQUEST_BODY_BYTES) -> void {
     auto raw_response = this->response_;
     auto snapshot = std::make_shared<HTTPRequest>(
         std::string{this->method()}, std::string{this->path()},

--- a/src/self/v1/schemas/api/error.json
+++ b/src/self/v1/schemas/api/error.json
@@ -131,6 +131,14 @@
     },
     {
       "const": {
+        "type": "sourcemeta:one/expectation-failed",
+        "title": "Expectation Failed",
+        "status": 417,
+        "detail": "The Expect header carries an unsupported expectation"
+      }
+    },
+    {
+      "const": {
         "type": "sourcemeta:one/missing-schema-match",
         "title": "Internal Server Error",
         "status": 500,

--- a/src/self/v1/schemas/api/error.json
+++ b/src/self/v1/schemas/api/error.json
@@ -126,7 +126,7 @@
         "type": "sourcemeta:one/payload-too-large",
         "title": "Content Too Large",
         "status": 413,
-        "detail": "The request body exceeds the 4 MB limit"
+        "detail": "The request body is too large"
       }
     },
     {

--- a/src/self/v1/schemas/mcp/error.json
+++ b/src/self/v1/schemas/mcp/error.json
@@ -179,7 +179,7 @@
         {
           "const": {
             "code": -32005,
-            "message": "Request body exceeds the 4 MB limit"
+            "message": "Request body is too large"
           }
         },
         {

--- a/src/self/v1/schemas/mcp/error.json
+++ b/src/self/v1/schemas/mcp/error.json
@@ -184,6 +184,12 @@
         },
         {
           "const": {
+            "code": -32009,
+            "message": "The Expect header carries an unsupported expectation"
+          }
+        },
+        {
+          "const": {
             "code": -32006,
             "message": "Accept header must list application/json and text/event-stream"
           }

--- a/test/e2e/headless/hurl/schemas-evaluate.all.hurl
+++ b/test/e2e/headless/hurl/schemas-evaluate.all.hurl
@@ -50,6 +50,26 @@ header "X-Frame-Options" not exists
 header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
 jsonpath "$.valid" == true
 
+# RFC 9110 §10.1.1: the expectation token is case-insensitive. A
+# `100-Continue` (capital C) request must NOT be rejected as an
+# unknown expectation
+POST {{base}}/self/v1/api/schemas/evaluate/test/schemas/string
+Expect: 100-Continue
+Content-Type: application/json
+"Hello World"
+HTTP 200
+Cache-Control: no-store
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+header "Vary" not exists
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.valid" == true
+
 # RFC 9110 §10.1.1: any expectation other than `100-continue` is
 # unsupported. The fast-fail emits 417 before the body is touched
 POST {{base}}/self/v1/api/schemas/evaluate/test/schemas/string

--- a/test/e2e/headless/hurl/schemas-evaluate.all.hurl
+++ b/test/e2e/headless/hurl/schemas-evaluate.all.hurl
@@ -50,6 +50,79 @@ header "X-Frame-Options" not exists
 header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
 jsonpath "$.valid" == true
 
+# RFC 9110 §10.1.1: any expectation other than `100-continue` is
+# unsupported. The fast-fail emits 417 before the body is touched
+POST {{base}}/self/v1/api/schemas/evaluate/test/schemas/string
+Expect: please-do-something-weird
+Content-Type: application/json
+"Hello World"
+HTTP 417
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+last_response: body
+schema_path: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "Vary" not exists
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.status" == 417
+jsonpath "$.type" == "sourcemeta:one/expectation-failed"
+jsonpath "$.title" == "Expectation Failed"
+jsonpath "$.detail" == "The Expect header carries an unsupported expectation"
+
+POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
+```
+{{last_response}}
+```
+HTTP 200
+Cache-Control: no-store
+[Asserts]
+header "Vary" not exists
+jsonpath "$.valid" == true
+
+# RFC 9110 §15.5.14: when a client declares a `Content-Length` that
+# already exceeds the 4 MB cap, fast-fail with 413 before scheduling
+# the read
+POST {{base}}/self/v1/api/schemas/evaluate/test/schemas/string
+Content-Length: 5000000
+Content-Type: application/json
+"Hello World"
+HTTP 413
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+last_response: body
+schema_path: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "Vary" not exists
+header "Referrer-Policy" not exists
+header "Content-Security-Policy" not exists
+header "X-Frame-Options" not exists
+header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] GMT$/
+jsonpath "$.status" == 413
+jsonpath "$.type" == "sourcemeta:one/payload-too-large"
+jsonpath "$.title" == "Content Too Large"
+jsonpath "$.detail" == "The request body exceeds the 4 MB limit"
+
+POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
+```
+{{last_response}}
+```
+HTTP 200
+Cache-Control: no-store
+[Asserts]
+header "Vary" not exists
+jsonpath "$.valid" == true
+
 POST {{base}}/self/v1/api/schemas/evaluate/test/schemas/string
 Content-Type: application/json
 "Hello World"

--- a/test/e2e/headless/hurl/schemas-evaluate.all.hurl
+++ b/test/e2e/headless/hurl/schemas-evaluate.all.hurl
@@ -111,7 +111,7 @@ header "Date" matches /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (0[1-9]|[12][0-9]|3[01]) 
 jsonpath "$.status" == 413
 jsonpath "$.type" == "sourcemeta:one/payload-too-large"
 jsonpath "$.title" == "Content Too Large"
-jsonpath "$.detail" == "The request body exceeds the 4 MB limit"
+jsonpath "$.detail" == "The request body is too large"
 
 POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
 ```


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
