### PR TITLE
Do not support key names in `authentication` for now

### DIFF
--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -175,7 +175,7 @@ auto Authentication::admits(const std::string_view registry_path,
     -> Authentication::Verdict {
   // A path is served only when at least one policy governs it, as every
   // policy grants anonymous public access for now
-  return {.allowed = this->match(registry_path) != 0, .key_name = {}};
+  return {.allowed = this->match(registry_path) != 0};
 }
 
 } // namespace sourcemeta::one

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -36,11 +36,9 @@ public:
     std::span<const std::string_view> paths;
   };
 
-  // The result of validating a caller against the policies that govern a
-  // path. The key name is for audit logging and is empty for anonymous access
+  // The result of validating a caller against the policies that govern a path
   struct Verdict {
     bool allowed;
-    std::string_view key_name;
   };
 
   // Compile a set of policies into a memory-mappable artifact at the given

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -66,7 +66,6 @@ TEST(Authentication, public_root_admits_every_path) {
   EXPECT_TRUE(authentication.admits("", "").allowed);
   EXPECT_TRUE(authentication.admits("acme", "").allowed);
   EXPECT_TRUE(authentication.admits("/acme/foo/bar", "").allowed);
-  EXPECT_TRUE(authentication.admits("/acme/foo/bar", "").key_name.empty());
 }
 
 TEST(Authentication, scoped_prefix_admits_only_its_subtree) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

