### PR TITLE
Better encapsulate artifact reading in preparation for auth

### DIFF
--- a/enterprise/e2e/html/hurl/mcp-2025-11-25-resources.all.hurl
+++ b/enterprise/e2e/html/hurl/mcp-2025-11-25-resources.all.hurl
@@ -444,7 +444,7 @@ jsonpath "$.result.resources[20].uri" == "{{base}}/self/v1/schemas/api/error"
 jsonpath "$.result.resources[20].name" == "Sourcemeta One API Error"
 jsonpath "$.result.resources[20].description" == "The error response format returned by the Sourcemeta One API endpoints"
 jsonpath "$.result.resources[20].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[20].size" == 5479
+jsonpath "$.result.resources[20].size" == 5693
 jsonpath "$.result.resources[20].annotations.priority" == 0
 jsonpath "$.result.resources[21].uri" == "{{base}}/self/v1/schemas/api/list/response"
 jsonpath "$.result.resources[21].name" == "Sourcemeta One List API Response"
@@ -534,7 +534,7 @@ jsonpath "$.result.resources[35].uri" == "{{base}}/self/v1/schemas/mcp/error"
 jsonpath "$.result.resources[35].name" == "Sourcemeta One MCP Error Response"
 jsonpath "$.result.resources[35].description" == "The error response Sourcemeta One returns when an MCP request fails"
 jsonpath "$.result.resources[35].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[35].size" == 5860
+jsonpath "$.result.resources[35].size" == 5991
 jsonpath "$.result.resources[35].annotations.priority" == 0
 jsonpath "$.result.resources[36].uri" == "{{base}}/self/v1/schemas/mcp/initialize/request"
 jsonpath "$.result.resources[36].name" == "Sourcemeta One MCP Initialize Request"

--- a/enterprise/e2e/path/hurl/mcp-2025-11-25-resources.all.hurl
+++ b/enterprise/e2e/path/hurl/mcp-2025-11-25-resources.all.hurl
@@ -68,7 +68,7 @@ jsonpath "$.result.resources[7].uri" == "{{base}}/v1/catalog/self/v1/schemas/api
 jsonpath "$.result.resources[7].name" == "Sourcemeta One API Error"
 jsonpath "$.result.resources[7].description" == "The error response format returned by the Sourcemeta One API endpoints"
 jsonpath "$.result.resources[7].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[7].size" == 5490
+jsonpath "$.result.resources[7].size" == 5704
 jsonpath "$.result.resources[7].annotations.priority" == 0
 jsonpath "$.result.resources[8].uri" == "{{base}}/v1/catalog/self/v1/schemas/api/list/response"
 jsonpath "$.result.resources[8].name" == "Sourcemeta One List API Response"
@@ -158,7 +158,7 @@ jsonpath "$.result.resources[22].uri" == "{{base}}/v1/catalog/self/v1/schemas/mc
 jsonpath "$.result.resources[22].name" == "Sourcemeta One MCP Error Response"
 jsonpath "$.result.resources[22].description" == "The error response Sourcemeta One returns when an MCP request fails"
 jsonpath "$.result.resources[22].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[22].size" == 5871
+jsonpath "$.result.resources[22].size" == 6002
 jsonpath "$.result.resources[22].annotations.priority" == 0
 jsonpath "$.result.resources[23].uri" == "{{base}}/v1/catalog/self/v1/schemas/mcp/initialize/request"
 jsonpath "$.result.resources[23].name" == "Sourcemeta One MCP Initialize Request"

--- a/enterprise/server/action_mcp_v1.cc
+++ b/enterprise/server/action_mcp_v1.cc
@@ -167,7 +167,7 @@ auto ActionMCP_v1::on_resources_read(const sourcemeta::core::JSON &request_json)
       uri, Tree::Schemas, bundle ? "bundle" : "schema")};
   if (resolution.outcome ==
       sourcemeta::one::ArtifactResolution::Outcome::Denied) {
-    return sourcemeta::core::jsonrpc_make_error(&id, -32001,
+    return sourcemeta::core::jsonrpc_make_error(&id, -32010,
                                                 "Authentication required");
   }
   if (resolution.outcome !=

--- a/enterprise/server/action_mcp_v1.cc
+++ b/enterprise/server/action_mcp_v1.cc
@@ -163,14 +163,20 @@ auto ActionMCP_v1::on_resources_read(const sourcemeta::core::JSON &request_json)
         "Resource not found");
   }
 
