### PR TITLE
Properly make use of `Cache-Control: private`

### DIFF
--- a/enterprise/e2e/auth/hurl/directory.all.hurl
+++ b/enterprise/e2e/auth/hurl/directory.all.hurl
@@ -37,6 +37,7 @@ WWW-Authenticate: Bearer realm="registry"
 GET {{base}}/self/v1/api/list/private
 Authorization: Bearer primary-secret-key
 HTTP 200
+Cache-Control: private, max-age=0, must-revalidate
 Content-Type: application/json
 Link: </self/v1/schemas/api/list/response>; rel="describedby"
 [Captures]
@@ -88,6 +89,7 @@ GET {{base}}/private/
 Accept: text/html
 Authorization: Bearer primary-secret-key
 HTTP 200
+Cache-Control: private, max-age=0, must-revalidate
 [Asserts]
 header "Content-Type" contains "text/html"
 

--- a/enterprise/e2e/auth/hurl/metapack.all.hurl
+++ b/enterprise/e2e/auth/hurl/metapack.all.hurl
@@ -56,10 +56,12 @@ HTTP 200
 [Asserts]
 jsonpath "$.valid" == true
 
-# With the right credential the apiKey schema's health is served and validates
+# With the right credential the apiKey schema's health is served and validates,
+# marked private so shared caches do not store it
 GET {{base}}/self/v1/api/schemas/health/private/secret
 Authorization: Bearer primary-secret-key
 HTTP 200
+Cache-Control: private, max-age=0, must-revalidate
 Content-Type: application/json
 Link: </self/v1/schemas/api/schemas/health/response>; rel="describedby"
 [Captures]
@@ -80,6 +82,7 @@ jsonpath "$.valid" == true
 GET {{base}}/self/v1/api/schemas/locations/private/secret
 Authorization: Bearer primary-secret-key
 HTTP 200
+Cache-Control: private, max-age=0, must-revalidate
 Content-Type: application/json
 Link: </self/v1/schemas/api/schemas/locations/response>; rel="describedby"
 [Captures]

--- a/enterprise/e2e/auth/hurl/schema-html.all.hurl
+++ b/enterprise/e2e/auth/hurl/schema-html.all.hurl
@@ -18,11 +18,13 @@ WWW-Authenticate: Bearer realm="registry"
 xpath "string(//title)" == "Unauthorized"
 xpath "string(//h2[@class='fw-bold'])" == "This page requires authentication"
 
-# apiKey schema HTML is served with the credential
+# apiKey schema HTML is served with the credential, marked private so shared
+# caches do not store it
 GET {{base}}/private/secret
 Accept: text/html
 Authorization: Bearer primary-secret-key
 HTTP 200
+Cache-Control: private, max-age=0, must-revalidate
 [Asserts]
 header "Content-Type" contains "text/html"
 

--- a/enterprise/e2e/auth/hurl/schema.all.hurl
+++ b/enterprise/e2e/auth/hurl/schema.all.hurl
@@ -32,11 +32,12 @@ Access-Control-Allow-Origin: *
   "detail": "This resource requires authentication"
 }
 
-# The primary key admits the apiKey schema
+# The primary key admits the apiKey schema, and the response is marked private
+# so that shared caches do not store it
 GET {{base}}/private/secret.json
 Authorization: Bearer primary-secret-key
 HTTP 200
-Cache-Control: public, max-age=0, must-revalidate
+Cache-Control: private, max-age=0, must-revalidate
 Content-Type: application/schema+json
 Link: <https://json-schema.org/draft/2020-12/schema>; rel="describedby"
 Access-Control-Allow-Origin: *
@@ -60,6 +61,7 @@ header "ETag" exists
 GET {{base}}/private/secret.json
 Authorization: Bearer secondary-secret-key
 HTTP 200
+Cache-Control: private, max-age=0, must-revalidate
 Content-Type: application/schema+json
 Access-Control-Allow-Origin: *
 [Asserts]
@@ -95,6 +97,7 @@ WWW-Authenticate: Bearer realm="registry"
 GET {{base}}/reports/quarterly.json
 Authorization: Bearer primary-secret-key
 HTTP 200
+Cache-Control: private, max-age=0, must-revalidate
 Content-Type: application/schema+json
 Link: <https://json-schema.org/draft/2020-12/schema>; rel="describedby"
 Access-Control-Allow-Origin: *
@@ -117,6 +120,7 @@ WWW-Authenticate: Bearer realm="registry"
 GET {{base}}/internal/config.json
 Authorization: Bearer internal-secret-key
 HTTP 200
