### PR TITLE
Move policy checking to the `enterprise/` directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ if(ONE_INDEX OR ONE_SERVER)
   add_subdirectory(src/router)
 
   if(ONE_ENTERPRISE)
+    add_subdirectory(enterprise/authentication)
     add_subdirectory(enterprise/server)
   endif()
 

--- a/enterprise/authentication/CMakeLists.txt
+++ b/enterprise/authentication/CMakeLists.txt
@@ -1,0 +1,4 @@
+sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME enterprise_authentication
+  SOURCES enterprise_authentication.cc)
+
+target_compile_definitions(sourcemeta_one_enterprise_authentication PUBLIC SOURCEMETA_ONE_ENTERPRISE)

--- a/enterprise/authentication/enterprise_authentication.cc
+++ b/enterprise/authentication/enterprise_authentication.cc
@@ -1,0 +1,11 @@
+#include <sourcemeta/one/enterprise_authentication.h>
+
+namespace sourcemeta::one {
+
+auto authentication_admits_enterprise(const std::string_view) -> bool {
+  // Policy types beyond public are introduced in a later step. Until then
+  // there are none to evaluate, so no caller is admitted through this path
+  return false;
+}
+
+} // namespace sourcemeta::one

--- a/enterprise/authentication/include/sourcemeta/one/enterprise_authentication.h
+++ b/enterprise/authentication/include/sourcemeta/one/enterprise_authentication.h
@@ -1,0 +1,21 @@
+#ifndef SOURCEMETA_ONE_ENTERPRISE_AUTHENTICATION_H_
+#define SOURCEMETA_ONE_ENTERPRISE_AUTHENTICATION_H_
+
+#ifndef SOURCEMETA_ONE_ENTERPRISE_AUTHENTICATION_EXPORT
+#include <sourcemeta/one/enterprise_authentication_export.h>
+#endif
+
+#include <string_view> // std::string_view
+
+namespace sourcemeta::one {
+
+// Evaluate a non-public authentication policy against a caller credential.
+// Policy types beyond public are an enterprise feature, so their matching
+// logic lives here and is compiled out of the community edition. Returns
+// whether the credential satisfies the policy
+auto SOURCEMETA_ONE_ENTERPRISE_AUTHENTICATION_EXPORT
+authentication_admits_enterprise(std::string_view credential) -> bool;
+
+} // namespace sourcemeta::one
+
+#endif

--- a/src/authentication/CMakeLists.txt
+++ b/src/authentication/CMakeLists.txt
@@ -2,3 +2,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME authentication
   SOURCES authentication.cc authentication_save.cc)
 
 target_link_libraries(sourcemeta_one_authentication PUBLIC sourcemeta::core::io)
+
+if(ONE_ENTERPRISE)
+  target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::one::enterprise_authentication)
+endif()

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -27,8 +27,11 @@ auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
   }
 
   const auto *header{view.as<AuthenticationHeader>()};
+  // The policy count must fit the bitmask width, otherwise matching would
+  // shift past the width of a PolicySet, which is undefined behavior
   if (header->magic != AUTHENTICATION_MAGIC ||
-      header->version != AUTHENTICATION_VERSION || header->node_count == 0) {
+      header->version != AUTHENTICATION_VERSION || header->node_count == 0 ||
+      header->policy_count > Authentication::MAXIMUM_POLICIES) {
     return false;
   }
 

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -4,6 +4,10 @@
 
 #include "authentication_format.h"
 
+#if defined(SOURCEMETA_ONE_ENTERPRISE)
+#include <sourcemeta/one/enterprise_authentication.h>
+#endif
+
 #include <cstddef> // std::size_t
 #include <cstdint> // std::uint32_t
 #include <utility> // std::move
@@ -37,6 +41,15 @@ auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
   if (header->nodes_offset > size ||
       nodes_bytes > size - header->nodes_offset) {
     return false;
+  }
+
+  if (header->policy_count > 0) {
+    const auto policies_bytes{static_cast<std::size_t>(header->policy_count) *
+                              sizeof(AuthenticationPolicyEntry)};
+    if (header->policies_offset > size ||
+        policies_bytes > size - header->policies_offset) {
+      return false;
+    }
   }
 
   std::size_t strings_length{0};
