### PR TITLE
Treat URL extensions as content negotiation in authentication matching

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -10,6 +10,7 @@
 #include <cstdlib>       // std::getenv
 #include <cstring>       // std::memcpy
 #include <filesystem>    // std::filesystem::path
+#include <limits>        // std::numeric_limits
 #include <memory>        // std::unique_ptr, std::make_unique
 #include <mutex>         // std::mutex, std::lock_guard
 #include <optional>      // std::optional
@@ -21,6 +22,49 @@
 #include <utility>       // std::move
 
 namespace {
+
+constexpr std::uint32_t NO_CHILD{std::numeric_limits<std::uint32_t>::max()};
+
+// A base that is not a whole-segment prefix is left in place, where it matches
+// no policy and is denied
+auto strip_base_path(const std::string_view path,
+                     const std::string_view base) noexcept -> std::string_view {
+  if (base.empty() || !path.starts_with(base)) {
+    return path;
+  }
+
+  auto remainder{path};
+  remainder.remove_prefix(base.size());
+  if (remainder.empty() || base.back() == '/' || remainder.front() == '/') {
+    return remainder;
+  }
+
+  return path;
+}
+
+auto find_child(const sourcemeta::one::AuthenticationNode &node,
+                const sourcemeta::one::AuthenticationEdge *edges,
+                const char *strings, const std::string_view segment) noexcept
+    -> std::uint32_t {
+  std::uint32_t low{node.first_edge};
+  std::uint32_t high{node.first_edge + node.edge_count};
+  while (low < high) {
+    const auto middle{low + ((high - low) / 2)};
+    const auto &edge{edges[middle]};
+    const std::string_view value{strings + edge.segment_offset,
+                                 edge.segment_length};
+    const auto comparison{value.compare(segment)};
+    if (comparison == 0) {
+      return edge.child;
+    } else if (comparison < 0) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+
+  return NO_CHILD;
+}
 
 // The artifact is produced by a trusted indexer, but on-disk truncation or
 // corruption could leave a header whose magic and version still match while
@@ -283,30 +327,29 @@ struct Authentication::Impl {
          segment = authentication_next_segment(registry_path, cursor)) {
       const auto &node{nodes[current]};
 
-      // A node's edges are serialized contiguously and sorted by segment, so
-      // the matching child is found with a binary search
-      std::uint32_t low{node.first_edge};
-      std::uint32_t high{node.first_edge + node.edge_count};
-      bool descended{false};
-      while (low < high) {
-        const auto middle{low + ((high - low) / 2)};
-        const auto &edge{edges[middle]};
-        const std::string_view value{this->strings_ + edge.segment_offset,
-                                     edge.segment_length};
-        const auto comparison{value.compare(segment)};
-        if (comparison == 0) {
-          current = edge.child;
-          result |= nodes[current].mask;
-          descended = true;
-          break;
-        } else if (comparison < 0) {
-          low = middle + 1;
-        } else {
-          high = middle;
-        }
+      // An extension is content negotiation, so a representation also matches
+      // the extensionless resource policy, and union semantics admit both
+      const auto exact{find_child(node, edges, this->strings_, segment)};
+      auto stem{NO_CHILD};
+      const auto extension{segment.rfind('.')};
+      if (extension != std::string_view::npos && extension > 0) {
+        stem = find_child(node, edges, this->strings_,
+                          segment.substr(0, extension));
       }
 
-      if (!descended) {
+      if (exact != NO_CHILD) {
+        result |= nodes[exact].mask;
+      }
+
+      if (stem != NO_CHILD) {
+        result |= nodes[stem].mask;
+      }
+
+      if (exact != NO_CHILD) {
+        current = exact;
+      } else if (stem != NO_CHILD) {
+        current = stem;
+      } else {
         break;
       }
     }
@@ -432,9 +475,11 @@ Authentication::Authentication(const std::filesystem::path &path)
 Authentication::~Authentication() = default;
 
 auto Authentication::admits(const std::string_view registry_path,
-                            const std::string_view credential) const
+                            const std::string_view credential,
+                            const std::string_view base_path) const
     -> Authentication::Verdict {
-  return {.allowed = this->impl_->admits(registry_path, credential)};
+  return {.allowed = this->impl_->admits(
+              strip_base_path(registry_path, base_path), credential)};
 }
 
 auto Authentication::reference_permitted(

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -322,19 +322,24 @@ struct Authentication::Impl {
     PolicySet result{nodes[0].mask};
     std::uint32_t current{0};
     std::size_t cursor{0};
-    for (auto segment{authentication_next_segment(registry_path, cursor)};
-         !segment.empty();
-         segment = authentication_next_segment(registry_path, cursor)) {
+    auto segment{authentication_next_segment(registry_path, cursor)};
+    while (!segment.empty()) {
+      auto lookahead{cursor};
+      const auto next{authentication_next_segment(registry_path, lookahead)};
       const auto &node{nodes[current]};
 
-      // An extension is content negotiation, so a representation also matches
-      // the extensionless resource policy, and union semantics admit both
       const auto exact{find_child(node, edges, this->strings_, segment)};
+      // An extension is content negotiation on the resource itself, so only the
+      // terminal segment also matches the extensionless resource policy, with
+      // union semantics admitting both. An intermediate dotted segment is a
+      // distinct directory and must not inherit its stem's policies
       auto stem{NO_CHILD};
-      const auto extension{segment.rfind('.')};
-      if (extension != std::string_view::npos && extension > 0) {
-        stem = find_child(node, edges, this->strings_,
-                          segment.substr(0, extension));
+      if (next.empty()) {
+        const auto extension{segment.rfind('.')};
+        if (extension != std::string_view::npos && extension > 0) {
+          stem = find_child(node, edges, this->strings_,
+                            segment.substr(0, extension));
+        }
       }
 
       if (exact != NO_CHILD) {
@@ -352,6 +357,9 @@ struct Authentication::Impl {
       } else {
         break;
       }
+
+      segment = next;
+      cursor = lookahead;
     }
 
     return result;

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -231,6 +231,25 @@ TEST(Authentication,
       authentication.admits("/secret/data.xml", "specific-secret").allowed);
 }
 
+TEST(Authentication, extension_handling_is_confined_to_the_terminal_segment) {
+  const std::array<std::string_view, 1> paths{{"/v1"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::Public, paths}}};
+  const auto path{test_path("intermediate_dot.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{path};
+  // The policy on /v1 governs its own subtree
+  EXPECT_TRUE(authentication.admits("/v1", "").allowed);
+  EXPECT_TRUE(authentication.admits("/v1/secret", "").allowed);
+  // As a terminal segment, /v1.0 is a representation of /v1 under the
+  // content-negotiation rule, the same way /person.json represents /person
+  EXPECT_TRUE(authentication.admits("/v1.0", "").allowed);
+  // But as an intermediate segment it is a distinct directory that must not
+  // descend into the /v1 subtree, so its children do not inherit the policy
+  EXPECT_FALSE(authentication.admits("/v1.0/secret", "").allowed);
+}
+
 TEST(Authentication, representation_agnostic_and_specific_policies_compose) {
   const std::array<std::string_view, 1> resource{{"/docs/page"}};
   const std::array<std::string_view, 1> representation{{"/docs/page.pdf"}};

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -168,6 +168,129 @@ TEST(Authentication, single_policy_with_multiple_prefixes) {
   EXPECT_FALSE(authentication.admits("/public", "").allowed);
 }
 
+TEST(Authentication, extensionless_policy_covers_every_representation) {
+  const std::array<std::string_view, 1> paths{{"/secret/data"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_REPRESENTATION"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::ApiKey, paths, keys}}};
+  const auto path{test_path("representation_agnostic.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  setenv("ONE_TEST_KEY_REPRESENTATION", "representation-secret", 1);
+
+  const sourcemeta::one::Authentication authentication{path};
+  // The resource, every representation of it, and its subtree are all governed
+  EXPECT_FALSE(authentication.admits("/secret/data", "").allowed);
+  EXPECT_FALSE(authentication.admits("/secret/data.json", "").allowed);
+  EXPECT_FALSE(authentication.admits("/secret/data.xml", "").allowed);
+  EXPECT_FALSE(authentication.admits("/secret/data/nested", "").allowed);
+  EXPECT_TRUE(
+      authentication.admits("/secret/data", "representation-secret").allowed);
+  EXPECT_TRUE(
+      authentication.admits("/secret/data.json", "representation-secret")
+          .allowed);
+  EXPECT_TRUE(authentication.admits("/secret/data.xml", "representation-secret")
+                  .allowed);
+  EXPECT_TRUE(
+      authentication.admits("/secret/data/nested", "representation-secret")
+          .allowed);
+  // A sibling resource sharing a textual prefix is outside the policy, so even
+  // the key does not admit it (it is governed by no policy at all)
+  EXPECT_FALSE(
+      authentication.admits("/secret/database", "representation-secret")
+          .allowed);
+  EXPECT_FALSE(
+      authentication.admits("/secret/data2.json", "representation-secret")
+          .allowed);
+}
+
+TEST(Authentication,
+     extension_specific_policy_covers_only_that_representation) {
+  const std::array<std::string_view, 1> paths{{"/secret/data.json"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_SPECIFIC"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{sourcemeta::one::Authentication::Type::ApiKey, paths, keys}}};
+  const auto path{test_path("representation_specific.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  setenv("ONE_TEST_KEY_SPECIFIC", "specific-secret", 1);
+
+  const sourcemeta::one::Authentication authentication{path};
+  // Only the named representation is gated
+  EXPECT_FALSE(authentication.admits("/secret/data.json", "").allowed);
+  EXPECT_TRUE(
+      authentication.admits("/secret/data.json", "specific-secret").allowed);
+  EXPECT_TRUE(
+      authentication.admits("/secret/data.json/nested", "specific-secret")
+          .allowed);
+  // The bare resource and other representations are outside this policy, so
+  // the key does not admit them either
+  EXPECT_FALSE(
+      authentication.admits("/secret/data", "specific-secret").allowed);
+  EXPECT_FALSE(
+      authentication.admits("/secret/data.xml", "specific-secret").allowed);
+}
+
+TEST(Authentication, representation_agnostic_and_specific_policies_compose) {
+  const std::array<std::string_view, 1> resource{{"/docs/page"}};
+  const std::array<std::string_view, 1> representation{{"/docs/page.pdf"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_PDF"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{sourcemeta::one::Authentication::Type::Public, resource},
+       {sourcemeta::one::Authentication::Type::ApiKey, representation, keys}}};
+  const auto path{test_path("representation_compose.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  setenv("ONE_TEST_KEY_PDF", "pdf-secret", 1);
+
+  const sourcemeta::one::Authentication authentication{path};
+  // The public resource policy admits the resource and its representations,
+  // including the pdf, since union semantics let public win over the apiKey
+  EXPECT_TRUE(authentication.admits("/docs/page", "").allowed);
+  EXPECT_TRUE(authentication.admits("/docs/page.html", "").allowed);
+  EXPECT_TRUE(authentication.admits("/docs/page.pdf", "").allowed);
+}
+
+TEST(Authentication, base_path_is_stripped_before_matching) {
+  const std::array<std::string_view, 1> public_paths{{"/public"}};
+  const std::array<std::string_view, 1> apikey_paths{{"/private"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_BASE"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{sourcemeta::one::Authentication::Type::Public, public_paths},
+       {sourcemeta::one::Authentication::Type::ApiKey, apikey_paths, keys}}};
+  const auto path{test_path("base_path.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  setenv("ONE_TEST_KEY_BASE", "base-secret", 1);
+
+  const sourcemeta::one::Authentication authentication{path};
+  // With the base path stripped, the registry path under it is matched
+  EXPECT_TRUE(authentication.admits("/registry/public/string", "", "/registry")
+                  .allowed);
+  EXPECT_FALSE(
+      authentication.admits("/registry/private/secret", "", "/registry")
+          .allowed);
+  EXPECT_TRUE(
+      authentication
+          .admits("/registry/private/secret", "base-secret", "/registry")
+          .allowed);
+
+  // An empty base path strips nothing
+  EXPECT_TRUE(authentication.admits("/public/string", "", "").allowed);
+  EXPECT_FALSE(authentication.admits("/private/secret", "", "").allowed);
+
+  // A base path that is not a whole-segment prefix is left in place, so the
+  // path matches no policy and is denied
+  EXPECT_FALSE(
+      authentication.admits("/registryextra/public/string", "", "/registry")
+          .allowed);
+
+  // A request outside the base path is left in place and matches no policy
+  EXPECT_FALSE(
+      authentication.admits("/elsewhere/public/string", "", "/registry")
+          .allowed);
+}
+
 TEST(Authentication, corrupted_section_offset_denies_everything) {
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -23,7 +23,7 @@ Authentication::Authentication(const std::filesystem::path &) {}
 
 Authentication::~Authentication() = default;
 
-auto Authentication::admits(const std::string_view,
+auto Authentication::admits(const std::string_view, const std::string_view,
                             const std::string_view) const
     -> Authentication::Verdict {
   return {.allowed = true};

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -103,8 +103,11 @@ public:
   auto operator=(const Authentication &) -> Authentication & = delete;
   auto operator=(Authentication &&) -> Authentication & = delete;
 
+  // A non-empty base path is stripped off the input before matching, turning a
+  // request URL path into a registry path
   [[nodiscard]] auto admits(std::string_view registry_path,
-                            std::string_view credential) const -> Verdict;
+                            std::string_view credential,
+                            std::string_view base_path = {}) const -> Verdict;
 
   [[nodiscard]] auto reference_permitted(std::string_view referrer_path,
                                          std::string_view referent_path) const


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