+Cache-Control: private, max-age=0, must-revalidate
 Content-Type: application/schema+json
 Access-Control-Allow-Origin: *
 {
@@ -149,10 +153,12 @@ header "ETag" exists
   "type": "boolean"
 }
 
-# Public access wins even when a credential is also supplied
+# Public access wins even when a credential is also supplied, so the response
+# stays publicly cacheable
 GET {{base}}/private/open/shared.json
 Authorization: Bearer primary-secret-key
 HTTP 200
+Cache-Control: public, max-age=0, must-revalidate
 Content-Type: application/schema+json
 [Asserts]
 jsonpath "$.type" == "boolean"

--- a/enterprise/e2e/auth/hurl/unauthorized.all.hurl
+++ b/enterprise/e2e/auth/hurl/unauthorized.all.hurl
@@ -65,7 +65,7 @@ jsonpath "$.valid" == true
 GET {{base}}/private/secret.json
 Authorization: Bearer primary-secret-key
 HTTP 200
-Cache-Control: public, max-age=0, must-revalidate
+Cache-Control: private, max-age=0, must-revalidate
 Content-Type: application/schema+json
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: Link, ETag
@@ -169,7 +169,7 @@ GET {{base}}/private/secret
 Accept: text/html
 Authorization: Bearer primary-secret-key
 HTTP 200
-Cache-Control: public, max-age=0, must-revalidate
+Cache-Control: private, max-age=0, must-revalidate
 [Asserts]
 header "Content-Type" contains "text/html"
 xpath "string(//title)" != "Unauthorized"

--- a/src/actions/action_default_v1.h
+++ b/src/actions/action_default_v1.h
@@ -113,11 +113,12 @@ public:
         }
         if (root_html.outcome ==
             sourcemeta::one::ArtifactResolution::Outcome::Found) {
-          this->artifact_serve(
-              root_html.path.value(), sourcemeta::core::HTTP_STATUS_OK, false,
-              {}, {}, HTML_BROWSER_SECURITY, request, response,
-              this->error_schema_, "public, max-age=0, must-revalidate",
-              "Accept, Accept-Encoding");
+          this->artifact_serve(root_html.path.value(),
+                               sourcemeta::core::HTTP_STATUS_OK, false, {}, {},
+                               HTML_BROWSER_SECURITY, request, response,
+                               this->error_schema_,
+                               this->content_cache_control(root_html.is_public),
+                               "Accept, Accept-Encoding");
           return;
         }
       }
@@ -158,14 +159,16 @@ public:
           this->artifact_serve(
               schema_html.path.value(), sourcemeta::core::HTTP_STATUS_OK, false,
               {}, {}, HTML_BROWSER_SECURITY, request, response,
-              this->error_schema_, "public, max-age=0, must-revalidate",
+              this->error_schema_,
+              this->content_cache_control(schema_html.is_public),
               "Accept, Accept-Encoding");
         } else if (directory_html.outcome ==
                    sourcemeta::one::ArtifactResolution::Outcome::Found) {
           this->artifact_serve(
               directory_html.path.value(), sourcemeta::core::HTTP_STATUS_OK,
               false, {}, {}, HTML_BROWSER_SECURITY, request, response,
-              this->error_schema_, "public, max-age=0, must-revalidate",
+              this->error_schema_,
+              this->content_cache_control(directory_html.is_public),
               "Accept, Accept-Encoding");
         } else {
           const auto not_found{this->artifact_resolve_path_unauthenticated(

--- a/src/actions/action_dependency_tree_v1.h
+++ b/src/actions/action_dependency_tree_v1.h
@@ -99,7 +99,7 @@ public:
     this->artifact_serve(
         resolution.path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
         this->response_schema_, {}, request, response, this->error_schema_,
-        "public, max-age=0, must-revalidate", "Accept-Encoding");
+        this->content_cache_control(resolution.is_public), "Accept-Encoding");
   }
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,

--- a/src/actions/action_jsonschema_serve_v1.h
+++ b/src/actions/action_jsonschema_serve_v1.h
@@ -87,7 +87,8 @@ public:
         resolution.path.value(), sourcemeta::core::HTTP_STATUS_OK, true,
         is_deno ? std::string_view{"application/json"} : std::string_view{}, {},
         {}, request, response, error_schema,
-        "public, max-age=0, must-revalidate", "User-Agent, Accept-Encoding");
+        self.content_cache_control(resolution.is_public),
+        "User-Agent, Accept-Encoding");
   }
 
   auto rest(const std::span<std::string_view> matches,

--- a/src/actions/action_list_directory_v1.h
+++ b/src/actions/action_list_directory_v1.h
@@ -78,7 +78,7 @@ public:
     this->artifact_serve(
         resolution.path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
         this->response_schema_, {}, request, response, this->error_schema_,
-        "public, max-age=0, must-revalidate", "Accept-Encoding");
+        this->content_cache_control(resolution.is_public), "Accept-Encoding");
   }
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,