-  const auto schema_artifact_path{this->artifact_resolve_path(
+  const auto resolution{this->artifact_resolve_path(
       uri, Tree::Schemas, bundle ? "bundle" : "schema")};
-  if (!schema_artifact_path.has_value()) {
+  if (resolution.outcome ==
+      sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+    return sourcemeta::core::jsonrpc_make_error(&id, -32001,
+                                                "Authentication required");
+  }
+  if (resolution.outcome !=
+      sourcemeta::one::ArtifactResolution::Outcome::Found) {
     return sourcemeta::core::jsonrpc_make_error(
         &id, sourcemeta::core::MCP_CODE_RESOURCE_NOT_FOUND,
         "Resource not found");
   }
-  const auto schema{this->artifact_read_json(schema_artifact_path.value())};
+  const auto schema{this->artifact_read_json(resolution.path.value())};
   if (!schema.has_value()) {
     return sourcemeta::core::jsonrpc_make_error(
         &id, sourcemeta::core::MCP_CODE_RESOURCE_NOT_FOUND,

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_actions.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_actions.h
@@ -46,11 +46,12 @@ public:
       }
     });
 
-    const auto mcp_metadata_path{
+    const auto mcp_metadata{
         this->artifact_resolve_path("", Tree::Explorer, "mcp")};
-    assert(mcp_metadata_path.has_value());
+    assert(mcp_metadata.outcome ==
+           sourcemeta::one::ArtifactResolution::Outcome::Found);
     auto mcp_metadata_option{
-        this->artifact_read_json(mcp_metadata_path.value())};
+        this->artifact_read_json(mcp_metadata.path.value())};
     assert(mcp_metadata_option.has_value());
     this->mcp_metadata_ = std::move(mcp_metadata_option.value());
     this->allowed_origin_ = this->mcp_metadata_.at("origin").to_string();

--- a/src/actions/action_default_v1.h
+++ b/src/actions/action_default_v1.h
@@ -105,11 +105,19 @@ public:
           "text/html") {
         const auto root_html{
             this->artifact_resolve_path("", Tree::Explorer, "directory-html")};
-        if (root_html.has_value()) {
+        if (root_html.outcome ==
+            sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+          sourcemeta::one::json_error_unauthorized(request, response,
+                                                   this->error_schema_, "*");
+          return;
+        }
+        if (root_html.outcome ==
+            sourcemeta::one::ArtifactResolution::Outcome::Found) {
           this->artifact_serve(
-              root_html.value(), sourcemeta::core::HTTP_STATUS_OK, false, {},
-              {}, HTML_BROWSER_SECURITY, request, response, this->error_schema_,
-              "public, max-age=0, must-revalidate", "Accept, Accept-Encoding");
+              root_html.path.value(), sourcemeta::core::HTTP_STATUS_OK, false,
+              {}, {}, HTML_BROWSER_SECURITY, request, response,
+              this->error_schema_, "public, max-age=0, must-revalidate",
+              "Accept, Accept-Encoding");
           return;
         }
       }
@@ -136,26 +144,45 @@ public:
             this->artifact_resolve_path(path, Tree::Explorer, "schema-html")};
         const auto directory_html{this->artifact_resolve_path(
             path, Tree::Explorer, "directory-html")};
