### PR TITLE
Implement the `authentication.bin` trie `mmap` format

### DIFF
--- a/src/actions/action_schema_search_v1.h
+++ b/src/actions/action_schema_search_v1.h
@@ -179,8 +179,7 @@ public:
     auto result{this->search_view_.search(
         query, limit, scope, [this, &credential](const std::string_view path) {
           const auto &authentication{this->dispatcher().authentication()};
-          return authentication.admits(authentication.match(path), credential)
-              .allowed;
+          return authentication.admits(path, credential).allowed;
         })};
     response.write_status(sourcemeta::core::HTTP_STATUS_OK);
     response.write_header("Access-Control-Allow-Origin", "*");
@@ -280,8 +279,7 @@ public:
         arguments.at("q").to_string(), limit, scope,
         [this, &credential](const std::string_view path) {
           const auto &authentication{this->dispatcher().authentication()};
-          return authentication.admits(authentication.match(path), credential)
-              .allowed;
+          return authentication.admits(path, credential).allowed;
         })};
     auto envelope{sourcemeta::core::JSON::make_object()};
     envelope.assign_assume_new("results", std::move(results));

--- a/src/authentication/CMakeLists.txt
+++ b/src/authentication/CMakeLists.txt
@@ -1,4 +1,4 @@
 sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME authentication
   SOURCES authentication.cc authentication_save.cc)
 
-target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::io)
+target_link_libraries(sourcemeta_one_authentication PUBLIC sourcemeta::core::io)

--- a/src/authentication/CMakeLists.txt
+++ b/src/authentication/CMakeLists.txt
@@ -1,2 +1,4 @@
 sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME authentication
-  SOURCES authentication.cc)
+  SOURCES authentication.cc authentication_save.cc)
+
+target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::io)

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -83,7 +83,7 @@ auto Authentication::match(const std::string_view registry_path) const noexcept
   return result;
 }
 
-auto Authentication::admits(const Authentication::PolicySet policies,
+auto Authentication::admits(const std::string_view registry_path,
                             const std::string_view) const noexcept
     -> Authentication::Verdict {
   // An unconfigured instance admits everyone. Once configured, a path is
@@ -93,7 +93,7 @@ auto Authentication::admits(const Authentication::PolicySet policies,
     return {.allowed = true, .key_name = {}};
   }
 
-  return {.allowed = policies != 0, .key_name = {}};
+  return {.allowed = this->match(registry_path) != 0, .key_name = {}};
 }
 
 } // namespace sourcemeta::one

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -1,18 +1,99 @@
 #include <sourcemeta/one/authentication.h>
 