--- a/src/actions/action_serve_explorer_artifact_v1.h
+++ b/src/actions/action_serve_explorer_artifact_v1.h
@@ -88,7 +88,7 @@ public:
     this->artifact_serve(
         resolution.path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
         this->response_schema_, {}, request, response, this->error_schema_,
-        "public, max-age=0, must-revalidate", "Accept-Encoding");
+        this->content_cache_control(resolution.is_public), "Accept-Encoding");
   }
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,

--- a/src/actions/action_serve_schema_artifact_v1.h
+++ b/src/actions/action_serve_schema_artifact_v1.h
@@ -95,7 +95,7 @@ public:
     this->artifact_serve(
         resolution.path.value(), sourcemeta::core::HTTP_STATUS_OK, true, {},
         this->response_schema_, {}, request, response, this->error_schema_,
-        "public, max-age=0, must-revalidate", "Accept-Encoding");
+        this->content_cache_control(resolution.is_public), "Accept-Encoding");
   }
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,

--- a/src/router/artifact.cc
+++ b/src/router/artifact.cc
@@ -131,15 +131,20 @@ auto RouterAction::artifact_resolve_path(
   const auto &authentication{this->dispatcher_.authentication()};
   const auto registry_path{relative.generic_string()};
   const auto verdict{authentication.admits(registry_path, credential)};
+  // Nothing is served on a denial or a miss, so report the path as not public
+  // and let any caller that skips the outcome check fall back to a private
+  // caching directive rather than a public one
   if (!verdict.allowed) {
     return {.outcome = ArtifactResolution::Outcome::Denied,
-            .path = std::nullopt};
+            .path = std::nullopt,
+            .is_public = false};
   }
 
   auto located{this->artifact_locate(input, tree, artifact_name)};
   if (!located.has_value()) {
     return {.outcome = ArtifactResolution::Outcome::NotFound,
-            .path = std::nullopt};
+            .path = std::nullopt,
+            .is_public = false};
   }
 
   // An empty credential admitted here means the path is open to anonymous

--- a/src/router/artifact.cc
+++ b/src/router/artifact.cc
@@ -129,8 +129,8 @@ auto RouterAction::artifact_resolve_path(
   }
 
   const auto &authentication{this->dispatcher_.authentication()};
-  const auto verdict{
-      authentication.admits(relative.generic_string(), credential)};
+  const auto registry_path{relative.generic_string()};
+  const auto verdict{authentication.admits(registry_path, credential)};
   if (!verdict.allowed) {
     return {.outcome = ArtifactResolution::Outcome::Denied,
             .path = std::nullopt};
@@ -142,8 +142,13 @@ auto RouterAction::artifact_resolve_path(
             .path = std::nullopt};
   }
 
+  // An empty credential admitted here means the path is open to anonymous
+  // callers, otherwise its public reach is checked without the credential
+  const auto is_public{credential.empty() ||
+                       authentication.admits(registry_path, {}).allowed};
   return {.outcome = ArtifactResolution::Outcome::Found,
-          .path = ResolvedArtifact{std::move(located).value()}};
+          .path = ResolvedArtifact{std::move(located).value()},
+          .is_public = is_public};
 }
 
 auto RouterAction::artifact_resolve_path_unauthenticated(

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -50,6 +50,9 @@ struct ArtifactResolution {
   enum class Outcome : std::uint8_t { Found, NotFound, Denied };
   Outcome outcome{Outcome::NotFound};
   std::optional<ResolvedArtifact> path;
+  // Whether the path is served to anonymous callers, as opposed to admitted
+  // only because the caller presented a matching credential
+  bool is_public{true};
 };
 
 class RouterAction {
@@ -110,6 +113,15 @@ public:
                                            std::string_view input, Tree tree,
                                            std::string_view artifact_name) const
       -> ArtifactResolution;
+
+  // The caching directive for served registry content. A response admitted
+  // only via a credential must not be stored by shared caches, so it is
+  // marked private rather than public
+  [[nodiscard]] static auto content_cache_control(const bool is_public) noexcept
+      -> std::string_view {
+    return is_public ? "public, max-age=0, must-revalidate"
+                     : "private, max-age=0, must-revalidate";
+  }
 
   [[nodiscard]] auto artifact_read_json(const ResolvedArtifact &artifact) const
       -> std::optional<sourcemeta::core::JSON>;


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

