### PR TITLE
Introduce an undocumented (for now) `authentication` config option

### DIFF
--- a/src/configuration/include/sourcemeta/one/configuration.h
+++ b/src/configuration/include/sourcemeta/one/configuration.h
@@ -15,6 +15,7 @@
 #include <unordered_map> // std::unordered_map
 #include <unordered_set> // std::unordered_set
 #include <variant>       // std::variant
+#include <vector>        // std::vector
 
 namespace sourcemeta::one {
 
@@ -52,6 +53,14 @@ struct Configuration {
 
   std::optional<HTML> html;
   bool api{true};
+
+  struct AuthenticationEntry {
+    enum class Type : std::uint8_t { Public };
+    Type type;
+    std::vector<sourcemeta::core::JSON::String> paths;
+  };
+
+  std::vector<AuthenticationEntry> authentication;
 
   struct Page {
     std::optional<sourcemeta::core::JSON::String> title;

--- a/src/configuration/parse.cc
+++ b/src/configuration/parse.cc
@@ -141,15 +141,17 @@ auto Configuration::parse(const sourcemeta::core::JSON &data,
     }
   }
 
-  for (const auto &entry : data.at("authentication").as_array()) {
-    Configuration::AuthenticationEntry parsed;
-    // The schema constrains the type to the values handled here
-    assert(entry.at("type").to_string() == "public");
-    parsed.type = Configuration::AuthenticationEntry::Type::Public;
-    for (const auto &path : entry.at("paths").as_array()) {
-      parsed.paths.push_back(path.to_string());
+  if (data.defines("authentication")) {
+    for (const auto &entry : data.at("authentication").as_array()) {
+      Configuration::AuthenticationEntry parsed;
+      // The schema constrains the type to the values handled here
+      assert(entry.at("type").to_string() == "public");
+      parsed.type = Configuration::AuthenticationEntry::Type::Public;
+      for (const auto &path : entry.at("paths").as_array()) {
+        parsed.paths.push_back(path.to_string());
+      }
+      result.authentication.push_back(std::move(parsed));
     }
-    result.authentication.push_back(std::move(parsed));
   }
 
   entries_from_json(result.entries, "", data, default_base_path);

--- a/src/configuration/parse.cc
+++ b/src/configuration/parse.cc
@@ -141,6 +141,17 @@ auto Configuration::parse(const sourcemeta::core::JSON &data,
     }
   }
 
+  for (const auto &entry : data.at("authentication").as_array()) {
+    Configuration::AuthenticationEntry parsed;
+    // The schema constrains the type to the values handled here
+    assert(entry.at("type").to_string() == "public");
+    parsed.type = Configuration::AuthenticationEntry::Type::Public;
+    for (const auto &path : entry.at("paths").as_array()) {
+      parsed.paths.push_back(path.to_string());
+    }
+    result.authentication.push_back(std::move(parsed));
+  }
+
   entries_from_json(result.entries, "", data, default_base_path);
 
   return result;

--- a/src/configuration/read.cc
+++ b/src/configuration/read.cc
@@ -196,17 +196,6 @@ auto Configuration::read(const std::filesystem::path &configuration_path,
         sourcemeta::core::JSON{"The next-generation JSON Schema platform"});
   }
 
-  if (data.is_object() && !data.defines("authentication")) {
-    auto entry{sourcemeta::core::JSON::make_object()};
-    entry.assign("type", sourcemeta::core::JSON{"public"});
-    auto paths{sourcemeta::core::JSON::make_array()};
-    paths.push_back(sourcemeta::core::JSON{"/"});
-    entry.assign("paths", std::move(paths));
-    auto authentication{sourcemeta::core::JSON::make_array()};
-    authentication.push_back(std::move(entry));
-    data.assign("authentication", std::move(authentication));
-  }
-
   if (data.is_object() && data.defines("api") && data.at("api").is_boolean() &&
       data.at("api").to_boolean()) {
     data.at("api").into_object();
@@ -241,6 +230,19 @@ auto Configuration::read(const std::filesystem::path &configuration_path,
   if (data.is_object() && data.defines("url") && data.defines("contents") &&
       data.at("contents").is_object()) {
     default_base_uri(data.at("contents"), data.at("url"));
+  }
+
+  // Applied after merging extensions so that an inherited authentication
+  // policy is not silently overridden by the public default
+  if (data.is_object() && !data.defines("authentication")) {
+    auto entry{sourcemeta::core::JSON::make_object()};
+    entry.assign("type", sourcemeta::core::JSON{"public"});
+    auto paths{sourcemeta::core::JSON::make_array()};
+    paths.push_back(sourcemeta::core::JSON{"/"});
+    entry.assign("paths", std::move(paths));
+    auto authentication{sourcemeta::core::JSON::make_array()};
+    authentication.push_back(std::move(entry));
+    data.assign("authentication", std::move(authentication));
   }
 
   return data;

--- a/src/configuration/read.cc
+++ b/src/configuration/read.cc
@@ -196,6 +196,17 @@ auto Configuration::read(const std::filesystem::path &configuration_path,
         sourcemeta::core::JSON{"The next-generation JSON Schema platform"});
   }
 
+  if (data.is_object() && !data.defines("authentication")) {
+    auto entry{sourcemeta::core::JSON::make_object()};
+    entry.assign("type", sourcemeta::core::JSON{"public"});
+    auto paths{sourcemeta::core::JSON::make_array()};
+    paths.push_back(sourcemeta::core::JSON{"/"});
+    entry.assign("paths", std::move(paths));
+    auto authentication{sourcemeta::core::JSON::make_array()};
+    authentication.push_back(std::move(entry));
+    data.assign("authentication", std::move(authentication));
+  }
+
   if (data.is_object() && data.defines("api") && data.at("api").is_boolean() &&
       data.at("api").to_boolean()) {
     data.at("api").into_object();

--- a/src/configuration/schema/configuration.json
+++ b/src/configuration/schema/configuration.json
@@ -67,6 +67,7 @@
     },
     "authentication": {
       "type": "array",
+      "maxItems": 64,
       "minItems": 1,
       "uniqueItems": true,
       "items": {

--- a/src/configuration/schema/configuration.json
+++ b/src/configuration/schema/configuration.json
@@ -64,6 +64,35 @@
       "x-format-assertion": true,
       "type": "string",
       "format": "uri"
+    },
+    "authentication": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "required": [ "type", "paths" ],
+            "properties": {
+              "type": {
+                "const": "public"
+              },
+              "paths": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "type": "string",
+                  "pattern": "^/",
+                  "minLength": 1
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
     }
   },
   "additionalProperties": false,

--- a/test/cli/index/common/fail-page-level-extends.sh
+++ b/test/cli/index/common/fail-page-level-extends.sh
@@ -55,7 +55,7 @@ The object properties not covered by other adjacent object keywords were expecte
 The object value was expected to validate against the referenced schema
   at instance location "/contents"
   at evaluate path "/properties/contents/\$ref"
-The object value was expected to validate against the 5 defined properties subschemas
+The object value was expected to validate against the 6 defined properties subschemas
   at instance location ""
   at evaluate path "/properties"
 EOF

--- a/test/cli/index/common/output-configuration-long.sh
+++ b/test/cli/index/common/output-configuration-long.sh
@@ -70,6 +70,12 @@ cat << EOF > "$TMP/expected.txt"
     "name": "Sourcemeta",
     "description": "The next-generation JSON Schema platform"
   },
+  "authentication": [
+    {
+      "type": "public",
+      "paths": [ "/" ]
+    }
+  ],
   "api": {}
 }
 EOF

--- a/test/cli/index/common/output-configuration-long.sh
+++ b/test/cli/index/common/output-configuration-long.sh
@@ -70,13 +70,13 @@ cat << EOF > "$TMP/expected.txt"
     "name": "Sourcemeta",
     "description": "The next-generation JSON Schema platform"
   },