@@ -117,6 +130,12 @@ Authentication::Authentication(const std::filesystem::path &path) {
     this->strings_ = view->as<char>(header->strings_offset);
   }
 
+  if (header->policy_count > 0) {
+    this->policies_ =
+        view->as<AuthenticationPolicyEntry>(header->policies_offset);
+    this->policy_count_ = header->policy_count;
+  }
+
   this->view_ = std::move(view);
 }
 
@@ -171,11 +190,35 @@ auto Authentication::match(const std::string_view registry_path) const noexcept
 }
 
 auto Authentication::admits(const std::string_view registry_path,
-                            const std::string_view) const noexcept
-    -> Authentication::Verdict {
-  // A path is served only when at least one policy governs it, as every
-  // policy grants anonymous public access for now
-  return {.allowed = this->match(registry_path) != 0};
+                            [[maybe_unused]] const std::string_view credential)
+    const -> Authentication::Verdict {
+  const auto governing{this->match(registry_path)};
+  if (governing == 0) {
+    // Unconfigured, broken, or a path that no policy governs
+    return {.allowed = false};
+  }
+
+  const auto *policies{
+      static_cast<const AuthenticationPolicyEntry *>(this->policies_)};
+  for (std::uint32_t index{0}; index < this->policy_count_; index += 1) {
+    if ((governing & (PolicySet{1} << index)) == 0) {
+      continue;
+    }
+
+    if (static_cast<Type>(policies[index].type) == Type::Public) {
+      // Public policies admit anonymously
+      return {.allowed = true};
+    }
+
+#if defined(SOURCEMETA_ONE_ENTERPRISE)
+    // Policy types beyond public are an enterprise feature
+    if (authentication_admits_enterprise(credential)) {
+      return {.allowed = true};
+    }
+#endif
+  }
+
+  return {.allowed = false};
 }
 
 } // namespace sourcemeta::one

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -61,8 +61,7 @@ public:
   // anonymous access. It is borrowed for the duration of the call, so a
   // caller that validates across an asynchronous boundary must own it
   [[nodiscard]] auto admits(std::string_view registry_path,
-                            std::string_view credential) const noexcept
-      -> Verdict;
+                            std::string_view credential) const -> Verdict;
 
 private:
   // A set of policy entries, one bit per entry. Entries are assigned
@@ -84,6 +83,12 @@ private:
   const void *nodes_{nullptr};
   const void *edges_{nullptr};
   const char *strings_{nullptr};
+
+  // The policy table, resolved once at construction, holding the type of each
+  // policy so that admits can dispatch on it. Null when the instance is
+  // unconfigured or declares no policies
+  const void *policies_{nullptr};
+  std::uint32_t policy_count_{0};
 
   std::unique_ptr<sourcemeta::core::FileView> view_;
 };

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -54,6 +54,28 @@ TEST(Authentication, structurally_corrupt_artifact_denies_everything) {
   EXPECT_FALSE(authentication.admits("/internal/foo", "").allowed);
 }
 
+TEST(Authentication, artifact_exceeding_the_policy_ceiling_denies_everything) {
+  const auto path{test_path("too-many-policies.bin")};
+  std::ofstream stream{path, std::ios::binary};
+  // A header with valid magic and version but a policy count past the bitmask
+  // width, which would shift out of range during matching
+  std::array<char, 40> header{};
+  header[0] = 'A';
+  header[1] = 'U';
+  header[2] = 'T';
+  header[3] = 'H';
+  header[4] = 1;
+  header[8] =
+      static_cast<char>(sourcemeta::one::Authentication::MAXIMUM_POLICIES + 1);
+  header[12] = 1;
+  stream.write(header.data(), header.size());
+  stream.close();
+
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_FALSE(authentication.admits("/", "").allowed);
+  EXPECT_FALSE(authentication.admits("/acme/foo", "").allowed);
+}
+
 TEST(Authentication, public_root_admits_every_path) {
   const std::array<std::string_view, 1> paths{{"/"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

