### PR TITLE
Render a lock icon for private directories in the UI

### DIFF
--- a/enterprise/e2e/auth/hurl/directory.all.hurl
+++ b/enterprise/e2e/auth/hurl/directory.all.hurl
@@ -207,6 +207,9 @@ HTTP 200
 Cache-Control: private, max-age=0, must-revalidate
 [Asserts]
 header "Content-Type" contains "text/html"
+# Inside the gated collection nothing adds a new policy, so there is no further
+# barrier: the lock sits only at the boundary, never repeated within
+xpath "count(//i[contains(@class, 'bi-lock-fill')])" == 0
 
 # The HTML rendering of the nested directory is gated identically
 GET {{base}}/private/open/
@@ -226,7 +229,10 @@ Cache-Control: private, max-age=0, must-revalidate
 [Asserts]
 header "Content-Type" contains "text/html"
 
-# The HTML rendering of the public root lists anonymously, never the 401 page
+# The HTML rendering of the public root lists anonymously, never the 401 page.
+# A child whose governing policies differ from the root is an authentication
+# barrier, shown with a lock instead of the plain folder icon, while a child that
+# shares the root's public scope keeps the folder
 GET {{base}}/
 Accept: text/html
 HTTP 200
@@ -234,3 +240,11 @@ Cache-Control: public, max-age=0, must-revalidate
 [Asserts]
 header "Content-Type" contains "text/html"
 xpath "string(//title)" != "Unauthorized"
+xpath "count(//i[contains(@class, 'bi-lock-fill')])" == 3
+xpath "count(//i[contains(@class, 'bi-folder-fill')])" == 3
+xpath "count(//tr[.//a[normalize-space(.) = 'private']]//i[contains(@class, 'bi-lock-fill')])" == 1
+xpath "count(//tr[.//a[normalize-space(.) = 'internal']]//i[contains(@class, 'bi-lock-fill')])" == 1
+xpath "count(//tr[.//a[normalize-space(.) = 'reports']]//i[contains(@class, 'bi-lock-fill')])" == 1
+xpath "count(//tr[.//a[normalize-space(.) = 'public']]//i[contains(@class, 'bi-lock-fill')])" == 0
+xpath "count(//tr[.//a[normalize-space(.) = 'public']]//i[contains(@class, 'bi-folder-fill')])" == 1
+xpath "count(//tr[.//a[normalize-space(.) = 'orphan']]//i[contains(@class, 'bi-folder-fill')])" == 1

--- a/src/web/helpers.h
+++ b/src/web/helpers.h
@@ -233,13 +233,18 @@ inline auto make_directory_header(sourcemeta::core::HTMLWriter &writer,
 }
 
 inline auto make_file_manager_row(sourcemeta::core::HTMLWriter &writer,
-                                  const sourcemeta::core::JSON &entry) -> void {
+                                  const sourcemeta::core::JSON &entry,
+                                  const bool barrier) -> void {
   writer.tr();
 
   // Type column
   writer.td().attribute("class", "text-nowrap");
   if (entry.at("type").to_string() == "directory") {
-    if (entry.defines("github") && !entry.at("github").includes('/')) {
+    // A child whose governing policies differ from the directory being listed
+    // is an authentication barrier, shown with a lock instead of a folder
+    if (barrier) {
+      writer.i().attribute("class", "bi bi-lock-fill text-warning").close();
+    } else if (entry.defines("github") && !entry.at("github").includes('/')) {
       writer.img()
           .attribute("src", "https://github.com/" +
                                 entry.at("github").to_string() + ".png?size=80")
@@ -341,6 +346,7 @@ inline auto make_file_manager(sourcemeta::core::HTMLWriter &writer,
 
   const auto self_path{base_path + "/self"};
   const auto self_path_slash{base_path + "/self/"};
+  const auto &policies{directory.at("policies")};
 
   writer.div().attribute("class", "container-fluid p-4 flex-grow-1");
 
@@ -356,7 +362,7 @@ inline auto make_file_manager(sourcemeta::core::HTMLWriter &writer,
         has_regular_entries = true;
       }
 
-      make_file_manager_row(writer, entry);
+      make_file_manager_row(writer, entry, entry.at("policies") != policies);
     }
   }
 
@@ -375,7 +381,7 @@ inline auto make_file_manager(sourcemeta::core::HTMLWriter &writer,
           "class", "table table-bordered border-light-subtle table-light");
       make_file_manager_table_header(writer);
       writer.tbody();
-      make_file_manager_row(writer, entry);
+      make_file_manager_row(writer, entry, entry.at("policies") != policies);
       writer.close();
       writer.close();
       break;


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