+  "api": {},
   "authentication": [
     {
       "type": "public",
       "paths": [ "/" ]
     }
-  ],
-  "api": {}
+  ]
 }
 EOF
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/cli/index/common/output-configuration-short.sh
+++ b/test/cli/index/common/output-configuration-short.sh
@@ -70,6 +70,12 @@ cat << EOF > "$TMP/expected.txt"
     "name": "Sourcemeta",
     "description": "The next-generation JSON Schema platform"
   },
+  "authentication": [
+    {
+      "type": "public",
+      "paths": [ "/" ]
+    }
+  ],
   "api": {}
 }
 EOF

--- a/test/cli/index/common/output-configuration-short.sh
+++ b/test/cli/index/common/output-configuration-short.sh
@@ -70,13 +70,13 @@ cat << EOF > "$TMP/expected.txt"
     "name": "Sourcemeta",
     "description": "The next-generation JSON Schema platform"
   },
+  "api": {},
   "authentication": [
     {
       "type": "public",
       "paths": [ "/" ]
     }
-  ],
-  "api": {}
+  ]
 }
 EOF
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/unit/configuration/configuration_read_test.cc
+++ b/test/unit/configuration/configuration_read_test.cc
@@ -22,6 +22,7 @@ TEST(Configuration_read, read_valid_001) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -89,6 +90,7 @@ TEST(Configuration_read, read_valid_002) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -143,6 +145,7 @@ TEST(Configuration_read, read_valid_003) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -196,6 +199,7 @@ TEST(Configuration_read, read_valid_004) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -252,6 +256,7 @@ TEST(Configuration_read, read_valid_005) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -308,6 +313,7 @@ TEST(Configuration_read, read_valid_006) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -356,6 +362,7 @@ TEST(Configuration_read, read_valid_007) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": false,
@@ -400,6 +407,7 @@ TEST(Configuration_read, read_valid_008) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -447,6 +455,7 @@ TEST(Configuration_read, read_valid_009) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -494,6 +503,7 @@ TEST(Configuration_read, read_valid_010) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": false,
@@ -538,6 +548,7 @@ TEST(Configuration_read, read_valid_011) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "contents": {
       "self": {
         "title": "Self",
@@ -579,6 +590,7 @@ TEST(Configuration_read, read_valid_012) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -632,6 +644,7 @@ TEST(Configuration_read, read_valid_013) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -689,6 +702,7 @@ TEST(Configuration_read, read_valid_014) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -902,6 +916,7 @@ TEST(Configuration_read, read_valid_016_api_explicit_object) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {
@@ -943,6 +958,7 @@ TEST(Configuration_read, read_valid_017_api_false_html_false) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": false,
     "html": false
@@ -959,6 +975,7 @@ TEST(Configuration_read, read_valid_018_api_true_coerced_to_object) {
       sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
 
   std::string text{R"JSON({
+    "authentication": [ { "type": "public", "paths": [ "/" ] } ],
     "url": "http://localhost:8000",
     "api": {},
     "html": {

--- a/test/unit/configuration/configuration_test.cc
+++ b/test/unit/configuration/configuration_test.cc
@@ -794,3 +794,43 @@ TEST(Configuration, authentication_rejects_unknown_type) {
       sourcemeta::one::Configuration::parse(raw_configuration, "one.json", "."),
       sourcemeta::one::ConfigurationValidationError);
 }
+
+TEST(Configuration, authentication_accepts_maximum_entries) {
+  auto raw_configuration{sourcemeta::core::JSON::make_object()};
+  raw_configuration.assign("url",
+                           sourcemeta::core::JSON{"https://example.com"});
+  auto entries{sourcemeta::core::JSON::make_array()};
+  for (std::size_t index = 0; index < 64; ++index) {
+    auto entry{sourcemeta::core::JSON::make_object()};
+    entry.assign("type", sourcemeta::core::JSON{"public"});
+    auto paths{sourcemeta::core::JSON::make_array()};
+    paths.push_back(sourcemeta::core::JSON{"/p" + std::to_string(index)});
+    entry.assign("paths", std::move(paths));
+    entries.push_back(std::move(entry));
+  }
+  raw_configuration.assign("authentication", std::move(entries));
+
+  const auto configuration{sourcemeta::one::Configuration::parse(
+      raw_configuration, "one.json", ".")};
+  EXPECT_EQ(configuration.authentication.size(), 64);
+}
+
+TEST(Configuration, authentication_rejects_above_maximum_entries) {
+  auto raw_configuration{sourcemeta::core::JSON::make_object()};
+  raw_configuration.assign("url",
+                           sourcemeta::core::JSON{"https://example.com"});
+  auto entries{sourcemeta::core::JSON::make_array()};
+  for (std::size_t index = 0; index < 65; ++index) {
+    auto entry{sourcemeta::core::JSON::make_object()};
+    entry.assign("type", sourcemeta::core::JSON{"public"});
+    auto paths{sourcemeta::core::JSON::make_array()};
+    paths.push_back(sourcemeta::core::JSON{"/p" + std::to_string(index)});
+    entry.assign("paths", std::move(paths));
+    entries.push_back(std::move(entry));
+  }
+  raw_configuration.assign("authentication", std::move(entries));
+
+  EXPECT_THROW(
+      sourcemeta::one::Configuration::parse(raw_configuration, "one.json", "."),
+      sourcemeta::one::ConfigurationValidationError);
+}

--- a/test/unit/configuration/configuration_test.cc
+++ b/test/unit/configuration/configuration_test.cc
@@ -712,6 +712,21 @@ TEST(Configuration, authentication_defaults_to_public_root) {
             (std::vector<sourcemeta::core::JSON::String>{"/"}));
 }
 
+TEST(Configuration, authentication_inherited_from_extends) {
+  const auto configuration_path{std::filesystem::path{STUB_DIRECTORY} /
+                                "parse_valid_authentication_extends.json"};
+  const auto raw_configuration{
+      sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
+  const auto configuration{sourcemeta::one::Configuration::parse(
+      raw_configuration, configuration_path, configuration_path.parent_path())};
+
+  EXPECT_EQ(configuration.authentication.size(), 1);
+  EXPECT_EQ(configuration.authentication.at(0).type,
+            sourcemeta::one::Configuration::AuthenticationEntry::Type::Public);
+  EXPECT_EQ(configuration.authentication.at(0).paths,
+            (std::vector<sourcemeta::core::JSON::String>{"/internal"}));
+}
+
 TEST(Configuration, authentication_explicit_paths) {
   const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
     "url": "https://example.com",

--- a/test/unit/configuration/configuration_test.cc
+++ b/test/unit/configuration/configuration_test.cc
@@ -696,3 +696,101 @@ TEST(Configuration, priority_helper_defaults_when_missing_or_wrong_type) {
                           sourcemeta::core::JSON{"high"});
   EXPECT_EQ(sourcemeta::one::Configuration::priority(collection), 50);
 }
+
+TEST(Configuration, authentication_defaults_to_public_root) {
+  const auto configuration_path{std::filesystem::path{STUB_DIRECTORY} /
+                                "parse_valid_001.json"};
+  const auto raw_configuration{
+      sourcemeta::one::Configuration::read(configuration_path, SELF_DIRECTORY)};
+  const auto configuration{sourcemeta::one::Configuration::parse(
+      raw_configuration, configuration_path, configuration_path.parent_path())};
+
+  EXPECT_EQ(configuration.authentication.size(), 1);
+  EXPECT_EQ(configuration.authentication.at(0).type,
+            sourcemeta::one::Configuration::AuthenticationEntry::Type::Public);
+  EXPECT_EQ(configuration.authentication.at(0).paths,
+            (std::vector<sourcemeta::core::JSON::String>{"/"}));
+}
+
+TEST(Configuration, authentication_explicit_paths) {
+  const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
+    "url": "https://example.com",
+    "authentication": [
+      { "type": "public", "paths": [ "/internal", "/vendor" ] }
+    ]
+  })JSON")};
+  const auto configuration{sourcemeta::one::Configuration::parse(
+      raw_configuration, "one.json", ".")};
+
+  EXPECT_EQ(configuration.authentication.size(), 1);
+  EXPECT_EQ(configuration.authentication.at(0).type,
+            sourcemeta::one::Configuration::AuthenticationEntry::Type::Public);
+  EXPECT_EQ(
+      configuration.authentication.at(0).paths,
+      (std::vector<sourcemeta::core::JSON::String>{"/internal", "/vendor"}));
+}
+
+TEST(Configuration, authentication_rejects_empty_array) {
+  const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
+    "url": "https://example.com",
+    "authentication": []
+  })JSON")};
+  EXPECT_THROW(
+      sourcemeta::one::Configuration::parse(raw_configuration, "one.json", "."),
+      sourcemeta::one::ConfigurationValidationError);
+}
+
+TEST(Configuration, authentication_rejects_duplicate_entries) {
+  const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
+    "url": "https://example.com",
+    "authentication": [
+      { "type": "public", "paths": [ "/" ] },
+      { "type": "public", "paths": [ "/" ] }
+    ]
+  })JSON")};
+  EXPECT_THROW(
+      sourcemeta::one::Configuration::parse(raw_configuration, "one.json", "."),
+      sourcemeta::one::ConfigurationValidationError);
+}
+
+TEST(Configuration, authentication_rejects_missing_paths) {
+  const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
+    "url": "https://example.com",
+    "authentication": [ { "type": "public" } ]
+  })JSON")};
+  EXPECT_THROW(
+      sourcemeta::one::Configuration::parse(raw_configuration, "one.json", "."),
+      sourcemeta::one::ConfigurationValidationError);
+}
+
+TEST(Configuration, authentication_rejects_empty_path) {
+  const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
+    "url": "https://example.com",
+    "authentication": [ { "type": "public", "paths": [ "" ] } ]
+  })JSON")};
+  EXPECT_THROW(
+      sourcemeta::one::Configuration::parse(raw_configuration, "one.json", "."),
+      sourcemeta::one::ConfigurationValidationError);
+}
+
+TEST(Configuration, authentication_rejects_path_without_leading_slash) {
+  const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
+    "url": "https://example.com",
+    "authentication": [ { "type": "public", "paths": [ "acme" ] } ]
+  })JSON")};
+  EXPECT_THROW(
+      sourcemeta::one::Configuration::parse(raw_configuration, "one.json", "."),
+      sourcemeta::one::ConfigurationValidationError);
+}
+
+TEST(Configuration, authentication_rejects_unknown_type) {
+  const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
+    "url": "https://example.com",
+    "authentication": [
+      { "type": "apiKey", "paths": [ "/" ] }
+    ]
+  })JSON")};
+  EXPECT_THROW(
+      sourcemeta::one::Configuration::parse(raw_configuration, "one.json", "."),
+      sourcemeta::one::ConfigurationValidationError);
+}

--- a/test/unit/configuration/stub/parse_valid_authentication_extends.json
+++ b/test/unit/configuration/stub/parse_valid_authentication_extends.json
@@ -1,0 +1,4 @@
+{
+  "url": "http://localhost:8000",
+  "extends": [ "./parse_valid_authentication_extends_base.json" ]
+}

--- a/test/unit/configuration/stub/parse_valid_authentication_extends_base.json
+++ b/test/unit/configuration/stub/parse_valid_authentication_extends_base.json
@@ -1,0 +1,5 @@
+{
+  "authentication": [
+    { "type": "public", "paths": [ "/internal" ] }
+  ]
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

