### PR TITLE
Implement `apiKey` identity support on the authentication module

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -132,7 +132,7 @@ auto constant_time_equal(const std::string_view left,
     return false;
   }
 
-  unsigned char difference{0};
+  int difference{0};
   for (std::size_t index{0}; index < left.size(); index += 1) {
     difference |= static_cast<unsigned char>(left[index]) ^
                   static_cast<unsigned char>(right[index]);

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -4,12 +4,19 @@
 
 #include "authentication_format.h"
 
-#include <cstddef>     // std::size_t
-#include <cstdint>     // std::uint32_t, std::uint64_t
-#include <filesystem>  // std::filesystem::path
-#include <memory>      // std::unique_ptr, std::make_unique
-#include <string_view> // std::string_view
-#include <utility>     // std::move
+#include <cstddef>       // std::byte, std::size_t
+#include <cstdint>       // std::uint32_t, std::uint64_t
+#include <cstdlib>       // std::getenv
+#include <cstring>       // std::memcpy
+#include <filesystem>    // std::filesystem::path
+#include <memory>        // std::unique_ptr, std::make_unique
+#include <mutex>         // std::mutex, std::lock_guard
+#include <optional>      // std::optional
+#include <span>          // std::span
+#include <string>        // std::string
+#include <string_view>   // std::string_view
+#include <unordered_map> // std::unordered_map
+#include <utility>       // std::move
 
 namespace {
 
@@ -37,7 +44,8 @@ auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
   // The artifact is produced by a single serializer with a fixed section
   // order, so recompute every offset from the counts and require the header
   // to match exactly. This rejects a corrupted layout whose sections overlap
-  // or sit out of order, rather than reinterpreting unrelated bytes
+  // or sit out of order, rather than reinterpreting unrelated bytes. The
+  // per-policy metadata blob is appended after the string section
   const auto policies_offset{
       static_cast<std::size_t>(sizeof(AuthenticationHeader))};
   const auto policies_bytes{static_cast<std::size_t>(header->policy_count) *
@@ -66,6 +74,23 @@ auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
     return false;
   }
 
+  if (header->policy_count > 0) {
+    const auto *policies{
+        view.as<AuthenticationPolicyEntry>(header->policies_offset)};
+    // Each policy's metadata is appended in declaration order after the string
+    // blob, so a valid artifact lays them out contiguously from there onward
+    auto metadata_cursor{strings_offset + strings_length};
+    for (std::uint32_t index{0}; index < header->policy_count; index += 1) {
+      const auto &entry{policies[index]};
+      if (entry.metadata_offset != metadata_cursor ||
+          entry.metadata_length > size - metadata_cursor) {
+        return false;
+      }
+
+      metadata_cursor += entry.metadata_length;
+    }
+  }
+
   const auto *nodes{view.as<AuthenticationNode>(header->nodes_offset)};
   for (std::uint32_t index{0}; index < header->node_count; index += 1) {
     const auto &node{nodes[index]};
@@ -88,6 +113,83 @@ auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
   }
 
   return true;
+}
+
+auto read_u32(const std::span<const std::byte> metadata, std::size_t &cursor,
+              std::uint32_t &value) -> bool {
+  if (cursor > metadata.size() || metadata.size() - cursor < sizeof(value)) {
+    return false;
+  }
+
+  std::memcpy(&value, metadata.data() + cursor, sizeof(value));
+  cursor += sizeof(value);
+  return true;
+}
+
+auto constant_time_equal(const std::string_view left,
+                         const std::string_view right) -> bool {
+  if (left.size() != right.size()) {
+    return false;
+  }
+
+  unsigned char difference{0};
+  for (std::size_t index{0}; index < left.size(); index += 1) {
+    difference |= static_cast<unsigned char>(left[index]) ^
+                  static_cast<unsigned char>(right[index]);
+  }
+
+  return difference == 0;
+}
+
+auto resolve_environment(const std::string_view variable)
+    -> std::optional<std::string> {
+  static std::mutex mutex;
+  static std::unordered_map<std::string, std::optional<std::string>> cache;
+  const std::string name{variable};
+  const std::lock_guard<std::mutex> lock{mutex};
+  const auto existing{cache.find(name)};
+  if (existing != cache.cend()) {
+    return existing->second;
+  }
+
+  std::optional<std::string> resolved;
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  const char *value{std::getenv(name.c_str())};
+  if (value != nullptr) {
+    resolved = value;
+  }
+
+  cache.emplace(name, resolved);
+  return resolved;
+}
+
+auto admits_apikey(const std::span<const std::byte> metadata,
+                   const std::string_view credential) -> bool {
+  std::size_t cursor{0};
+  std::uint32_t count{0};
+  if (!read_u32(metadata, cursor, count)) {
+    return false;
+  }
+
+  for (std::uint32_t index{0}; index < count; index += 1) {
+    std::uint32_t length{0};
+    if (!read_u32(metadata, cursor, length) ||
+        metadata.size() - cursor < length) {
+      return false;
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    const std::string_view variable{
+        reinterpret_cast<const char *>(metadata.data() + cursor), length};
+    cursor += length;
+
+    const auto stored{resolve_environment(variable)};
+    if (stored.has_value() && constant_time_equal(credential, stored.value())) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 } // namespace
@@ -188,8 +290,8 @@ struct Authentication::Impl {
     return result;
   }
 
-  [[nodiscard]] auto admits(const std::string_view registry_path) const
-      -> bool {
+  [[nodiscard]] auto admits(const std::string_view registry_path,
+                            const std::string_view credential) const -> bool {
     const auto governing{this->match(registry_path)};
     if (governing == 0) {
       // Unconfigured, broken, or a path that no policy governs
@@ -203,12 +305,21 @@ struct Authentication::Impl {
         continue;
       }
 
-      if (static_cast<Type>(policies[index].type) == Type::Public) {
+      const auto &entry{policies[index]};
+      if (static_cast<Type>(entry.type) == Type::Public) {
         // Public policies admit anonymously
         return true;
       }
 
-      // Every other policy type denies access
+      std::span<const std::byte> metadata;
+      if (entry.metadata_length > 0) {
+        metadata = {this->view_->as<std::byte>(entry.metadata_offset),
+                    entry.metadata_length};
+      }
+
+      if (admits_apikey(metadata, credential)) {
+        return true;
+      }
     }
 
     return false;
@@ -239,9 +350,9 @@ Authentication::Authentication(const std::filesystem::path &path)
 Authentication::~Authentication() = default;
 
 auto Authentication::admits(const std::string_view registry_path,
-                            [[maybe_unused]] const std::string_view credential)
-    const -> Authentication::Verdict {
-  return {.allowed = this->impl_->admits(registry_path)};
+                            const std::string_view credential) const
+    -> Authentication::Verdict {
+  return {.allowed = this->impl_->admits(registry_path, credential)};
 }
 
 } // namespace sourcemeta::one

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -306,19 +306,21 @@ struct Authentication::Impl {
       }
 
       const auto &entry{policies[index]};
-      if (static_cast<Type>(entry.type) == Type::Public) {
-        // Public policies admit anonymously
+      const auto type{static_cast<Type>(entry.type)};
+      if (type == Type::Public) {
         return true;
       }
 
-      std::span<const std::byte> metadata;
-      if (entry.metadata_length > 0) {
-        metadata = {this->view_->as<std::byte>(entry.metadata_offset),
-                    entry.metadata_length};
-      }
+      if (type == Type::ApiKey) {
+        std::span<const std::byte> metadata;
+        if (entry.metadata_length > 0) {
+          metadata = {this->view_->as<std::byte>(entry.metadata_offset),
+                      entry.metadata_length};
+        }
 
-      if (admits_apikey(metadata, credential)) {
-        return true;
+        if (admits_apikey(metadata, credential)) {
+          return true;
+        }
       }
     }
 

--- a/enterprise/authentication/authentication_format.h
+++ b/enterprise/authentication/authentication_format.h
@@ -44,8 +44,11 @@ struct AuthenticationEdge {
 };
 
 // One entry per policy, in declaration order, mirroring the bit assigned to
-// it in the node masks
+// it in the node masks. The metadata range locates the policy's opaque blob
+// by absolute file offset, empty for public policies
 struct AuthenticationPolicyEntry {
+  std::uint32_t metadata_offset;
+  std::uint32_t metadata_length;
   std::uint8_t type;
 };
 
@@ -55,7 +58,8 @@ static_assert(sizeof(AuthenticationHeader) == 40);
 static_assert(sizeof(AuthenticationNode) == 16);
 static_assert(alignof(AuthenticationNode) == 8);
 static_assert(sizeof(AuthenticationEdge) == 12);
-static_assert(sizeof(AuthenticationPolicyEntry) == 1);
+static_assert(sizeof(AuthenticationPolicyEntry) == 12);
+static_assert(alignof(AuthenticationPolicyEntry) == 4);
 
 // Advance the cursor to the next non-empty path segment and return it. The
 // returned view is empty once the path is exhausted. Leading, trailing, and

--- a/enterprise/authentication/authentication_format.h
+++ b/enterprise/authentication/authentication_format.h
@@ -8,7 +8,7 @@
 namespace sourcemeta::one {
 
 constexpr std::uint32_t AUTHENTICATION_MAGIC{0x48545541};
-constexpr std::uint32_t AUTHENTICATION_VERSION{1};
+constexpr std::uint32_t AUTHENTICATION_VERSION{2};
 
 // The artifact begins with this header. Every variable-length section is
 // located through an absolute byte offset so the matcher can address it

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -4,15 +4,17 @@
 
 #include "authentication_format.h"
 
-#include <algorithm> // std::ranges::sort
-#include <cstddef>   // std::byte, std::size_t
-#include <cstdint>   // std::uint32_t, std::uint64_t, std::uint8_t
-#include <cstring>   // std::memcpy
-#include <span>      // std::span
-#include <stdexcept> // std::runtime_error
-#include <string>    // std::string
-#include <utility>   // std::pair
-#include <vector>    // std::vector
+#include <algorithm>   // std::ranges::sort
+#include <array>       // std::array
+#include <cstddef>     // std::byte, std::size_t
+#include <cstdint>     // std::uint32_t, std::uint64_t, std::uint8_t
+#include <cstring>     // std::memcpy
+#include <span>        // std::span
+#include <stdexcept>   // std::runtime_error
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::pair
+#include <vector>      // std::vector
 
 namespace {
 
@@ -38,6 +40,28 @@ auto find_or_create_child(std::vector<BuildNode> &nodes,
 
 auto align_to_word(const std::uint32_t offset) -> std::uint32_t {
   return (offset + 7U) & ~static_cast<std::uint32_t>(7U);
+}
+
+auto append_u32(std::vector<std::byte> &output, const std::uint32_t value)
+    -> void {
+  std::array<std::byte, sizeof(value)> bytes{};
+  std::memcpy(bytes.data(), &value, sizeof(value));
+  output.insert(output.end(), bytes.begin(), bytes.end());
+}
+
+auto encode_apikey_metadata(
+    const std::span<const std::string_view> environment_variables)
+    -> std::vector<std::byte> {
+  std::vector<std::byte> result;
+  append_u32(result, static_cast<std::uint32_t>(environment_variables.size()));
+  for (const auto variable : environment_variables) {
+    append_u32(result, static_cast<std::uint32_t>(variable.size()));
+    for (const char character : variable) {
+      result.push_back(static_cast<std::byte>(character));
+    }
+  }
+
+  return result;
 }
 
 } // namespace
@@ -121,18 +145,39 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
                                                     sizeof(AuthenticationEdge));
   header.strings_length = static_cast<std::uint32_t>(strings.size());
 
-  std::vector<std::byte> buffer(header.strings_offset + header.strings_length,
+  // The per-policy metadata is appended after the string blob and located by
+  // absolute offset, so the header layout stays fixed
+  const auto metadata_start{header.strings_offset + header.strings_length};
+  std::vector<AuthenticationPolicyEntry> policy_table;
+  policy_table.reserve(policies.size());
+  std::vector<std::byte> metadata;
+  for (const auto &policy : policies) {
+    const auto policy_metadata{policy.keys.empty()
+                                   ? std::vector<std::byte>{}
+                                   : encode_apikey_metadata(policy.keys)};
+    AuthenticationPolicyEntry entry{};
+    entry.metadata_offset =
+        metadata_start + static_cast<std::uint32_t>(metadata.size());
+    entry.metadata_length = static_cast<std::uint32_t>(policy_metadata.size());
+    entry.type = static_cast<std::uint8_t>(policy.type);
+    policy_table.push_back(entry);
+    metadata.insert(metadata.end(), policy_metadata.begin(),
+                    policy_metadata.end());
+  }
+
+  std::vector<std::byte> buffer(metadata_start +
+                                    static_cast<std::uint32_t>(metadata.size()),
                                 std::byte{0});
   std::memcpy(buffer.data(), &header, sizeof(header));
-  for (std::size_t index{0}; index < policies.size(); index += 1) {
-    buffer[header.policies_offset + index] =
-        static_cast<std::byte>(policies[index].type);
+  // The policy table, node, edge, string, and metadata sections are each empty
+  // in some valid artifacts, and an empty vector may expose a null data pointer
+  if (!policy_table.empty()) {
+    std::memcpy(buffer.data() + header.policies_offset, policy_table.data(),
+                policy_table.size() * sizeof(AuthenticationPolicyEntry));
   }
 
   std::memcpy(buffer.data() + header.nodes_offset, serialized.data(),
               serialized.size() * sizeof(AuthenticationNode));
-  // The edge and string sections are empty when no policy declares a nested
-  // prefix, and an empty vector may expose a null data pointer
   if (!edges.empty()) {
     std::memcpy(buffer.data() + header.edges_offset, edges.data(),
                 edges.size() * sizeof(AuthenticationEdge));
@@ -141,6 +186,11 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
   if (!strings.empty()) {
     std::memcpy(buffer.data() + header.strings_offset, strings.data(),
                 strings.size());
+  }
+
+  if (!metadata.empty()) {
+    std::memcpy(buffer.data() + metadata_start, metadata.data(),
+                metadata.size());
   }
 
   sourcemeta::core::write_file(path, buffer);

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -165,9 +165,8 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
                     policy_metadata.end());
   }
 
-  std::vector<std::byte> buffer(metadata_start +
-                                    static_cast<std::uint32_t>(metadata.size()),
-                                std::byte{0});
+  std::vector<std::byte> buffer(
+      static_cast<std::size_t>(metadata_start) + metadata.size(), std::byte{0});
   std::memcpy(buffer.data(), &header, sizeof(header));
   // The policy table, node, edge, string, and metadata sections are each empty
   // in some valid artifacts, and an empty vector may expose a null data pointer

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -46,7 +46,7 @@ TEST(Authentication, structurally_corrupt_artifact_denies_everything) {
   header[1] = 'U';
   header[2] = 'T';
   header[3] = 'H';
-  header[4] = 1;
+  header[4] = 2;
   stream.write(header.data(), header.size());
   stream.close();
 
@@ -65,7 +65,7 @@ TEST(Authentication, artifact_exceeding_the_policy_ceiling_denies_everything) {
   header[1] = 'U';
   header[2] = 'T';
   header[3] = 'H';
-  header[4] = 1;
+  header[4] = 2;
   header[8] =
       static_cast<char>(sourcemeta::one::Authentication::MAXIMUM_POLICIES + 1);
   header[12] = 1;

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -3,9 +3,10 @@
 #include <gtest/gtest.h>
 
 #include <array>       // std::array
-#include <cstddef>     // std::size_t
+#include <cstddef>     // std::byte, std::size_t
+#include <cstdlib>     // setenv
 #include <filesystem>  // std::filesystem::path
-#include <fstream>     // std::ofstream
+#include <fstream>     // std::ofstream, std::fstream
 #include <span>        // std::span
 #include <string>      // std::string
 #include <string_view> // std::string_view
@@ -219,30 +220,102 @@ TEST(Authentication, supports_the_maximum_number_of_policies) {
   EXPECT_FALSE(authentication.admits("/missing", "").allowed);
 }
 
-TEST(Authentication, apikey_policy_denies_every_credential) {
+TEST(Authentication, apikey_admits_matching_credential) {
+  setenv("ONE_TEST_KEY_MATCH", "secret-match", 1);
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_MATCH"}};
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{sourcemeta::one::Authentication::Type::ApiKey, paths}}};
-  const auto path{test_path("apikey_policy.bin")};
+      {{sourcemeta::one::Authentication::Type::ApiKey, paths, keys}}};
+  const auto path{test_path("apikey_match.bin")};
   sourcemeta::one::Authentication::save(policies, path);
 
   const sourcemeta::one::Authentication authentication{path};
-  EXPECT_FALSE(authentication.admits("/internal", "any-credential").allowed);
+  EXPECT_TRUE(authentication.admits("/internal/foo", "secret-match").allowed);
+  EXPECT_FALSE(authentication.admits("/internal/foo", "wrong").allowed);
   EXPECT_FALSE(authentication.admits("/internal/foo", "").allowed);
-  EXPECT_FALSE(authentication.admits("/internal/foo/bar", "secret").allowed);
+}
+
+TEST(Authentication, apikey_with_multiple_keys_admits_any) {
+  setenv("ONE_TEST_KEY_MULTI_A", "key-a", 1);
+  setenv("ONE_TEST_KEY_MULTI_B", "key-b", 1);
+  const std::array<std::string_view, 2> keys{
+      {"ONE_TEST_KEY_MULTI_A", "ONE_TEST_KEY_MULTI_B"}};
+  const std::array<std::string_view, 1> paths{{"/internal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::ApiKey, paths, keys}}};
+  const auto path{test_path("apikey_multi.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_TRUE(authentication.admits("/internal/foo", "key-a").allowed);
+  EXPECT_TRUE(authentication.admits("/internal/foo", "key-b").allowed);
+  EXPECT_FALSE(authentication.admits("/internal/foo", "key-c").allowed);
+}
+
+TEST(Authentication, apikey_with_unset_variable_denies) {
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_UNSET"}};
+  const std::array<std::string_view, 1> paths{{"/internal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::ApiKey, paths, keys}}};
+  const auto path{test_path("apikey_unset.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_FALSE(authentication.admits("/internal/foo", "anything").allowed);
+  EXPECT_FALSE(authentication.admits("/internal/foo", "").allowed);
+}
+
+TEST(Authentication, apikey_denies_uncovered_path) {
+  setenv("ONE_TEST_KEY_SCOPED", "scoped-secret", 1);
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_SCOPED"}};
+  const std::array<std::string_view, 1> paths{{"/internal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::ApiKey, paths, keys}}};
+  const auto path{test_path("apikey_scoped.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_TRUE(authentication.admits("/internal/foo", "scoped-secret").allowed);
+  EXPECT_FALSE(authentication.admits("/other", "scoped-secret").allowed);
 }
 
 TEST(Authentication, public_overrides_apikey_on_shared_path) {
+  setenv("ONE_TEST_KEY_SHARED", "shared-secret", 1);
   const std::array<std::string_view, 1> public_paths{{"/internal"}};
   const std::array<std::string_view, 1> apikey_paths{{"/internal"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_SHARED"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{sourcemeta::one::Authentication::Type::Public, public_paths},
-       {sourcemeta::one::Authentication::Type::ApiKey, apikey_paths}}};
+       {sourcemeta::one::Authentication::Type::ApiKey, apikey_paths, keys}}};
   const auto path{test_path("apikey_shared.bin")};
   sourcemeta::one::Authentication::save(policies, path);
 
-  // The public policy admits anonymously even though an apiKey policy governs
-  // the same path
   const sourcemeta::one::Authentication authentication{path};
+  // The public policy admits anonymously even without a credential
   EXPECT_TRUE(authentication.admits("/internal/foo", "").allowed);
+}
+
+TEST(Authentication, metadata_outside_its_region_denies_everything) {
+  setenv("ONE_TEST_KEY_REGION", "region-secret", 1);
+  const std::array<std::string_view, 1> public_paths{{"/public"}};
+  const std::array<std::string_view, 1> apikey_paths{{"/internal"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_REGION"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{sourcemeta::one::Authentication::Type::Public, public_paths},
+       {sourcemeta::one::Authentication::Type::ApiKey, apikey_paths, keys}}};
+  const auto path{test_path("metadata_region.bin")};
+  sourcemeta::one::Authentication::save(policies, path);
+
+  // Point the second policy's metadata offset, the first field of its entry at
+  // byte 52, into the policy table instead of the trailing metadata region
+  std::fstream stream{path, std::ios::binary | std::ios::in | std::ios::out};
+  stream.seekp(52);
+  const std::array<char, 4> aliased{};
+  stream.write(aliased.data(), aliased.size());
+  stream.close();
+
+  // The whole artifact is rejected, so even the untouched public policy denies
+  const sourcemeta::one::Authentication authentication{path};
+  EXPECT_FALSE(authentication.admits("/public/foo", "").allowed);
+  EXPECT_FALSE(authentication.admits("/internal/foo", "region-secret").allowed);
 }

--- a/src/authentication/CMakeLists.txt
+++ b/src/authentication/CMakeLists.txt
@@ -3,6 +3,7 @@ if(ONE_ENTERPRISE)
     SOURCES
       "${PROJECT_SOURCE_DIR}/enterprise/authentication/authentication.cc"
       "${PROJECT_SOURCE_DIR}/enterprise/authentication/authentication_save.cc")
+  target_compile_definitions(sourcemeta_one_authentication PUBLIC SOURCEMETA_ONE_ENTERPRISE)
 else()
   sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME authentication
     SOURCES authentication.cc)

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -23,6 +23,7 @@ public:
   struct Policy {
     Type type;
     std::span<const std::string_view> paths;
+    std::span<const std::string_view> keys{};
   };
 
   struct Verdict {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