+#include <sourcemeta/core/io.h>
+
+#include "authentication_format.h"
+
+#include <cstddef>   // std::size_t
+#include <cstdint>   // std::uint32_t
+#include <stdexcept> // std::runtime_error
+#include <utility>   // std::move
+
 namespace sourcemeta::one {
 
-Authentication::Authentication(const std::filesystem::path &) {}
+Authentication::Authentication(const std::filesystem::path &path) {
+  // A missing artifact is the only unconfigured case, where the instance
+  // admits everyone. An artifact that exists but cannot be mapped or
+  // validated is a fatal misconfiguration: failing open would silently
+  // expose every path that the policy was meant to restrict
+  if (!std::filesystem::exists(path)) {
+    return;
+  }
 
-auto Authentication::match(const std::string_view) const noexcept
-    -> Authentication::PolicySet {
-  return 0;
+  auto view{std::make_unique<sourcemeta::core::FileView>(path)};
+  if (view->size() < sizeof(AuthenticationHeader)) {
+    throw std::runtime_error("The authentication policy artifact is malformed");
+  }
+
+  const auto *header{view->as<AuthenticationHeader>()};
+  if (header->magic != AUTHENTICATION_MAGIC ||
+      header->version != AUTHENTICATION_VERSION) {
+    throw std::runtime_error("The authentication policy artifact is malformed");
+  }
+
+  this->view_ = std::move(view);
 }
 
-auto Authentication::admits(const Authentication::PolicySet,
+Authentication::~Authentication() = default;
+
+auto Authentication::match(const std::string_view registry_path) const noexcept
+    -> Authentication::PolicySet {
+  if (!this->view_) {
+    return 0;
+  }
+
+  const auto *header{this->view_->as<AuthenticationHeader>()};
+  const auto *nodes{this->view_->as<AuthenticationNode>(header->nodes_offset)};
+
+  // The edge and string sections are empty when no policy declares a nested
+  // prefix, in which case they sit at the end of the buffer and must not be
+  // addressed
+  const AuthenticationEdge *edges{nullptr};
+  const char *strings{nullptr};
+  if (header->edge_count > 0) {
+    edges = this->view_->as<AuthenticationEdge>(header->edges_offset);
+    strings = this->view_->as<char>(header->strings_offset);
+  }
+
+  Authentication::PolicySet result{nodes[0].mask};
+  std::uint32_t current{0};
+  std::size_t cursor{0};
+  for (auto segment{authentication_next_segment(registry_path, cursor)};
+       !segment.empty();
+       segment = authentication_next_segment(registry_path, cursor)) {
+    const auto &node{nodes[current]};
+    bool descended{false};
+    for (std::uint32_t index{0}; index < node.edge_count; index += 1) {
+      const auto &edge{edges[node.first_edge + index]};
+      const std::string_view value{strings + edge.segment_offset,
+                                   edge.segment_length};
+      if (value == segment) {
+        current = edge.child;
+        result |= nodes[current].mask;
+        descended = true;
+        break;
+      }
+    }
+
+    if (!descended) {
+      break;
+    }
+  }
+
+  return result;
+}
+
+auto Authentication::admits(const Authentication::PolicySet policies,
                             const std::string_view) const noexcept
     -> Authentication::Verdict {
-  return {.allowed = true, .key_name = {}};
+  // An unconfigured instance admits everyone. Once configured, a path is
+  // served only when at least one policy governs it, as every policy grants
+  // anonymous public access for now
+  if (!this->view_) {
+    return {.allowed = true, .key_name = {}};
+  }
+
+  return {.allowed = policies != 0, .key_name = {}};
 }
 
 } // namespace sourcemeta::one

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -9,6 +9,81 @@
 #include <stdexcept> // std::runtime_error
 #include <utility>   // std::move
 
+namespace {
+
+// The artifact is produced by a trusted indexer, but on-disk truncation or
+// corruption could leave a header whose magic and version still match while
+// its offsets and counts point out of bounds. Validating the whole layout
+// once here keeps the matching hot path free of any per-call bounds checks
+auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
+    -> bool {
+  using namespace sourcemeta::one;
+  const auto size{view.size()};
+  if (size < sizeof(AuthenticationHeader)) {
+    return false;
+  }
+
+  const auto *header{view.as<AuthenticationHeader>()};
+  if (header->magic != AUTHENTICATION_MAGIC ||
+      header->version != AUTHENTICATION_VERSION || header->node_count == 0) {
+    return false;
+  }
+
+  if (header->nodes_offset % alignof(AuthenticationNode) != 0) {
+    return false;
+  }
+
+  const auto nodes_bytes{static_cast<std::size_t>(header->node_count) *
+                         sizeof(AuthenticationNode)};
+  if (header->nodes_offset > size ||
+      nodes_bytes > size - header->nodes_offset) {
+    return false;
+  }
+
+  std::size_t strings_length{0};
+  if (header->edge_count > 0) {
+    if (header->edges_offset % alignof(AuthenticationEdge) != 0) {
+      return false;
+    }
+
+    const auto edges_bytes{static_cast<std::size_t>(header->edge_count) *
+                           sizeof(AuthenticationEdge)};
+    if (header->edges_offset > size ||
+        edges_bytes > size - header->edges_offset ||
+        header->strings_offset > size ||
+        header->strings_length > size - header->strings_offset) {
+      return false;
+    }
+
+    strings_length = header->strings_length;
+  }
+
+  const auto *nodes{view.as<AuthenticationNode>(header->nodes_offset)};
+  for (std::uint32_t index{0}; index < header->node_count; index += 1) {
+    const auto &node{nodes[index]};
+    if (node.edge_count > header->edge_count ||
+        node.first_edge > header->edge_count - node.edge_count) {
+      return false;
+    }
+  }
+
+  if (header->edge_count > 0) {
+    const auto *edges{view.as<AuthenticationEdge>(header->edges_offset)};
+    for (std::uint32_t index{0}; index < header->edge_count; index += 1) {
+      const auto &edge{edges[index]};
+      if (edge.child >= header->node_count ||
+          edge.segment_offset > strings_length ||
+          edge.segment_length > strings_length - edge.segment_offset) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+} // namespace
+
 namespace sourcemeta::one {
 
 Authentication::Authentication(const std::filesystem::path &path) {
@@ -21,16 +96,11 @@ Authentication::Authentication(const std::filesystem::path &path) {
   }
 
   auto view{std::make_unique<sourcemeta::core::FileView>(path)};
-  if (view->size() < sizeof(AuthenticationHeader)) {
+  if (!structurally_valid(*view)) {
     throw std::runtime_error("The authentication policy artifact is malformed");
   }
 
   const auto *header{view->as<AuthenticationHeader>()};
-  if (header->magic != AUTHENTICATION_MAGIC ||
-      header->version != AUTHENTICATION_VERSION) {
-    throw std::runtime_error("The authentication policy artifact is malformed");
-  }
-
   this->nodes_ = view->as<AuthenticationNode>(header->nodes_offset);
   // The edge and string sections are empty when no policy declares a nested
   // prefix, in which case they sit at the end of the buffer and must not be

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -31,6 +31,15 @@ Authentication::Authentication(const std::filesystem::path &path) {
     throw std::runtime_error("The authentication policy artifact is malformed");
   }
 
+  this->nodes_ = view->as<AuthenticationNode>(header->nodes_offset);
+  // The edge and string sections are empty when no policy declares a nested
+  // prefix, in which case they sit at the end of the buffer and must not be
+  // addressed
+  if (header->edge_count > 0) {
+    this->edges_ = view->as<AuthenticationEdge>(header->edges_offset);
+    this->strings_ = view->as<char>(header->strings_offset);
+  }
+
   this->view_ = std::move(view);
 }
 
@@ -38,22 +47,12 @@ Authentication::~Authentication() = default;
 
 auto Authentication::match(const std::string_view registry_path) const noexcept
     -> Authentication::PolicySet {
-  if (!this->view_) {
+  if (this->nodes_ == nullptr) {
     return 0;
   }
 
-  const auto *header{this->view_->as<AuthenticationHeader>()};
-  const auto *nodes{this->view_->as<AuthenticationNode>(header->nodes_offset)};
-
-  // The edge and string sections are empty when no policy declares a nested
-  // prefix, in which case they sit at the end of the buffer and must not be
-  // addressed
-  const AuthenticationEdge *edges{nullptr};
-  const char *strings{nullptr};
-  if (header->edge_count > 0) {
-    edges = this->view_->as<AuthenticationEdge>(header->edges_offset);
-    strings = this->view_->as<char>(header->strings_offset);
-  }
+  const auto *nodes{static_cast<const AuthenticationNode *>(this->nodes_)};
+  const auto *edges{static_cast<const AuthenticationEdge *>(this->edges_)};
 
   Authentication::PolicySet result{nodes[0].mask};
   std::uint32_t current{0};
@@ -62,16 +61,27 @@ auto Authentication::match(const std::string_view registry_path) const noexcept
        !segment.empty();
        segment = authentication_next_segment(registry_path, cursor)) {
     const auto &node{nodes[current]};
+
+    // A node's edges are serialized contiguously and sorted by segment, so
+    // the matching child is found with a binary search
+    std::uint32_t low{node.first_edge};
+    std::uint32_t high{node.first_edge + node.edge_count};
     bool descended{false};
-    for (std::uint32_t index{0}; index < node.edge_count; index += 1) {
-      const auto &edge{edges[node.first_edge + index]};
-      const std::string_view value{strings + edge.segment_offset,
+    while (low < high) {
+      const auto middle{low + ((high - low) / 2)};
+      const auto &edge{edges[middle]};
+      const std::string_view value{this->strings_ + edge.segment_offset,
                                    edge.segment_length};
-      if (value == segment) {
+      const auto comparison{value.compare(segment)};
+      if (comparison == 0) {
         current = edge.child;
         result |= nodes[current].mask;
         descended = true;
         break;
+      } else if (comparison < 0) {
+        low = middle + 1;
+      } else {
+        high = middle;
       }
     }
 
@@ -89,7 +99,7 @@ auto Authentication::admits(const std::string_view registry_path,
   // An unconfigured instance admits everyone. Once configured, a path is
   // served only when at least one policy governs it, as every policy grants
   // anonymous public access for now
-  if (!this->view_) {
+  if (this->nodes_ == nullptr) {
     return {.allowed = true, .key_name = {}};
   }
 

--- a/src/authentication/authentication_format.h
+++ b/src/authentication/authentication_format.h
@@ -1,0 +1,77 @@
+#ifndef SOURCEMETA_ONE_AUTHENTICATION_FORMAT_H_
+#define SOURCEMETA_ONE_AUTHENTICATION_FORMAT_H_
+
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint32_t, std::uint64_t, std::uint8_t
+#include <string_view> // std::string_view
+
+namespace sourcemeta::one {
+
+constexpr std::uint32_t AUTHENTICATION_MAGIC{0x48545541};
+constexpr std::uint32_t AUTHENTICATION_VERSION{1};
+
+// The artifact begins with this header. Every variable-length section is
+// located through an absolute byte offset so the matcher can address it
+// directly in the memory-mapped buffer
+struct AuthenticationHeader {
+  std::uint32_t magic;
+  std::uint32_t version;
+  std::uint32_t policy_count;
+  std::uint32_t node_count;
+  std::uint32_t edge_count;
+  std::uint32_t policies_offset;
+  std::uint32_t nodes_offset;
+  std::uint32_t edges_offset;
+  std::uint32_t strings_offset;
+  std::uint32_t strings_length;
+};
+
+// A node in the prefix trie. The mask holds the policies whose path prefix
+// terminates exactly at this node, so matching accumulates the masks of
+// every node visited from the root to the deepest matching prefix
+struct alignas(8) AuthenticationNode {
+  std::uint64_t mask;
+  std::uint32_t first_edge;
+  std::uint32_t edge_count;
+};
+
+// An edge from a node to one of its children, labelled by a path segment
+// stored in the string blob
+struct AuthenticationEdge {
+  std::uint32_t segment_offset;
+  std::uint32_t segment_length;
+  std::uint32_t child;
+};
+
+// One entry per policy, in declaration order, mirroring the bit assigned to
+// it in the node masks
+struct AuthenticationPolicyEntry {
+  std::uint8_t type;
+};
+
+// Advance the cursor to the next non-empty path segment and return it. The
+// returned view is empty once the path is exhausted. Leading, trailing, and
+// repeated slashes are ignored, so "/a/b", "a/b", and "a/b/" all yield the
+// segments "a" then "b"
+inline auto authentication_next_segment(const std::string_view path,
+                                        std::size_t &cursor) noexcept
+    -> std::string_view {
+  while (cursor < path.size() && path[cursor] == '/') {
+    cursor += 1;
+  }
+
+  if (cursor >= path.size()) {
+    return {};
+  }
+
+  const auto start{cursor};
+  while (cursor < path.size() && path[cursor] != '/') {
+    cursor += 1;
+  }
+
+  return {path.data() + start, cursor - start};
+}
+
+} // namespace sourcemeta::one
+
+#endif

--- a/src/authentication/authentication_format.h
+++ b/src/authentication/authentication_format.h
@@ -49,6 +49,14 @@ struct AuthenticationPolicyEntry {
   std::uint8_t type;
 };
 
+// The structures are cast directly out of the memory-mapped buffer, so their
+// layout must stay fixed across edits and compilers
+static_assert(sizeof(AuthenticationHeader) == 40);
+static_assert(sizeof(AuthenticationNode) == 16);
+static_assert(alignof(AuthenticationNode) == 8);
+static_assert(sizeof(AuthenticationEdge) == 12);
+static_assert(sizeof(AuthenticationPolicyEntry) == 1);
+
 // Advance the cursor to the next non-empty path segment and return it. The
 // returned view is empty once the path is exhausted. Leading, trailing, and
 // repeated slashes are ignored, so "/a/b", "a/b", and "a/b/" all yield the

--- a/src/authentication/authentication_save.cc
+++ b/src/authentication/authentication_save.cc
@@ -5,11 +5,11 @@
 #include "authentication_format.h"
 
 #include <algorithm> // std::ranges::sort
-#include <cassert>   // assert
 #include <cstddef>   // std::byte, std::size_t
 #include <cstdint>   // std::uint32_t, std::uint64_t, std::uint8_t
 #include <cstring>   // std::memcpy
 #include <span>      // std::span
+#include <stdexcept> // std::runtime_error
 #include <string>    // std::string
 #include <utility>   // std::pair
 #include <vector>    // std::vector
@@ -46,7 +46,11 @@ namespace sourcemeta::one {
 
 auto Authentication::save(std::span<const Authentication::Policy> policies,
                           const std::filesystem::path &path) -> void {
-  assert(policies.size() <= Authentication::MAXIMUM_POLICIES);
+  // Each policy occupies one bit of the node masks, so exceeding the ceiling
+  // would shift past the width of a PolicySet
+  if (policies.size() > Authentication::MAXIMUM_POLICIES) {
+    throw std::runtime_error("Too many authentication policies");
+  }
 
   std::vector<BuildNode> nodes;
   nodes.emplace_back();
@@ -127,10 +131,17 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
 
   std::memcpy(buffer.data() + header.nodes_offset, serialized.data(),
               serialized.size() * sizeof(AuthenticationNode));
-  std::memcpy(buffer.data() + header.edges_offset, edges.data(),
-              edges.size() * sizeof(AuthenticationEdge));
-  std::memcpy(buffer.data() + header.strings_offset, strings.data(),
-              strings.size());
+  // The edge and string sections are empty when no policy declares a nested
+  // prefix, and an empty vector may expose a null data pointer
+  if (!edges.empty()) {
+    std::memcpy(buffer.data() + header.edges_offset, edges.data(),
+                edges.size() * sizeof(AuthenticationEdge));
+  }
+
+  if (!strings.empty()) {
+    std::memcpy(buffer.data() + header.strings_offset, strings.data(),
+                strings.size());
+  }
 
   sourcemeta::core::write_file(path, buffer);
 }

--- a/src/authentication/authentication_save.cc
+++ b/src/authentication/authentication_save.cc
@@ -4,14 +4,15 @@
 
 #include "authentication_format.h"
 
-#include <cassert> // assert
-#include <cstddef> // std::byte, std::size_t
-#include <cstdint> // std::uint32_t, std::uint64_t, std::uint8_t
-#include <cstring> // std::memcpy
-#include <span>    // std::span
-#include <string>  // std::string
-#include <utility> // std::pair
-#include <vector>  // std::vector
+#include <algorithm> // std::ranges::sort
+#include <cassert>   // assert
+#include <cstddef>   // std::byte, std::size_t
+#include <cstdint>   // std::uint32_t, std::uint64_t, std::uint8_t
+#include <cstring>   // std::memcpy
+#include <span>      // std::span
+#include <string>    // std::string
+#include <utility>   // std::pair
+#include <vector>    // std::vector
 
 namespace {
 
@@ -63,6 +64,12 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
 
       nodes[current].mask |= bit;
     }
+  }
+
+  // Sort each node's edges by segment so the matcher can binary search them
+  for (auto &node : nodes) {
+    std::ranges::sort(node.edges, {},
+                      &std::pair<std::string, std::uint32_t>::first);
   }
 
   std::string strings;

--- a/src/authentication/authentication_save.cc
+++ b/src/authentication/authentication_save.cc
@@ -1,0 +1,131 @@
+#include <sourcemeta/one/authentication.h>
+
+#include <sourcemeta/core/io.h>
+
+#include "authentication_format.h"
+
+#include <cassert> // assert
+#include <cstddef> // std::byte, std::size_t
+#include <cstdint> // std::uint32_t, std::uint64_t, std::uint8_t
+#include <cstring> // std::memcpy
+#include <span>    // std::span
+#include <string>  // std::string
+#include <utility> // std::pair
+#include <vector>  // std::vector
+
+namespace {
+
+struct BuildNode {
+  std::uint64_t mask{0};
+  std::vector<std::pair<std::string, std::uint32_t>> edges;
+};
+
+auto find_or_create_child(std::vector<BuildNode> &nodes,
+                          const std::uint32_t parent,
+                          const std::string_view segment) -> std::uint32_t {
+  for (const auto &edge : nodes[parent].edges) {
+    if (edge.first == segment) {
+      return edge.second;
+    }
+  }
+
+  const auto child{static_cast<std::uint32_t>(nodes.size())};
+  nodes.emplace_back();
+  nodes[parent].edges.emplace_back(std::string{segment}, child);
+  return child;
+}
+
+auto align_to_word(const std::uint32_t offset) -> std::uint32_t {
+  return (offset + 7U) & ~static_cast<std::uint32_t>(7U);
+}
+
+} // namespace
+
+namespace sourcemeta::one {
+
+auto Authentication::save(std::span<const Authentication::Policy> policies,
+                          const std::filesystem::path &path) -> void {
+  assert(policies.size() <= Authentication::MAXIMUM_POLICIES);
+
+  std::vector<BuildNode> nodes;
+  nodes.emplace_back();
+
+  for (std::size_t index{0}; index < policies.size(); index += 1) {
+    const auto bit{static_cast<std::uint64_t>(1) << index};
+    for (const auto &policy_path : policies[index].paths) {
+      std::uint32_t current{0};
+      std::size_t cursor{0};
+      for (auto segment{authentication_next_segment(policy_path, cursor)};
+           !segment.empty();
+           segment = authentication_next_segment(policy_path, cursor)) {
+        current = find_or_create_child(nodes, current, segment);
+      }
+
+      nodes[current].mask |= bit;
+    }
+  }
+
+  std::string strings;
+  std::vector<AuthenticationEdge> edges;
+  std::vector<AuthenticationNode> serialized;
+  serialized.reserve(nodes.size());
+  for (const auto &node : nodes) {
+    AuthenticationNode entry{};
+    entry.mask = node.mask;
+    entry.first_edge = static_cast<std::uint32_t>(edges.size());
+    entry.edge_count = static_cast<std::uint32_t>(node.edges.size());
+    for (const auto &edge : node.edges) {
+      AuthenticationEdge serialized_edge{};
+      serialized_edge.segment_offset =
+          static_cast<std::uint32_t>(strings.size());
+      serialized_edge.segment_length =
+          static_cast<std::uint32_t>(edge.first.size());
+      serialized_edge.child = edge.second;
+      strings += edge.first;
+      edges.push_back(serialized_edge);
+    }
+
+    serialized.push_back(entry);
+  }
+
+  AuthenticationHeader header{};
+  header.magic = AUTHENTICATION_MAGIC;
+  header.version = AUTHENTICATION_VERSION;
+  header.policy_count = static_cast<std::uint32_t>(policies.size());
+  header.node_count = static_cast<std::uint32_t>(serialized.size());
+  header.edge_count = static_cast<std::uint32_t>(edges.size());
+  header.policies_offset =
+      static_cast<std::uint32_t>(sizeof(AuthenticationHeader));
+  // The node array begins the word-aligned region the matcher addresses
+  // directly, so pad past the byte-packed policy table
+  header.nodes_offset = align_to_word(
+      header.policies_offset +
+      header.policy_count *
+          static_cast<std::uint32_t>(sizeof(AuthenticationPolicyEntry)));
+  header.edges_offset =
+      header.nodes_offset + header.node_count * static_cast<std::uint32_t>(
+                                                    sizeof(AuthenticationNode));
+  header.strings_offset =
+      header.edges_offset + header.edge_count * static_cast<std::uint32_t>(
+                                                    sizeof(AuthenticationEdge));
+  header.strings_length = static_cast<std::uint32_t>(strings.size());
+
+  std::vector<std::byte> buffer(header.strings_offset + header.strings_length,
+                                std::byte{0});
+  std::memcpy(buffer.data(), &header, sizeof(header));
+  for (std::size_t index{0}; index < policies.size(); index += 1) {
+    buffer[header.policies_offset + index] =
+        static_cast<std::byte>(policies[index].type);
+  }
+
+  std::memcpy(buffer.data() + header.nodes_offset, serialized.data(),
+              serialized.size() * sizeof(AuthenticationNode));
+  std::memcpy(buffer.data() + header.edges_offset, edges.data(),
+              edges.size() * sizeof(AuthenticationEdge));
+  std::memcpy(buffer.data() + header.strings_offset, strings.data(),
+              strings.size());
+
+  sourcemeta::core::write_file(path, buffer);
+}
+
+} // namespace sourcemeta::one

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -77,6 +77,16 @@ private:
   [[nodiscard]] auto match(std::string_view registry_path) const noexcept
       -> PolicySet;
 
+  // The trie section bases, resolved from the header once at construction so
+  // that matching never re-reads it. They are typed as the internal serialized
+  // structures and point into the memory-mapped buffer below, remaining valid
+  // for the lifetime of the view. All are null when the instance is
+  // unconfigured, and the edge and string bases are null when no policy
+  // declares a nested prefix
+  const void *nodes_{nullptr};
+  const void *edges_{nullptr};
+  const char *strings_{nullptr};
+
   std::unique_ptr<sourcemeta::core::FileView> view_;
 };
 

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -6,9 +6,15 @@
 #endif
 
 #include <cstddef>     // std::size_t
-#include <cstdint>     // std::uint64_t
+#include <cstdint>     // std::uint64_t, std::uint8_t
 #include <filesystem>  // std::filesystem::path
+#include <memory>      // std::unique_ptr
+#include <span>        // std::span
 #include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+class FileView;
+}
 
 namespace sourcemeta::one {
 
@@ -25,6 +31,18 @@ public:
 
   static constexpr std::size_t MAXIMUM_POLICIES{64};
 
+  // The kind of access a policy grants. Only anonymous public access
+  // exists for now
+  enum class Type : std::uint8_t { Public };
+
+  // A single policy as declared in the configuration. It governs every
+  // registry path nested under any of its prefixes. The paths are borrowed
+  // for the duration of the call to save, so the caller owns their storage
+  struct Policy {
+    Type type;
+    std::span<const std::string_view> paths;
+  };
+
   // The result of validating a caller against a set of policy entries.
   // The key name is for audit logging and is empty for anonymous access
   struct Verdict {
@@ -32,7 +50,20 @@ public:
     std::string_view key_name;
   };
 
+  // Compile a set of policies into a memory-mappable artifact at the given
+  // path. Entries are assigned identifiers in declaration order, so at most
+  // MAXIMUM_POLICIES may be provided
+  static auto save(std::span<const Policy> policies,
+                   const std::filesystem::path &path) -> void;
+
   explicit Authentication(const std::filesystem::path &path);
+  ~Authentication();
+
+  // The artifact is memory-mapped and owned for the lifetime of the view
+  Authentication(const Authentication &) = delete;
+  Authentication(Authentication &&) = delete;
+  auto operator=(const Authentication &) -> Authentication & = delete;
+  auto operator=(Authentication &&) -> Authentication & = delete;
 
   [[nodiscard]] auto match(std::string_view registry_path) const noexcept
       -> PolicySet;
@@ -43,6 +74,9 @@ public:
   [[nodiscard]] auto admits(PolicySet policies,
                             std::string_view credential) const noexcept
       -> Verdict;
+
+private:
+  std::unique_ptr<sourcemeta::core::FileView> view_;
 };
 
 } // namespace sourcemeta::one

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -5,16 +5,14 @@
 #include <sourcemeta/one/authentication_export.h>
 #endif
 
+#include <sourcemeta/core/io.h>
+
 #include <cstddef>     // std::size_t
 #include <cstdint>     // std::uint64_t, std::uint8_t
 #include <filesystem>  // std::filesystem::path
 #include <memory>      // std::unique_ptr
 #include <span>        // std::span
 #include <string_view> // std::string_view
-
-namespace sourcemeta::core {
-class FileView;
-}
 
 namespace sourcemeta::one {
 
@@ -24,11 +22,6 @@ namespace sourcemeta::one {
 // unconfigured instances, not a placeholder
 class SOURCEMETA_ONE_AUTHENTICATION_EXPORT Authentication {
 public:
-  // A set of policy entries, one bit per entry. Entries are assigned
-  // monotonically increasing identifiers in configuration declaration
-  // order, so a governing set is a single machine word
-  using PolicySet = std::uint64_t;
-
   static constexpr std::size_t MAXIMUM_POLICIES{64};
 
   // The kind of access a policy grants. Only anonymous public access
@@ -43,8 +36,8 @@ public:
     std::span<const std::string_view> paths;
   };
 
-  // The result of validating a caller against a set of policy entries.
-  // The key name is for audit logging and is empty for anonymous access
+  // The result of validating a caller against the policies that govern a
+  // path. The key name is for audit logging and is empty for anonymous access
   struct Verdict {
     bool allowed;
     std::string_view key_name;
@@ -65,17 +58,25 @@ public:
   auto operator=(const Authentication &) -> Authentication & = delete;
   auto operator=(Authentication &&) -> Authentication & = delete;
 
-  [[nodiscard]] auto match(std::string_view registry_path) const noexcept
-      -> PolicySet;
-
-  // The credential is the bearer token presented by the caller, empty for
+  // Validate a caller against the policies that govern a registry path. The
+  // credential is the bearer token presented by the caller, empty for
   // anonymous access. It is borrowed for the duration of the call, so a
   // caller that validates across an asynchronous boundary must own it
-  [[nodiscard]] auto admits(PolicySet policies,
+  [[nodiscard]] auto admits(std::string_view registry_path,
                             std::string_view credential) const noexcept
       -> Verdict;
 
 private:
+  // A set of policy entries, one bit per entry. Entries are assigned
+  // monotonically increasing identifiers in configuration declaration
+  // order, so a governing set is a single machine word
+  using PolicySet = std::uint64_t;
+
+  // The policies that govern a registry path, accumulated from every prefix
+  // covering it. An unconfigured instance yields the empty set
+  [[nodiscard]] auto match(std::string_view registry_path) const noexcept
+      -> PolicySet;
+
   std::unique_ptr<sourcemeta::core::FileView> view_;
 };
 

--- a/src/router/artifact.cc
+++ b/src/router/artifact.cc
@@ -129,8 +129,8 @@ auto RouterAction::artifact_resolve_path(
   }
 
   const auto &authentication{this->dispatcher_.authentication()};
-  const auto verdict{authentication.admits(
-      authentication.match(relative.generic_string()), credential)};
+  const auto verdict{
+      authentication.admits(relative.generic_string(), credential)};
   if (!verdict.allowed) {
     return {.outcome = ArtifactResolution::Outcome::Denied,
             .path = std::nullopt};

--- a/test/unit/authentication/CMakeLists.txt
+++ b/test/unit/authentication/CMakeLists.txt
@@ -3,3 +3,6 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT one NAME authentication
 
 target_link_libraries(sourcemeta_one_authentication_unit
   PRIVATE sourcemeta::one::authentication)
+
+target_compile_definitions(sourcemeta_one_authentication_unit
+  PRIVATE AUTHENTICATION_TEST_DIRECTORY="${CMAKE_CURRENT_BINARY_DIR}")

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -4,7 +4,6 @@
 
 #include <array>       // std::array
 #include <cstddef>     // std::size_t
-#include <cstdint>     // std::uint64_t
 #include <filesystem>  // std::filesystem::path
 #include <fstream>     // std::ofstream
 #include <span>        // std::span
@@ -17,27 +16,19 @@ static auto test_path(const std::string &name) -> std::filesystem::path {
   return std::filesystem::path{AUTHENTICATION_TEST_DIRECTORY} / name;
 }
 
-TEST(Authentication, absent_policy_matches_nothing) {
-  const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"}};
-  EXPECT_EQ(authentication.match("acme/foo"), 0);
-  EXPECT_EQ(authentication.match("/acme/foo"), 0);
-  EXPECT_EQ(authentication.match(""), 0);
-  EXPECT_EQ(authentication.match("/"), 0);
-}
-
 TEST(Authentication, absent_policy_admits_anonymous) {
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"}};
-  const auto verdict{authentication.admits(0, "")};
-  EXPECT_TRUE(verdict.allowed);
-  EXPECT_TRUE(verdict.key_name.empty());
+  EXPECT_TRUE(authentication.admits("/acme/foo", "").allowed);
+  EXPECT_TRUE(authentication.admits("/", "").allowed);
+  EXPECT_TRUE(authentication.admits("", "").allowed);
+  EXPECT_TRUE(authentication.admits("/acme/foo", "").key_name.empty());
 }
 
 TEST(Authentication, absent_policy_admits_credentialed) {
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"}};
-  const auto verdict{authentication.admits(0, "my-secret-key")};
+  const auto verdict{authentication.admits("/acme/foo", "my-secret-key")};
   EXPECT_TRUE(verdict.allowed);
   EXPECT_TRUE(verdict.key_name.empty());
 }
@@ -53,7 +44,7 @@ TEST(Authentication, malformed_artifact_is_rejected) {
                std::runtime_error);
 }
 
-TEST(Authentication, public_root_covers_every_path) {
+TEST(Authentication, public_root_admits_every_path) {
   const std::array<std::string_view, 1> paths{"/"};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{sourcemeta::one::Authentication::Type::Public, paths}}};
@@ -61,27 +52,14 @@ TEST(Authentication, public_root_covers_every_path) {
   sourcemeta::one::Authentication::save(policies, path);
 
   const sourcemeta::one::Authentication authentication{path};
-  EXPECT_EQ(authentication.match("/"), 0b1);
-  EXPECT_EQ(authentication.match(""), 0b1);
-  EXPECT_EQ(authentication.match("acme"), 0b1);
-  EXPECT_EQ(authentication.match("/acme/foo/bar"), 0b1);
+  EXPECT_TRUE(authentication.admits("/", "").allowed);
+  EXPECT_TRUE(authentication.admits("", "").allowed);
+  EXPECT_TRUE(authentication.admits("acme", "").allowed);
+  EXPECT_TRUE(authentication.admits("/acme/foo/bar", "").allowed);
+  EXPECT_TRUE(authentication.admits("/acme/foo/bar", "").key_name.empty());
 }
 
-TEST(Authentication, public_root_admits_everyone) {
-  const std::array<std::string_view, 1> paths{"/"};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{sourcemeta::one::Authentication::Type::Public, paths}}};
-  const auto path{test_path("public_root_admits.bin")};
-  sourcemeta::one::Authentication::save(policies, path);
-
-  const sourcemeta::one::Authentication authentication{path};
-  const auto verdict{
-      authentication.admits(authentication.match("/acme/foo"), "")};
-  EXPECT_TRUE(verdict.allowed);
-  EXPECT_TRUE(verdict.key_name.empty());
-}
-
-TEST(Authentication, scoped_prefix_covers_only_its_subtree) {
+TEST(Authentication, scoped_prefix_admits_only_its_subtree) {
   const std::array<std::string_view, 1> paths{"/internal"};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{sourcemeta::one::Authentication::Type::Public, paths}}};
@@ -89,11 +67,11 @@ TEST(Authentication, scoped_prefix_covers_only_its_subtree) {
   sourcemeta::one::Authentication::save(policies, path);
 
   const sourcemeta::one::Authentication authentication{path};
-  EXPECT_EQ(authentication.match("/internal"), 0b1);
-  EXPECT_EQ(authentication.match("/internal/foo"), 0b1);
-  EXPECT_EQ(authentication.match("/internal/foo/bar"), 0b1);
-  EXPECT_EQ(authentication.match("/"), 0);
-  EXPECT_EQ(authentication.match("/vendor"), 0);
+  EXPECT_TRUE(authentication.admits("/internal", "").allowed);
+  EXPECT_TRUE(authentication.admits("/internal/foo", "").allowed);
+  EXPECT_TRUE(authentication.admits("/internal/foo/bar", "").allowed);
+  EXPECT_FALSE(authentication.admits("/", "").allowed);
+  EXPECT_FALSE(authentication.admits("/vendor", "").allowed);
 }
 
 TEST(Authentication, scoped_prefix_matches_whole_segments_only) {
@@ -104,28 +82,12 @@ TEST(Authentication, scoped_prefix_matches_whole_segments_only) {
   sourcemeta::one::Authentication::save(policies, path);
 
   const sourcemeta::one::Authentication authentication{path};
-  EXPECT_EQ(authentication.match("/internalish"), 0);
-  EXPECT_EQ(authentication.match("/int"), 0);
-  EXPECT_EQ(authentication.match("/internal-team"), 0);
+  EXPECT_FALSE(authentication.admits("/internalish", "").allowed);
+  EXPECT_FALSE(authentication.admits("/int", "").allowed);
+  EXPECT_FALSE(authentication.admits("/internal-team", "").allowed);
 }
 
-TEST(Authentication, uncovered_path_is_denied_when_configured) {
-  const std::array<std::string_view, 1> paths{"/internal"};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{sourcemeta::one::Authentication::Type::Public, paths}}};
-  const auto path{test_path("uncovered_denied.bin")};
-  sourcemeta::one::Authentication::save(policies, path);
-
-  const sourcemeta::one::Authentication authentication{path};
-  const auto covered{
-      authentication.admits(authentication.match("/internal/foo"), "")};
-  EXPECT_TRUE(covered.allowed);
-  const auto uncovered{
-      authentication.admits(authentication.match("/vendor"), "")};
-  EXPECT_FALSE(uncovered.allowed);
-}
-
-TEST(Authentication, distinct_policies_receive_distinct_identifiers) {
+TEST(Authentication, distinct_policies_each_admit_their_scope) {
   const std::array<std::string_view, 1> alpha{"/alpha"};
   const std::array<std::string_view, 1> beta{"/beta"};
   const std::array<std::string_view, 1> gamma{"/gamma"};
@@ -137,30 +99,28 @@ TEST(Authentication, distinct_policies_receive_distinct_identifiers) {
   sourcemeta::one::Authentication::save(policies, path);
 
   const sourcemeta::one::Authentication authentication{path};
-  EXPECT_EQ(authentication.match("/alpha/one"), 0b001);
-  EXPECT_EQ(authentication.match("/beta/two"), 0b010);
-  EXPECT_EQ(authentication.match("/gamma/three"), 0b100);
-  EXPECT_EQ(authentication.match("/delta"), 0);
+  EXPECT_TRUE(authentication.admits("/alpha/one", "").allowed);
+  EXPECT_TRUE(authentication.admits("/beta/two", "").allowed);
+  EXPECT_TRUE(authentication.admits("/gamma/three", "").allowed);
+  EXPECT_FALSE(authentication.admits("/delta", "").allowed);
 }
 
-TEST(Authentication, nested_prefixes_accumulate_along_the_path) {
-  const std::array<std::string_view, 1> root{"/"};
+TEST(Authentication, nested_prefixes_admit_their_subtrees) {
   const std::array<std::string_view, 1> internal{"/internal"};
   const std::array<std::string_view, 1> secret{"/internal/secret"};
-  const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
-      {{sourcemeta::one::Authentication::Type::Public, root},
-       {sourcemeta::one::Authentication::Type::Public, internal},
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{sourcemeta::one::Authentication::Type::Public, internal},
        {sourcemeta::one::Authentication::Type::Public, secret}}};
   const auto path{test_path("nested_prefixes.bin")};
   sourcemeta::one::Authentication::save(policies, path);
 
   const sourcemeta::one::Authentication authentication{path};
-  EXPECT_EQ(authentication.match("/"), 0b001);
-  EXPECT_EQ(authentication.match("/public"), 0b001);
-  EXPECT_EQ(authentication.match("/internal"), 0b011);
-  EXPECT_EQ(authentication.match("/internal/other"), 0b011);
-  EXPECT_EQ(authentication.match("/internal/secret"), 0b111);
-  EXPECT_EQ(authentication.match("/internal/secret/deep"), 0b111);
+  EXPECT_TRUE(authentication.admits("/internal", "").allowed);
+  EXPECT_TRUE(authentication.admits("/internal/other", "").allowed);
+  EXPECT_TRUE(authentication.admits("/internal/secret", "").allowed);
+  EXPECT_TRUE(authentication.admits("/internal/secret/deep", "").allowed);
+  EXPECT_FALSE(authentication.admits("/", "").allowed);
+  EXPECT_FALSE(authentication.admits("/public", "").allowed);
 }
 
 TEST(Authentication, single_policy_with_multiple_prefixes) {
@@ -171,9 +131,9 @@ TEST(Authentication, single_policy_with_multiple_prefixes) {
   sourcemeta::one::Authentication::save(policies, path);
 
   const sourcemeta::one::Authentication authentication{path};
-  EXPECT_EQ(authentication.match("/internal/foo"), 0b1);
-  EXPECT_EQ(authentication.match("/vendor/bar"), 0b1);
-  EXPECT_EQ(authentication.match("/public"), 0);
+  EXPECT_TRUE(authentication.admits("/internal/foo", "").allowed);
+  EXPECT_TRUE(authentication.admits("/vendor/bar", "").allowed);
+  EXPECT_FALSE(authentication.admits("/public", "").allowed);
 }
 
 TEST(Authentication, supports_the_maximum_number_of_policies) {
@@ -202,8 +162,7 @@ TEST(Authentication, supports_the_maximum_number_of_policies) {
   sourcemeta::one::Authentication::save(policies, path);
 
   const sourcemeta::one::Authentication authentication{path};
-  EXPECT_EQ(authentication.match("/p0/foo"), static_cast<std::uint64_t>(1));
-  EXPECT_EQ(authentication.match("/p63/foo"), static_cast<std::uint64_t>(1)
-                                                  << 63);
-  EXPECT_EQ(authentication.match("/missing"), 0);
+  EXPECT_TRUE(authentication.admits("/p0/foo", "").allowed);
+  EXPECT_TRUE(authentication.admits("/p63/foo", "").allowed);
+  EXPECT_FALSE(authentication.admits("/missing", "").allowed);
 }

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -44,6 +44,24 @@ TEST(Authentication, malformed_artifact_is_rejected) {
                std::runtime_error);
 }
 
+TEST(Authentication, structurally_corrupt_artifact_is_rejected) {
+  const auto path{test_path("corrupt.bin")};
+  std::ofstream stream{path, std::ios::binary};
+  // A header whose magic and version are valid but whose node table is empty,
+  // which is structurally impossible since the root node is always present
+  std::array<char, 40> header{};
+  header[0] = 'A';
+  header[1] = 'U';
+  header[2] = 'T';
+  header[3] = 'H';
+  header[4] = 1;
+  stream.write(header.data(), header.size());
+  stream.close();
+
+  EXPECT_THROW(const sourcemeta::one::Authentication authentication{path},
+               std::runtime_error);
+}
+
 TEST(Authentication, public_root_admits_every_path) {
   const std::array<std::string_view, 1> paths{{"/"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -45,7 +45,7 @@ TEST(Authentication, malformed_artifact_is_rejected) {
 }
 
 TEST(Authentication, public_root_admits_every_path) {
-  const std::array<std::string_view, 1> paths{"/"};
+  const std::array<std::string_view, 1> paths{{"/"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{sourcemeta::one::Authentication::Type::Public, paths}}};
   const auto path{test_path("public_root.bin")};
@@ -60,7 +60,7 @@ TEST(Authentication, public_root_admits_every_path) {
 }
 
 TEST(Authentication, scoped_prefix_admits_only_its_subtree) {
-  const std::array<std::string_view, 1> paths{"/internal"};
+  const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{sourcemeta::one::Authentication::Type::Public, paths}}};
   const auto path{test_path("scoped_prefix.bin")};
@@ -75,7 +75,7 @@ TEST(Authentication, scoped_prefix_admits_only_its_subtree) {
 }
 
 TEST(Authentication, scoped_prefix_matches_whole_segments_only) {
-  const std::array<std::string_view, 1> paths{"/internal"};
+  const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{sourcemeta::one::Authentication::Type::Public, paths}}};
   const auto path{test_path("segment_boundary.bin")};
@@ -88,9 +88,9 @@ TEST(Authentication, scoped_prefix_matches_whole_segments_only) {
 }
 
 TEST(Authentication, distinct_policies_each_admit_their_scope) {
-  const std::array<std::string_view, 1> alpha{"/alpha"};
-  const std::array<std::string_view, 1> beta{"/beta"};
-  const std::array<std::string_view, 1> gamma{"/gamma"};
+  const std::array<std::string_view, 1> alpha{{"/alpha"}};
+  const std::array<std::string_view, 1> beta{{"/beta"}};
+  const std::array<std::string_view, 1> gamma{{"/gamma"}};
   const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
       {{sourcemeta::one::Authentication::Type::Public, alpha},
        {sourcemeta::one::Authentication::Type::Public, beta},
@@ -106,8 +106,8 @@ TEST(Authentication, distinct_policies_each_admit_their_scope) {
 }
 
 TEST(Authentication, nested_prefixes_admit_their_subtrees) {
-  const std::array<std::string_view, 1> internal{"/internal"};
-  const std::array<std::string_view, 1> secret{"/internal/secret"};
+  const std::array<std::string_view, 1> internal{{"/internal"}};
+  const std::array<std::string_view, 1> secret{{"/internal/secret"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{sourcemeta::one::Authentication::Type::Public, internal},
        {sourcemeta::one::Authentication::Type::Public, secret}}};
@@ -124,7 +124,7 @@ TEST(Authentication, nested_prefixes_admit_their_subtrees) {
 }
 
 TEST(Authentication, single_policy_with_multiple_prefixes) {
-  const std::array<std::string_view, 2> paths{"/internal", "/vendor"};
+  const std::array<std::string_view, 2> paths{{"/internal", "/vendor"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{sourcemeta::one::Authentication::Type::Public, paths}}};
   const auto path{test_path("multiple_prefixes.bin")};

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -2,7 +2,20 @@
 
 #include <gtest/gtest.h>
 
-#include <filesystem> // std::filesystem::path
+#include <array>       // std::array
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint64_t
+#include <filesystem>  // std::filesystem::path
+#include <fstream>     // std::ofstream
+#include <span>        // std::span
+#include <stdexcept>   // std::runtime_error
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <vector>      // std::vector
+
+static auto test_path(const std::string &name) -> std::filesystem::path {
+  return std::filesystem::path{AUTHENTICATION_TEST_DIRECTORY} / name;
+}
 
 TEST(Authentication, absent_policy_matches_nothing) {
   const sourcemeta::one::Authentication authentication{
@@ -27,4 +40,170 @@ TEST(Authentication, absent_policy_admits_credentialed) {
   const auto verdict{authentication.admits(0, "my-secret-key")};
   EXPECT_TRUE(verdict.allowed);
   EXPECT_TRUE(verdict.key_name.empty());
+}
+
+TEST(Authentication, malformed_artifact_is_rejected) {
+  const auto path{test_path("malformed.bin")};
+  std::ofstream stream{path, std::ios::binary};
+  const std::array<char, 64> garbage{};
+  stream.write(garbage.data(), garbage.size());
+  stream.close();
+
+  EXPECT_THROW(const sourcemeta::one::Authentication authentication{path},
+               std::runtime_error);
+}
+
+TEST(Authentication, public_root_covers_every_path) {
+  const std::array<std::string_view, 1> paths{"/"};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::Public, paths}}};
+  const auto path{test_path("public_root.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_EQ(authentication.match("/"), 0b1);
+  EXPECT_EQ(authentication.match(""), 0b1);
+  EXPECT_EQ(authentication.match("acme"), 0b1);
+  EXPECT_EQ(authentication.match("/acme/foo/bar"), 0b1);
+}
+
+TEST(Authentication, public_root_admits_everyone) {
+  const std::array<std::string_view, 1> paths{"/"};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::Public, paths}}};
+  const auto path{test_path("public_root_admits.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  const auto verdict{
+      authentication.admits(authentication.match("/acme/foo"), "")};
+  EXPECT_TRUE(verdict.allowed);
+  EXPECT_TRUE(verdict.key_name.empty());
+}
+
+TEST(Authentication, scoped_prefix_covers_only_its_subtree) {
+  const std::array<std::string_view, 1> paths{"/internal"};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::Public, paths}}};
+  const auto path{test_path("scoped_prefix.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_EQ(authentication.match("/internal"), 0b1);
+  EXPECT_EQ(authentication.match("/internal/foo"), 0b1);
+  EXPECT_EQ(authentication.match("/internal/foo/bar"), 0b1);
+  EXPECT_EQ(authentication.match("/"), 0);
+  EXPECT_EQ(authentication.match("/vendor"), 0);
+}
+
+TEST(Authentication, scoped_prefix_matches_whole_segments_only) {
+  const std::array<std::string_view, 1> paths{"/internal"};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::Public, paths}}};
+  const auto path{test_path("segment_boundary.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_EQ(authentication.match("/internalish"), 0);
+  EXPECT_EQ(authentication.match("/int"), 0);
+  EXPECT_EQ(authentication.match("/internal-team"), 0);
+}
+
+TEST(Authentication, uncovered_path_is_denied_when_configured) {
+  const std::array<std::string_view, 1> paths{"/internal"};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::Public, paths}}};
+  const auto path{test_path("uncovered_denied.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  const auto covered{
+      authentication.admits(authentication.match("/internal/foo"), "")};
+  EXPECT_TRUE(covered.allowed);
+  const auto uncovered{
+      authentication.admits(authentication.match("/vendor"), "")};
+  EXPECT_FALSE(uncovered.allowed);
+}
+
+TEST(Authentication, distinct_policies_receive_distinct_identifiers) {
+  const std::array<std::string_view, 1> alpha{"/alpha"};
+  const std::array<std::string_view, 1> beta{"/beta"};
+  const std::array<std::string_view, 1> gamma{"/gamma"};
+  const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
+      {{sourcemeta::one::Authentication::Type::Public, alpha},
+       {sourcemeta::one::Authentication::Type::Public, beta},
+       {sourcemeta::one::Authentication::Type::Public, gamma}}};
+  const auto path{test_path("distinct_policies.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_EQ(authentication.match("/alpha/one"), 0b001);
+  EXPECT_EQ(authentication.match("/beta/two"), 0b010);
+  EXPECT_EQ(authentication.match("/gamma/three"), 0b100);
+  EXPECT_EQ(authentication.match("/delta"), 0);
+}
+
+TEST(Authentication, nested_prefixes_accumulate_along_the_path) {
+  const std::array<std::string_view, 1> root{"/"};
+  const std::array<std::string_view, 1> internal{"/internal"};
+  const std::array<std::string_view, 1> secret{"/internal/secret"};
+  const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
+      {{sourcemeta::one::Authentication::Type::Public, root},
+       {sourcemeta::one::Authentication::Type::Public, internal},
+       {sourcemeta::one::Authentication::Type::Public, secret}}};
+  const auto path{test_path("nested_prefixes.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_EQ(authentication.match("/"), 0b001);
+  EXPECT_EQ(authentication.match("/public"), 0b001);
+  EXPECT_EQ(authentication.match("/internal"), 0b011);
+  EXPECT_EQ(authentication.match("/internal/other"), 0b011);
+  EXPECT_EQ(authentication.match("/internal/secret"), 0b111);
+  EXPECT_EQ(authentication.match("/internal/secret/deep"), 0b111);
+}
+
+TEST(Authentication, single_policy_with_multiple_prefixes) {
+  const std::array<std::string_view, 2> paths{"/internal", "/vendor"};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::Public, paths}}};
+  const auto path{test_path("multiple_prefixes.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_EQ(authentication.match("/internal/foo"), 0b1);
+  EXPECT_EQ(authentication.match("/vendor/bar"), 0b1);
+  EXPECT_EQ(authentication.match("/public"), 0);
+}
+
+TEST(Authentication, supports_the_maximum_number_of_policies) {
+  constexpr auto maximum{sourcemeta::one::Authentication::MAXIMUM_POLICIES};
+  std::vector<std::string> path_storage;
+  path_storage.reserve(maximum);
+  for (std::size_t index{0}; index < maximum; index += 1) {
+    path_storage.push_back("/p" + std::to_string(index));
+  }
+
+  std::vector<std::string_view> path_views;
+  path_views.reserve(maximum);
+  for (const auto &value : path_storage) {
+    path_views.push_back(value);
+  }
+
+  std::vector<sourcemeta::one::Authentication::Policy> policies;
+  policies.reserve(maximum);
+  for (std::size_t index{0}; index < maximum; index += 1) {
+    policies.push_back(
+        {sourcemeta::one::Authentication::Type::Public,
+         std::span<const std::string_view>{&path_views[index], 1}});
+  }
+
+  const auto path{test_path("maximum_policies.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_EQ(authentication.match("/p0/foo"), static_cast<std::uint64_t>(1));
+  EXPECT_EQ(authentication.match("/p63/foo"), static_cast<std::uint64_t>(1)
+                                                  << 63);
+  EXPECT_EQ(authentication.match("/missing"), 0);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