-        if (!path.ends_with("/") && schema_html.has_value()) {
+        if (schema_html.outcome ==
+                sourcemeta::one::ArtifactResolution::Outcome::Denied ||
+            directory_html.outcome ==
+                sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+          sourcemeta::one::json_error_unauthorized(request, response,
+                                                   this->error_schema_, "*");
+          return;
+        }
+        if (!path.ends_with("/") &&
+            schema_html.outcome ==
+                sourcemeta::one::ArtifactResolution::Outcome::Found) {
           this->artifact_serve(
-              schema_html.value(), sourcemeta::core::HTTP_STATUS_OK, false, {},
-              {}, HTML_BROWSER_SECURITY, request, response, this->error_schema_,
-              "public, max-age=0, must-revalidate", "Accept, Accept-Encoding");
-        } else if (directory_html.has_value()) {
-          this->artifact_serve(
-              directory_html.value(), sourcemeta::core::HTTP_STATUS_OK, false,
+              schema_html.path.value(), sourcemeta::core::HTTP_STATUS_OK, false,
               {}, {}, HTML_BROWSER_SECURITY, request, response,
+              this->error_schema_, "public, max-age=0, must-revalidate",
+              "Accept, Accept-Encoding");
+        } else if (directory_html.outcome ==
+                   sourcemeta::one::ArtifactResolution::Outcome::Found) {
+          this->artifact_serve(
+              directory_html.path.value(), sourcemeta::core::HTTP_STATUS_OK,
+              false, {}, {}, HTML_BROWSER_SECURITY, request, response,
               this->error_schema_, "public, max-age=0, must-revalidate",
               "Accept, Accept-Encoding");
         } else {
           const auto not_found{
               this->artifact_resolve_path("", Tree::Explorer, "404")};
-          if (not_found.has_value()) {
+          if (not_found.outcome ==
+              sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+            sourcemeta::one::json_error_unauthorized(request, response,
+                                                     this->error_schema_, "*");
+            return;
+          }
+          if (not_found.outcome ==
+              sourcemeta::one::ArtifactResolution::Outcome::Found) {
             // The 404 HTML page is itself an error response, so it
             // travels with the same `no-store` discipline as the
             // JSON Problem Details errors.
             this->artifact_serve(
-                not_found.value(), sourcemeta::core::HTTP_STATUS_NOT_FOUND,
+                not_found.path.value(), sourcemeta::core::HTTP_STATUS_NOT_FOUND,
                 false, {}, {}, HTML_BROWSER_SECURITY, request, response,
                 this->error_schema_, "no-store", "Accept, Accept-Encoding");
           } else {
@@ -179,9 +206,23 @@ public:
           this->artifact_resolve_path(path, Tree::Explorer, "schema-html")};
       const auto directory_html{
           this->artifact_resolve_path(path, Tree::Explorer, "directory-html")};
-      if (schema_json.has_value() ||
-          (!path.ends_with("/") && schema_html.has_value()) ||
-          directory_html.has_value()) {
+      if (schema_json.outcome ==
+              sourcemeta::one::ArtifactResolution::Outcome::Denied ||
+          schema_html.outcome ==
+              sourcemeta::one::ArtifactResolution::Outcome::Denied ||
+          directory_html.outcome ==
+              sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+        sourcemeta::one::json_error_unauthorized(request, response,
+                                                 this->error_schema_, "*");
+        return;
+      }
+      if (schema_json.outcome ==
+              sourcemeta::one::ArtifactResolution::Outcome::Found ||
+          (!path.ends_with("/") &&
+           schema_html.outcome ==
+               sourcemeta::one::ArtifactResolution::Outcome::Found) ||
+          directory_html.outcome ==
+              sourcemeta::one::ArtifactResolution::Outcome::Found) {
         sourcemeta::one::json_error(
             request, response, sourcemeta::core::HTTP_STATUS_METHOD_NOT_ALLOWED,
             "urn:sourcemeta:one:method-not-allowed",

--- a/src/actions/action_dependency_tree_v1.h
+++ b/src/actions/action_dependency_tree_v1.h
@@ -80,9 +80,16 @@ public:
       return;
     }
 
-    const auto path{this->artifact_resolve_path(matches.front(), Tree::Schemas,
-                                                this->metapack_)};
-    if (!path.has_value()) {
+    const auto resolution{this->artifact_resolve_path(
+        matches.front(), Tree::Schemas, this->metapack_)};
+    if (resolution.outcome ==
+        sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      sourcemeta::one::json_error_unauthorized(request, response,
+                                               this->error_schema_, "*");
+      return;
+    }
+    if (resolution.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
           "urn:sourcemeta:one:not-found", "There is nothing at this URL",
@@ -90,7 +97,7 @@ public:
       return;
     }
     this->artifact_serve(
-        path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
+        resolution.path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
         this->response_schema_, {}, request, response, this->error_schema_,
         "public, max-age=0, must-revalidate", "Accept-Encoding");
   }
@@ -108,13 +115,19 @@ public:
           std::move(request_output));
     }
 
-    const auto path{this->artifact_resolve_path(
+    const auto resolution{this->artifact_resolve_path(
         arguments.at("schema").to_string(), Tree::Schemas, this->metapack_)};
-    if (!path.has_value()) {
+    if (resolution.outcome ==
+        sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      return sourcemeta::core::mcp_make_tool_error(request_id,
+                                                   "Authentication required");
+    }
+    if (resolution.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");
     }
-    auto contents{this->artifact_read_json(path.value())};
+    auto contents{this->artifact_read_json(resolution.path.value())};
     if (!contents.has_value()) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");

--- a/src/actions/action_jsonschema_evaluate_v1.h
+++ b/src/actions/action_jsonschema_evaluate_v1.h
@@ -83,12 +83,21 @@ public:
         this->artifact_resolve_path(schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
         schema_uri, Tree::Schemas, "blaze-exhaustive")};
-    if (!schema_present.has_value()) {
+    if (schema_present.outcome ==
+            sourcemeta::one::ArtifactResolution::Outcome::Denied ||
+        evaluation_enabled.outcome ==
+            sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      return sourcemeta::core::mcp_make_tool_error(request_id,
+                                                   "Authentication required");
+    }
+    if (schema_present.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");
     }
 
-    if (!evaluation_enabled.has_value()) {
+    if (evaluation_enabled.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       return sourcemeta::core::mcp_make_tool_error(
           request_id, "This schema was not precompiled for schema evaluation");
     }
@@ -167,7 +176,16 @@ public:
     const auto evaluation_enabled{self.artifact_resolve_path(
         schema_uri, sourcemeta::one::RouterAction::Tree::Schemas,
         "blaze-exhaustive")};
-    if (!schema_present.has_value()) {
+    if (schema_present.outcome ==
+            sourcemeta::one::ArtifactResolution::Outcome::Denied ||
+        evaluation_enabled.outcome ==
+            sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      sourcemeta::one::json_error_unauthorized(request, response, error_schema,
+                                               "*");
+      return;
+    }
+    if (schema_present.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
           "urn:sourcemeta:one:not-found", "There is nothing at this URL",
@@ -175,7 +193,8 @@ public:
       return;
     }
 
-    if (!evaluation_enabled.has_value()) {
+    if (evaluation_enabled.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       // RFC 9110 §15.5.6: Allow lists the methods this specific target
       // resource currently supports. POST hits this very branch (returns
       // 405) when the schema was not precompiled, so only OPTIONS is

--- a/src/actions/action_jsonschema_serve_v1.h
+++ b/src/actions/action_jsonschema_serve_v1.h
@@ -60,9 +60,16 @@ public:
                                     : (bundle || is_deno)
                                         ? std::string_view{"bundle"}
                                         : std::string_view{"schema"}};
-    const auto path{self.artifact_resolve_path(
+    const auto resolution{self.artifact_resolve_path(
         schema_path, sourcemeta::one::RouterAction::Tree::Schemas, artifact)};
-    if (!path.has_value()) {
+    if (resolution.outcome ==
+        sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      sourcemeta::one::json_error_unauthorized(request, response, error_schema,
+                                               "*");
+      return;
+    }
+    if (resolution.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
           "urn:sourcemeta:one:not-found", "There is nothing at this URL",
@@ -76,7 +83,7 @@ public:
     // `Accept-Encoding` axis, otherwise a cache hit from one client
     // could leak the wrong representation to another.
     self.artifact_serve(
-        path.value(), sourcemeta::core::HTTP_STATUS_OK, true,
+        resolution.path.value(), sourcemeta::core::HTTP_STATUS_OK, true,
         is_deno ? std::string_view{"application/json"} : std::string_view{}, {},
         {}, request, response, error_schema,
         "public, max-age=0, must-revalidate", "User-Agent, Accept-Encoding");

--- a/src/actions/action_jsonschema_trace_v1.h
+++ b/src/actions/action_jsonschema_trace_v1.h
@@ -95,12 +95,21 @@ public:
         this->artifact_resolve_path(schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
         schema_uri, Tree::Schemas, "blaze-exhaustive")};
-    if (!schema_present.has_value()) {
+    if (schema_present.outcome ==
+            sourcemeta::one::ArtifactResolution::Outcome::Denied ||
+        evaluation_enabled.outcome ==
+            sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      return sourcemeta::core::mcp_make_tool_error(request_id,
+                                                   "Authentication required");
+    }
+    if (schema_present.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");
     }
 
-    if (!evaluation_enabled.has_value()) {
+    if (evaluation_enabled.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       return sourcemeta::core::mcp_make_tool_error(
           request_id, "This schema was not precompiled for schema evaluation");
     }
@@ -143,10 +152,12 @@ private:
 
       auto cached{referenced_locations.find(schema_uri)};
       if (cached == referenced_locations.end()) {
-        const auto locations_path{this->artifact_resolve_path(
+        const auto locations_resolution{this->artifact_resolve_path(
             keyword_location_string, Tree::Schemas, "locations")};
-        if (locations_path.has_value()) {
-          auto locations{this->artifact_read_json(locations_path.value())};
+        if (locations_resolution.outcome ==
+            sourcemeta::one::ArtifactResolution::Outcome::Found) {
+          auto locations{
+              this->artifact_read_json(locations_resolution.path.value())};
           if (locations.has_value() && locations.value().is_object() &&
               locations.value().defines("static")) {
             cached = referenced_locations
@@ -195,13 +206,14 @@ private:
       -> sourcemeta::core::JSON {
     auto steps{sourcemeta::core::JSON::make_array()};
 
-    const auto locations_path{
+    const auto locations_resolution{
         this->artifact_resolve_path(schema_uri, Tree::Schemas, "locations")};
-    if (!locations_path.has_value()) {
+    if (locations_resolution.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       throw std::runtime_error{"Failed to read schema locations metadata"};
     }
     const auto locations_option{
-        this->artifact_read_json(locations_path.value())};
+        this->artifact_read_json(locations_resolution.path.value())};
     if (!locations_option.has_value()) {
       throw std::runtime_error{"Failed to read schema locations metadata"};
     }

--- a/src/actions/action_list_directory_v1.h
+++ b/src/actions/action_list_directory_v1.h
@@ -59,9 +59,16 @@ public:
     }
     const std::string_view path_match{matches.empty() ? std::string_view{}
                                                       : matches.front()};
-    const auto path{
+    const auto resolution{
         this->artifact_resolve_path(path_match, Tree::Explorer, "directory")};
-    if (!path.has_value()) {
+    if (resolution.outcome ==
+        sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      sourcemeta::one::json_error_unauthorized(request, response,
+                                               this->error_schema_, "*");
+      return;
+    }
+    if (resolution.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
           "urn:sourcemeta:one:not-found", "There is nothing at this URL",
@@ -69,7 +76,7 @@ public:
       return;
     }
     this->artifact_serve(
-        path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
+        resolution.path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
         this->response_schema_, {}, request, response, this->error_schema_,
         "public, max-age=0, must-revalidate", "Accept-Encoding");
   }
@@ -89,13 +96,19 @@ public:
 
     static const sourcemeta::core::JSON EMPTY_STRING{""};
     const auto &path_arg{arguments.at_or("path", EMPTY_STRING).to_string()};
-    const auto path{
+    const auto resolution{
         this->artifact_resolve_path(path_arg, Tree::Explorer, "directory")};
-    if (!path.has_value()) {
+    if (resolution.outcome ==
+        sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      return sourcemeta::core::mcp_make_tool_error(request_id,
+                                                   "Authentication required");
+    }
+    if (resolution.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Directory not found");
     }
-    auto contents{this->artifact_read_json(path.value())};
+    auto contents{this->artifact_read_json(resolution.path.value())};
     if (!contents.has_value()) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Directory not found");

--- a/src/actions/action_mcp_v1.h
+++ b/src/actions/action_mcp_v1.h
@@ -53,11 +53,12 @@ public:
       }
     });
 
-    const auto mcp_metadata_path{
+    const auto mcp_metadata{
         this->artifact_resolve_path("", Tree::Explorer, "mcp")};
-    assert(mcp_metadata_path.has_value());
+    assert(mcp_metadata.outcome ==
+           sourcemeta::one::ArtifactResolution::Outcome::Found);
     auto mcp_metadata_option{
-        this->artifact_read_json(mcp_metadata_path.value())};
+        this->artifact_read_json(mcp_metadata.path.value())};
     assert(mcp_metadata_option.has_value());
     this->mcp_metadata_ = std::move(mcp_metadata_option.value());
     this->allowed_origin_ = this->mcp_metadata_.at("origin").to_string();

--- a/src/actions/action_serve_explorer_artifact_v1.h
+++ b/src/actions/action_serve_explorer_artifact_v1.h
@@ -69,9 +69,16 @@ public:
 
     const std::string_view path_match{matches.empty() ? std::string_view{}
                                                       : matches.front()};
-    const auto path{this->artifact_resolve_path(path_match, Tree::Explorer,
-                                                this->artifact_)};
-    if (!path.has_value()) {
+    const auto resolution{this->artifact_resolve_path(
+        path_match, Tree::Explorer, this->artifact_)};
+    if (resolution.outcome ==
+        sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      sourcemeta::one::json_error_unauthorized(request, response,
+                                               this->error_schema_, "*");
+      return;
+    }
+    if (resolution.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
           "urn:sourcemeta:one:not-found", "There is nothing at this URL",
@@ -79,7 +86,7 @@ public:
       return;
     }
     this->artifact_serve(
-        path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
+        resolution.path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
         this->response_schema_, {}, request, response, this->error_schema_,
         "public, max-age=0, must-revalidate", "Accept-Encoding");
   }
@@ -97,13 +104,19 @@ public:
           std::move(request_output));
     }
 
-    const auto path{this->artifact_resolve_path(
+    const auto resolution{this->artifact_resolve_path(
         arguments.at("schema").to_string(), Tree::Explorer, this->artifact_)};
-    if (!path.has_value()) {
+    if (resolution.outcome ==
+        sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      return sourcemeta::core::mcp_make_tool_error(request_id,
+                                                   "Authentication required");
+    }
+    if (resolution.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");
     }
-    auto contents{this->artifact_read_json(path.value())};
+    auto contents{this->artifact_read_json(resolution.path.value())};
     if (!contents.has_value()) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");

--- a/src/actions/action_serve_schema_artifact_v1.h
+++ b/src/actions/action_serve_schema_artifact_v1.h
@@ -76,9 +76,16 @@ public:
       return;
     }
 
-    const auto path{this->artifact_resolve_path(matches.front(), Tree::Schemas,
-                                                this->artifact_)};
-    if (!path.has_value()) {
+    const auto resolution{this->artifact_resolve_path(
+        matches.front(), Tree::Schemas, this->artifact_)};
+    if (resolution.outcome ==
+        sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      sourcemeta::one::json_error_unauthorized(request, response,
+                                               this->error_schema_, "*");
+      return;
+    }
+    if (resolution.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
           "urn:sourcemeta:one:not-found", "There is nothing at this URL",
@@ -86,7 +93,7 @@ public:
       return;
     }
     this->artifact_serve(
-        path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
+        resolution.path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
         this->response_schema_, {}, request, response, this->error_schema_,
         "public, max-age=0, must-revalidate", "Accept-Encoding");
   }
@@ -104,13 +111,19 @@ public:
           std::move(request_output));
     }
 
-    const auto path{this->artifact_resolve_path(
+    const auto resolution{this->artifact_resolve_path(
         arguments.at("schema").to_string(), Tree::Schemas, this->artifact_)};
-    if (!path.has_value()) {
+    if (resolution.outcome ==
+        sourcemeta::one::ArtifactResolution::Outcome::Denied) {
+      return sourcemeta::core::mcp_make_tool_error(request_id,
+                                                   "Authentication required");
+    }
+    if (resolution.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");
     }
-    auto contents{this->artifact_read_json(path.value())};
+    auto contents{this->artifact_read_json(resolution.path.value())};
     if (!contents.has_value()) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");

--- a/src/actions/action_serve_static_v1.h
+++ b/src/actions/action_serve_static_v1.h
@@ -65,15 +65,35 @@ public:
       return;
     }
 
+    const auto resolution{
+        this->artifact_resolve_static(this->file_root_, matches.front())};
+    if (resolution.outcome !=
+        sourcemeta::one::ArtifactResolution::Outcome::Found) {
+      // A path that escapes the static asset tree behaves exactly like
+      // a missing file, including the method check coming first
+      if (request.method() != "get" && request.method() != "head") {
+        sourcemeta::one::json_error(
+            request, response, sourcemeta::core::HTTP_STATUS_METHOD_NOT_ALLOWED,
+            "urn:sourcemeta:one:method-not-allowed",
+            "This HTTP method is invalid for this URL", this->error_schema_, "",
+            "GET, HEAD, OPTIONS");
+        return;
+      }
+      sourcemeta::one::json_error(
+          request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
+          "urn:sourcemeta:one:not-found", "There is nothing at this URL",
+          this->error_schema_, "");
+      return;
+    }
+
     // RFC 8246 §2: static assets are deploy-pinned (the build emits
     // them under a versioned URL), so a year-long `max-age` with the
     // `immutable` extension lets browsers skip the conditional GET
     // entirely.
     this->artifact_serve(
-        this->authorize_static(this->file_root_ / matches.front()),
-        sourcemeta::core::HTTP_STATUS_OK, false, {}, {}, {}, request, response,
-        this->error_schema_, "public, max-age=31536000, immutable",
-        "Accept-Encoding");
+        resolution.path.value(), sourcemeta::core::HTTP_STATUS_OK, false, {},
+        {}, {}, request, response, this->error_schema_,
+        "public, max-age=31536000, immutable", "Accept-Encoding");
   }
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,

--- a/src/actions/action_serve_static_v1.h
+++ b/src/actions/action_serve_static_v1.h
@@ -70,9 +70,10 @@ public:
     // `immutable` extension lets browsers skip the conditional GET
     // entirely.
     this->artifact_serve(
-        this->file_root_ / matches.front(), sourcemeta::core::HTTP_STATUS_OK,
-        false, {}, {}, {}, request, response, this->error_schema_,
-        "public, max-age=31536000, immutable", "Accept-Encoding");
+        this->authorize_static(this->file_root_ / matches.front()),
+        sourcemeta::core::HTTP_STATUS_OK, false, {}, {}, {}, request, response,
+        this->error_schema_, "public, max-age=31536000, immutable",
+        "Accept-Encoding");
   }
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,

--- a/src/http/include/sourcemeta/one/http_helpers.h
+++ b/src/http/include/sourcemeta/one/http_helpers.h
@@ -166,6 +166,13 @@ inline auto json_error(const HTTPRequest &request, HTTPResponse &response,
       status == sourcemeta::core::HTTP_STATUS_METHOD_NOT_ALLOWED) {
     response.write_header("Allow", allow);
   }
+  // RFC 9110 §15.5.2: a 401 response MUST carry WWW-Authenticate. The
+  // machine surface authenticates with bearer credentials only, so the
+  // challenge is constant.
+  // https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.2
+  if (status == sourcemeta::core::HTTP_STATUS_UNAUTHORIZED) {
+    response.write_header("WWW-Authenticate", "Bearer");
+  }
   if (!schema.empty()) {
     write_link_header(response, schema);
   }
@@ -173,6 +180,17 @@ inline auto json_error(const HTTPRequest &request, HTTPResponse &response,
   std::ostringstream output;
   sourcemeta::core::prettify(body, output);
   send_response(status, request, response, output.str(), Encoding::Identity);
+}
+
+// The single shape of an authentication denial on the HTTP surface, so
+// every protected resource answers identically
+inline auto json_error_unauthorized(const HTTPRequest &request,
+                                    HTTPResponse &response,
+                                    const std::string_view schema,
+                                    const std::string_view origin) -> void {
+  json_error(request, response, sourcemeta::core::HTTP_STATUS_UNAUTHORIZED,
+             "urn:sourcemeta:one:authentication-required",
+             "This resource requires authentication", schema, origin);
 }
 
 } // namespace sourcemeta::one

--- a/src/http/include/sourcemeta/one/http_helpers.h
+++ b/src/http/include/sourcemeta/one/http_helpers.h
@@ -168,10 +168,13 @@ inline auto json_error(const HTTPRequest &request, HTTPResponse &response,
   }
   // RFC 9110 §15.5.2: a 401 response MUST carry WWW-Authenticate. The
   // machine surface authenticates with bearer credentials only, so the
-  // challenge is constant.
+  // challenge is constant. RFC 6750 §3 additionally requires the scheme
+  // to be followed by at least one auth-param, and `realm` is the
+  // conventional one.
   // https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.2
+  // https://datatracker.ietf.org/doc/html/rfc6750#section-3
   if (status == sourcemeta::core::HTTP_STATUS_UNAUTHORIZED) {
-    response.write_header("WWW-Authenticate", "Bearer");
+    response.write_header("WWW-Authenticate", "Bearer realm=\"registry\"");
   }
   if (!schema.empty()) {
     write_link_header(response, schema);

--- a/src/router/artifact.cc
+++ b/src/router/artifact.cc
@@ -73,8 +73,7 @@ namespace sourcemeta::one {
 
 auto RouterAction::artifact_resolve_path(
     const std::string_view input, const Tree tree,
-    const std::string_view artifact_name) const
-    -> std::optional<std::filesystem::path> {
+    const std::string_view artifact_name) const -> ArtifactResolution {
   const std::string_view tree_segment{tree == Tree::Schemas ? "schemas"
                                                             : "explorer"};
   const auto tree_root{this->index_directory_ / tree_segment};
@@ -85,7 +84,8 @@ auto RouterAction::artifact_resolve_path(
       auto stripped{sourcemeta::core::URI::strip_path_prefix(
           input, this->server_uri_base_path_)};
       if (!stripped.has_value()) {
-        return std::nullopt;
+        return {.outcome = ArtifactResolution::Outcome::NotFound,
+                .path = std::nullopt};
       }
       resolved = std::filesystem::path{std::move(stripped).value()};
     }
@@ -97,28 +97,36 @@ auto RouterAction::artifact_resolve_path(
   directory /= std::string{artifact_name} + ".metapack";
   auto canonical{sourcemeta::core::weakly_canonical(directory)};
   if (!sourcemeta::core::is_under_path(canonical, tree_root)) {
-    return std::nullopt;
+    return {.outcome = ArtifactResolution::Outcome::NotFound,
+            .path = std::nullopt};
   }
   if (!std::filesystem::exists(canonical)) {
-    return std::nullopt;
+    return {.outcome = ArtifactResolution::Outcome::NotFound,
+            .path = std::nullopt};
   }
-  return canonical;
+  return {.outcome = ArtifactResolution::Outcome::Found,
+          .path = ResolvedArtifact{std::move(canonical)}};
 }
 
-auto RouterAction::artifact_read_json(
-    const std::filesystem::path &absolute_path) const
+auto RouterAction::authorize_static(std::filesystem::path absolute_path) const
+    -> ResolvedArtifact {
+  return ResolvedArtifact{std::move(absolute_path)};
+}
+
+auto RouterAction::artifact_read_json(const ResolvedArtifact &artifact) const
     -> std::optional<sourcemeta::core::JSON> {
-  return sourcemeta::one::metapack_read_json(absolute_path);
+  return sourcemeta::one::metapack_read_json(artifact.path());
 }
 
 auto RouterAction::artifact_serve(
-    const std::filesystem::path &absolute_path,
+    const ResolvedArtifact &artifact,
     const sourcemeta::core::HTTPStatus &status, const bool enable_cors,
     const std::string_view mime, const std::string_view link,
     const BrowserSecurityHeaders &browser_security, HTTPRequest &request,
     HTTPResponse &response, const std::string_view error_schema,
     const std::string_view cache_control, const std::string_view vary) const
     -> void {
+  const auto &absolute_path{artifact.path()};
   // Caller must pick the cache scope explicitly so no surface
   // silently inherits an inappropriate default. Cacheability is a
   // per-surface policy decision (RFC 9111 §5.2.2): static assets

--- a/src/router/artifact.cc
+++ b/src/router/artifact.cc
@@ -108,9 +108,16 @@ auto RouterAction::artifact_resolve_path(
           .path = ResolvedArtifact{std::move(canonical)}};
 }
 
-auto RouterAction::authorize_static(std::filesystem::path absolute_path) const
-    -> ResolvedArtifact {
-  return ResolvedArtifact{std::move(absolute_path)};
+auto RouterAction::artifact_resolve_static(
+    const std::filesystem::path &root, const std::string_view relative) const
+    -> ArtifactResolution {
+  auto canonical{sourcemeta::core::weakly_canonical(root / relative)};
+  if (!sourcemeta::core::is_under_path(canonical, root)) {
+    return {.outcome = ArtifactResolution::Outcome::NotFound,
+            .path = std::nullopt};
+  }
+  return {.outcome = ArtifactResolution::Outcome::Found,
+          .path = ResolvedArtifact{std::move(canonical)}};
 }
 
 auto RouterAction::artifact_read_json(const ResolvedArtifact &artifact) const

--- a/src/router/evaluate.cc
+++ b/src/router/evaluate.cc
@@ -12,11 +12,11 @@
 
 namespace sourcemeta::one {
 
-auto Router::blaze_template(const std::filesystem::path &absolute_path)
+auto Router::blaze_template(const ResolvedArtifact &artifact)
     -> std::shared_ptr<const sourcemeta::blaze::Template> {
-  return this->template_cache_.get_or_compute(absolute_path, [&absolute_path] {
+  return this->template_cache_.get_or_compute(artifact.path(), [&artifact] {
     const auto template_json{
-        sourcemeta::one::metapack_read_json(absolute_path)};
+        sourcemeta::one::metapack_read_json(artifact.path())};
     assert(template_json.has_value());
     auto compiled{sourcemeta::blaze::from_json(template_json.value())};
     assert(compiled.has_value());
@@ -27,12 +27,12 @@ auto Router::blaze_template(const std::filesystem::path &absolute_path)
 auto RouterAction::blaze_template(const std::string_view schema_uri,
                                   const sourcemeta::blaze::Mode mode) const
     -> std::shared_ptr<const sourcemeta::blaze::Template> {
-  const auto template_path{this->artifact_resolve_path(
+  const auto resolution{this->artifact_resolve_path(
       schema_uri, Tree::Schemas,
       mode == sourcemeta::blaze::Mode::FastValidation ? "blaze-fast"
                                                       : "blaze-exhaustive")};
-  assert(template_path.has_value());
-  return this->dispatcher_.blaze_template(template_path.value());
+  assert(resolution.outcome == ArtifactResolution::Outcome::Found);
+  return this->dispatcher_.blaze_template(resolution.path.value());
 }
 
 auto RouterAction::schema_evaluate_fast(

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -135,11 +135,15 @@ public:
       const sourcemeta::blaze::Callback &callback) const -> bool;
 
 protected:
-  // Escape hatch from resolution for paths that are not registry
-  // content. The only legitimate use is the compile-time static asset
-  // tree. Anything else must go through the resolver above
-  [[nodiscard]] auto authorize_static(std::filesystem::path absolute_path) const
-      -> ResolvedArtifact;
+  // Resolution for trees that are not registry content, such as the
+  // compile-time static asset bundle. Same containment discipline as
+  // registry resolution, against a caller-declared root, but access to
+  // these trees is governed at the route level, as their identity is a
+  // URL rather than a registry path. Existence is left to the serving
+  // layer, which orders its method check before the existence check
+  [[nodiscard]] auto artifact_resolve_static(const std::filesystem::path &root,
+                                             std::string_view relative) const
+      -> ArtifactResolution;
 
 private:
   [[nodiscard]] auto blaze_template(std::string_view schema_uri,

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -18,13 +18,38 @@
 #include <mutex>       // std::once_flag
 #include <optional>    // std::optional
 #include <span>        // std::span
-#include <string>      // std::string
 #include <string_view> // std::string_view
-#include <utility>     // std::pair
+#include <utility>     // std::move, std::pair
 
 namespace sourcemeta::one {
 
 class Router;
+class RouterAction;
+
+// Proof that a path was produced by the artifact resolver. Only the
+// action base class can mint one, so every artifact read must have
+// passed through resolution by construction
+class ResolvedArtifact {
+public:
+  [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
+    return this->path_;
+  }
+
+private:
+  friend class RouterAction;
+  explicit ResolvedArtifact(std::filesystem::path path)
+      : path_{std::move(path)} {}
+  std::filesystem::path path_;
+};
+
+// The three-outcome result of artifact resolution. Denial is distinct
+// from absence so surfaces can answer 401 versus 404. Nothing produces
+// Denied until authorisation lands in the resolver
+struct ArtifactResolution {
+  enum class Outcome : std::uint8_t { Found, NotFound, Denied };
+  Outcome outcome{Outcome::NotFound};
+  std::optional<ResolvedArtifact> path;
+};
 
 class RouterAction {
 public:
@@ -81,13 +106,12 @@ public:
 
   [[nodiscard]] auto artifact_resolve_path(std::string_view input, Tree tree,
                                            std::string_view artifact_name) const
-      -> std::optional<std::filesystem::path>;
+      -> ArtifactResolution;
 
-  [[nodiscard]] auto
-  artifact_read_json(const std::filesystem::path &absolute_path) const
+  [[nodiscard]] auto artifact_read_json(const ResolvedArtifact &artifact) const
       -> std::optional<sourcemeta::core::JSON>;
 
-  auto artifact_serve(const std::filesystem::path &absolute_path,
+  auto artifact_serve(const ResolvedArtifact &artifact,
                       const sourcemeta::core::HTTPStatus &status,
                       bool enable_cors, std::string_view mime,
                       std::string_view link,
@@ -109,6 +133,13 @@ public:
   [[nodiscard]] auto schema_evaluate_with_tracing(
       std::string_view schema_uri, const sourcemeta::core::JSON &instance,
       const sourcemeta::blaze::Callback &callback) const -> bool;
+
+protected:
+  // Escape hatch from resolution for paths that are not registry
+  // content. The only legitimate use is the compile-time static asset
+  // tree. Anything else must go through the resolver above
+  [[nodiscard]] auto authorize_static(std::filesystem::path absolute_path) const
+      -> ResolvedArtifact;
 
 private:
   [[nodiscard]] auto blaze_template(std::string_view schema_uri,
@@ -168,7 +199,7 @@ public:
              const sourcemeta::core::HTTPStatus &status, std::string_view type,
              std::string_view detail, std::string_view origin) const -> void;
 
-  [[nodiscard]] auto blaze_template(const std::filesystem::path &absolute_path)
+  [[nodiscard]] auto blaze_template(const ResolvedArtifact &artifact)
       -> std::shared_ptr<const sourcemeta::blaze::Template>;
 
 private:

--- a/src/self/v1/schemas/api/error.json
+++ b/src/self/v1/schemas/api/error.json
@@ -27,6 +27,14 @@
     },
     {
       "const": {
+        "type": "urn:sourcemeta:one:authentication-required",
+        "title": "Unauthorized",
+        "status": 401,
+        "detail": "This resource requires authentication"
+      }
+    },
+    {
+      "const": {
         "type": "urn:sourcemeta:one:method-not-allowed",
         "title": "Method Not Allowed",
         "status": 405,

--- a/src/self/v1/schemas/mcp/error.json
+++ b/src/self/v1/schemas/mcp/error.json
@@ -206,6 +206,12 @@
             "code": -32008,
             "message": "Content-Type must be application/json"
           }
+        },
+        {
+          "const": {
+            "code": -32010,
+            "message": "Authentication required"
+          }
         }
       ]
     }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

