### PR TITLE
Introduce a sealed session value primitive in preparation for SSO

### DIFF
--- a/enterprise/authentication/session.cc
+++ b/enterprise/authentication/session.cc
@@ -77,6 +77,12 @@ auto session_open(const std::string_view value,
                   const std::span<const std::string_view> secrets,
                   const std::chrono::sys_seconds now)
     -> std::optional<std::string> {
+  // Expiry comparisons are meaningless under a clock that reads before the
+  // epoch, so such a clock validates nothing
+  if (now.time_since_epoch().count() < 0) {
+    return std::nullopt;
+  }
+
   const auto version_end{value.find('.')};
   if (version_end == std::string_view::npos) {
     return std::nullopt;

--- a/enterprise/authentication/session.cc
+++ b/enterprise/authentication/session.cc
@@ -1,0 +1,134 @@
+#include <sourcemeta/one/authentication_session.h>
+
+#include <sourcemeta/core/crypto.h>
+
+#include <array>       // std::array
+#include <charconv>    // std::from_chars, std::errc
+#include <chrono>      // std::chrono::sys_seconds, std::chrono::seconds
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::int64_t, std::uint64_t, std::uint8_t
+#include <limits>      // std::numeric_limits
+#include <optional>    // std::optional, std::nullopt
+#include <span>        // std::span
+#include <string>      // std::string, std::to_string
+#include <string_view> // std::string_view
+
+namespace {
+
+// The version prefix lets the sealed format evolve without a value produced
+// under one format ever verifying under another
+constexpr std::string_view SESSION_VERSION{"1"};
+
+constexpr std::size_t SESSION_SIGNATURE_LENGTH{32};
+
+auto digest_view(const std::array<std::uint8_t, 32> &digest)
+    -> std::string_view {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  return {reinterpret_cast<const char *>(digest.data()), digest.size()};
+}
+
+auto parse_expiry(const std::string_view input)
+    -> std::optional<std::chrono::sys_seconds> {
+  if (input.empty()) {
+    return std::nullopt;
+  }
+
+  std::uint64_t count{0};
+  const auto *begin{input.data()};
+  const auto *end{input.data() + input.size()};
+  const auto result{std::from_chars(begin, end, count)};
+  if (result.ec != std::errc{} || result.ptr != end ||
+      count > static_cast<std::uint64_t>(
+                  std::numeric_limits<std::int64_t>::max())) {
+    return std::nullopt;
+  }
+
+  return std::chrono::sys_seconds{
+      std::chrono::seconds{static_cast<std::int64_t>(count)}};
+}
+
+} // namespace
+
+namespace sourcemeta::one {
+
+auto session_seal(const std::string_view payload, const std::string_view secret,
+                  const std::chrono::sys_seconds expiry) -> std::string {
+  std::string result{SESSION_VERSION};
+  result += '.';
+  result += std::to_string(expiry.time_since_epoch().count());
+  result += '.';
+  result += sourcemeta::core::base64url_encode(payload);
+  const auto digest{sourcemeta::core::hmac_sha256_digest(secret, result)};
+  result += '.';
+  result += sourcemeta::core::base64url_encode(digest_view(digest));
+  return result;
+}
+
+auto session_open(const std::string_view value,
+                  const std::span<const std::string_view> secrets,
+                  const std::chrono::sys_seconds now)
+    -> std::optional<std::string> {
+  const auto version_end{value.find('.')};
+  if (version_end == std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  const auto expiry_end{value.find('.', version_end + 1)};
+  if (expiry_end == std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  const auto payload_end{value.find('.', expiry_end + 1)};
+  if (payload_end == std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  const auto signature{value.substr(payload_end + 1)};
+  if (signature.find('.') != std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  if (value.substr(0, version_end) != SESSION_VERSION) {
+    return std::nullopt;
+  }
+
+  const auto expiry{parse_expiry(
+      value.substr(version_end + 1, expiry_end - version_end - 1))};
+  if (!expiry.has_value()) {
+    return std::nullopt;
+  }
+
+  const auto presented{sourcemeta::core::base64url_decode(signature)};
+  if (!presented.has_value() ||
+      presented.value().size() != SESSION_SIGNATURE_LENGTH) {
+    return std::nullopt;
+  }
+
+  // The signature covers everything before it, so the expiry and the payload
+  // are bound together and neither can be transplanted from another value
+  const auto signing_input{value.substr(0, payload_end)};
+  auto authentic{false};
+  for (const auto secret : secrets) {
+    const auto digest{
+        sourcemeta::core::hmac_sha256_digest(secret, signing_input)};
+    if (sourcemeta::core::secure_equals(digest_view(digest),
+                                        presented.value())) {
+      authentic = true;
+      break;
+    }
+  }
+
+  if (!authentic) {
+    return std::nullopt;
+  }
+
+  // A value is valid strictly before its expiry instant
+  if (now >= expiry.value()) {
+    return std::nullopt;
+  }
+
+  return sourcemeta::core::base64url_decode(
+      value.substr(expiry_end + 1, payload_end - expiry_end - 1));
+}
+
+} // namespace sourcemeta::one

--- a/enterprise/authentication/session.cc
+++ b/enterprise/authentication/session.cc
@@ -2,6 +2,7 @@
 
 #include <sourcemeta/core/crypto.h>
 
+#include <algorithm>   // std::max
 #include <array>       // std::array
 #include <charconv>    // std::from_chars, std::errc
 #include <chrono>      // std::chrono::sys_seconds, std::chrono::seconds
@@ -20,6 +21,11 @@ namespace {
 constexpr std::string_view SESSION_VERSION{"1"};
 
 constexpr std::size_t SESSION_SIGNATURE_LENGTH{32};
+
+// The canonical unpadded encoding of a signature has exactly one length, so
+// anything else is rejected before it is even decoded
+constexpr std::size_t SESSION_SIGNATURE_ENCODED_LENGTH{
+    ((SESSION_SIGNATURE_LENGTH * 4) + 2) / 3};
 
 auto digest_view(const std::array<std::uint8_t, 32> &digest)
     -> std::string_view {
@@ -55,7 +61,10 @@ auto session_seal(const std::string_view payload, const std::string_view secret,
                   const std::chrono::sys_seconds expiry) -> std::string {
   std::string result{SESSION_VERSION};
   result += '.';
-  result += std::to_string(expiry.time_since_epoch().count());
+  // A pre-epoch expiry is clamped so that every sealed value is well-formed,
+  // remaining expired from the moment it is produced
+  result += std::to_string(std::max(std::chrono::seconds::rep{0},
+                                    expiry.time_since_epoch().count()));
   result += '.';
   result += sourcemeta::core::base64url_encode(payload);
   const auto digest{sourcemeta::core::hmac_sha256_digest(secret, result)};
@@ -95,6 +104,10 @@ auto session_open(const std::string_view value,
   const auto expiry{parse_expiry(
       value.substr(version_end + 1, expiry_end - version_end - 1))};
   if (!expiry.has_value()) {
+    return std::nullopt;
+  }
+
+  if (signature.size() != SESSION_SIGNATURE_ENCODED_LENGTH) {
     return std::nullopt;
   }
 

--- a/enterprise/unit/authentication/CMakeLists.txt
+++ b/enterprise/unit/authentication/CMakeLists.txt
@@ -1,5 +1,5 @@
 sourcemeta_test(NAMESPACE sourcemeta PROJECT one NAME enterprise_authentication
-  SOURCES authentication_test.cc)
+  SOURCES authentication_test.cc session_test.cc)
 
 target_link_libraries(sourcemeta_one_enterprise_authentication_unit
   PRIVATE sourcemeta::one::authentication)

--- a/enterprise/unit/authentication/session_test.cc
+++ b/enterprise/unit/authentication/session_test.cc
@@ -133,6 +133,21 @@ TEST(session_denies_a_truncated_signature) {
       sourcemeta::one::session_open(truncated, SECRETS, NOW).has_value());
 }
 
+TEST(session_denies_a_lengthened_signature) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "session-secret", LATER)};
+  const auto lengthened{value + "AA"};
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(lengthened, SECRETS, NOW).has_value());
+}
+
+TEST(session_denies_a_value_sealed_with_a_pre_epoch_expiry) {
+  const std::chrono::sys_seconds before_epoch{std::chrono::seconds{-1}};
+  const auto value{sourcemeta::one::session_seal(
+      "the-payload", "session-secret", before_epoch)};
+  EXPECT_FALSE(sourcemeta::one::session_open(value, SECRETS, NOW).has_value());
+}
+
 TEST(session_denies_malformed_values) {
   EXPECT_FALSE(sourcemeta::one::session_open("", SECRETS, NOW).has_value());
   EXPECT_FALSE(sourcemeta::one::session_open(".", SECRETS, NOW).has_value());

--- a/enterprise/unit/authentication/session_test.cc
+++ b/enterprise/unit/authentication/session_test.cc
@@ -1,0 +1,183 @@
+#include <sourcemeta/one/authentication_session.h>
+
+#include <sourcemeta/core/test.h>
+
+#include <array>       // std::array
+#include <chrono>      // std::chrono::sys_seconds, std::chrono::seconds
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static constexpr std::chrono::sys_seconds NOW{std::chrono::seconds{1000000}};
+static constexpr std::chrono::sys_seconds LATER{std::chrono::seconds{1000060}};
+
+static const std::array<std::string_view, 1> SECRETS{{"session-secret"}};
+
+TEST(session_round_trips_a_payload) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "session-secret", LATER)};
+  const auto payload{sourcemeta::one::session_open(value, SECRETS, NOW)};
+  EXPECT_TRUE(payload.has_value());
+  EXPECT_EQ(payload.value(), "the-payload");
+}
+
+TEST(session_round_trips_an_empty_payload) {
+  const auto value{sourcemeta::one::session_seal("", "session-secret", LATER)};
+  const auto payload{sourcemeta::one::session_open(value, SECRETS, NOW)};
+  EXPECT_TRUE(payload.has_value());
+  EXPECT_EQ(payload.value(), "");
+}
+
+TEST(session_round_trips_a_payload_containing_separators) {
+  const auto value{sourcemeta::one::session_seal(
+      "left.right.{\"claims\":[1,2]}\n", "session-secret", LATER)};
+  const auto payload{sourcemeta::one::session_open(value, SECRETS, NOW)};
+  EXPECT_TRUE(payload.has_value());
+  EXPECT_EQ(payload.value(), "left.right.{\"claims\":[1,2]}\n");
+}
+
+TEST(session_value_is_cookie_safe) {
+  const auto value{sourcemeta::one::session_seal(
+      "payload with spaces; and = signs", "session-secret", LATER)};
+  for (const auto character : value) {
+    const auto safe{(character >= 'a' && character <= 'z') ||
+                    (character >= 'A' && character <= 'Z') ||
+                    (character >= '0' && character <= '9') ||
+                    character == '.' || character == '-' || character == '_'};
+    EXPECT_TRUE(safe);
+  }
+}
+
+TEST(session_denies_at_and_after_the_expiry_instant) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "session-secret", LATER)};
+  EXPECT_TRUE(sourcemeta::one::session_open(value, SECRETS, NOW).has_value());
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(value, SECRETS, LATER).has_value());
+  const std::chrono::sys_seconds after{LATER + std::chrono::seconds{1}};
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(value, SECRETS, after).has_value());
+}
+
+TEST(session_denies_a_wrong_secret) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "other-secret", LATER)};
+  EXPECT_FALSE(sourcemeta::one::session_open(value, SECRETS, NOW).has_value());
+}
+
+TEST(session_denies_with_no_secrets) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "session-secret", LATER)};
+  const std::array<std::string_view, 0> no_secrets{};
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(value, no_secrets, NOW).has_value());
+}
+
+TEST(session_admits_a_value_sealed_under_an_older_secret) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "old-secret", LATER)};
+  const std::array<std::string_view, 2> rotated{{"new-secret", "old-secret"}};
+  const auto payload{sourcemeta::one::session_open(value, rotated, NOW)};
+  EXPECT_TRUE(payload.has_value());
+  EXPECT_EQ(payload.value(), "the-payload");
+  const std::array<std::string_view, 1> retired{{"new-secret"}};
+  EXPECT_FALSE(sourcemeta::one::session_open(value, retired, NOW).has_value());
+}
+
+TEST(session_denies_a_tampered_payload) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "session-secret", LATER)};
+  auto tampered{value};
+  const auto payload_start{tampered.find('.', tampered.find('.') + 1) + 1};
+  tampered[payload_start] = tampered[payload_start] == 'A' ? 'B' : 'A';
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(tampered, SECRETS, NOW).has_value());
+}
+
+TEST(session_denies_a_tampered_expiry) {
+  const auto expired{
+      sourcemeta::one::session_seal("the-payload", "session-secret", NOW)};
+  // Extending the lifetime of an expired value must break its signature
+  const auto expiry_start{expired.find('.') + 1};
+  auto tampered{expired};
+  tampered.insert(expiry_start, "9");
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(tampered, SECRETS, NOW).has_value());
+}
+
+TEST(session_denies_a_tampered_version) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "session-secret", LATER)};
+  auto tampered{value};
+  tampered[0] = '2';
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(tampered, SECRETS, NOW).has_value());
+}
+
+TEST(session_denies_a_transplanted_signature) {
+  const auto first{
+      sourcemeta::one::session_seal("first-payload", "session-secret", LATER)};
+  const auto second{
+      sourcemeta::one::session_seal("second-payload", "session-secret", LATER)};
+  const auto first_body{first.substr(0, first.rfind('.'))};
+  const auto second_signature{second.substr(second.rfind('.') + 1)};
+  const auto spliced{first_body + "." + second_signature};
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(spliced, SECRETS, NOW).has_value());
+}
+
+TEST(session_denies_a_truncated_signature) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "session-secret", LATER)};
+  const auto truncated{value.substr(0, value.size() - 2)};
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(truncated, SECRETS, NOW).has_value());
+}
+
+TEST(session_denies_malformed_values) {
+  EXPECT_FALSE(sourcemeta::one::session_open("", SECRETS, NOW).has_value());
+  EXPECT_FALSE(sourcemeta::one::session_open(".", SECRETS, NOW).has_value());
+  EXPECT_FALSE(sourcemeta::one::session_open("...", SECRETS, NOW).has_value());
+  EXPECT_FALSE(sourcemeta::one::session_open("no-dots-at-all", SECRETS, NOW)
+                   .has_value());
+  EXPECT_FALSE(
+      sourcemeta::one::session_open("1.123.AA", SECRETS, NOW).has_value());
+  EXPECT_FALSE(sourcemeta::one::session_open("1.123.AA.BB.CC", SECRETS, NOW)
+                   .has_value());
+}
+
+TEST(session_denies_a_malformed_expiry) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "session-secret", LATER)};
+  const auto expiry_start{value.find('.') + 1};
+  const auto expiry_end{value.find('.', expiry_start)};
+
+  auto empty_expiry{value};
+  empty_expiry.erase(expiry_start, expiry_end - expiry_start);
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(empty_expiry, SECRETS, NOW).has_value());
+
+  auto textual_expiry{value};
+  textual_expiry.replace(expiry_start, expiry_end - expiry_start, "later");
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(textual_expiry, SECRETS, NOW).has_value());
+
+  auto negative_expiry{value};
+  negative_expiry.replace(expiry_start, expiry_end - expiry_start, "-1");
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(negative_expiry, SECRETS, NOW).has_value());
+
+  auto overflowing_expiry{value};
+  overflowing_expiry.replace(expiry_start, expiry_end - expiry_start,
+                             "99999999999999999999999999");
+  EXPECT_FALSE(sourcemeta::one::session_open(overflowing_expiry, SECRETS, NOW)
+                   .has_value());
+}
+
+TEST(session_denies_a_signature_that_is_not_base64url) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "session-secret", LATER)};
+  const auto body{value.substr(0, value.rfind('.'))};
+  const auto invalid{body + ".!!!not-base64url!!!"};
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(invalid, SECRETS, NOW).has_value());
+}

--- a/enterprise/unit/authentication/session_test.cc
+++ b/enterprise/unit/authentication/session_test.cc
@@ -146,6 +146,16 @@ TEST(session_denies_a_value_sealed_with_a_pre_epoch_expiry) {
   const auto value{sourcemeta::one::session_seal(
       "the-payload", "session-secret", before_epoch)};
   EXPECT_FALSE(sourcemeta::one::session_open(value, SECRETS, NOW).has_value());
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(value, SECRETS, before_epoch).has_value());
+}
+
+TEST(session_denies_everything_under_a_pre_epoch_clock) {
+  const auto value{
+      sourcemeta::one::session_seal("the-payload", "session-secret", LATER)};
+  const std::chrono::sys_seconds before_epoch{std::chrono::seconds{-1}};
+  EXPECT_FALSE(
+      sourcemeta::one::session_open(value, SECRETS, before_epoch).has_value());
 }
 
 TEST(session_denies_malformed_values) {

--- a/src/actions/action_mcp_v1.h
+++ b/src/actions/action_mcp_v1.h
@@ -190,7 +190,7 @@ public:
         [this, version = negotiated_version.value()](
             sourcemeta::one::HTTPRequest &callback_request,
             sourcemeta::one::HTTPResponse &callback_response,
-            std::string &&body, bool too_big) {
+            std::string &&body, bool too_big) -> void {
           if (too_big) {
             this->write_envelope(
                 callback_request, callback_response,
@@ -305,7 +305,7 @@ public:
         [this, version = negotiated_version.value()](
             sourcemeta::one::HTTPRequest &callback_request,
             sourcemeta::one::HTTPResponse &callback_response,
-            const std::exception_ptr &error) {
+            const std::exception_ptr &error) -> void {
           try {
             std::rethrow_exception(error);
           } catch (const std::exception &) {

--- a/src/authentication/CMakeLists.txt
+++ b/src/authentication/CMakeLists.txt
@@ -9,8 +9,8 @@ if(ONE_ENTERPRISE)
   target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::crypto)
 else()
   sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME authentication
-    PRIVATE_HEADERS error.h
-    SOURCES authentication.cc)
+    PRIVATE_HEADERS error.h session.h
+    SOURCES authentication.cc session.cc)
 endif()
 
 target_link_libraries(sourcemeta_one_authentication PUBLIC sourcemeta::core::io)

--- a/src/authentication/CMakeLists.txt
+++ b/src/authentication/CMakeLists.txt
@@ -1,9 +1,10 @@
 if(ONE_ENTERPRISE)
   sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME authentication
-    PRIVATE_HEADERS error.h
+    PRIVATE_HEADERS error.h session.h
     SOURCES
       "${PROJECT_SOURCE_DIR}/enterprise/authentication/authentication.cc"
-      "${PROJECT_SOURCE_DIR}/enterprise/authentication/authentication_save.cc")
+      "${PROJECT_SOURCE_DIR}/enterprise/authentication/authentication_save.cc"
+      "${PROJECT_SOURCE_DIR}/enterprise/authentication/session.cc")
   target_compile_definitions(sourcemeta_one_authentication PUBLIC SOURCEMETA_ONE_ENTERPRISE)
   target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::crypto)
 else()

--- a/src/authentication/include/sourcemeta/one/authentication_session.h
+++ b/src/authentication/include/sourcemeta/one/authentication_session.h
@@ -1,0 +1,34 @@
+#ifndef SOURCEMETA_ONE_AUTHENTICATION_SESSION_H
+#define SOURCEMETA_ONE_AUTHENTICATION_SESSION_H
+
+#ifndef SOURCEMETA_ONE_AUTHENTICATION_EXPORT
+#include <sourcemeta/one/authentication_export.h>
+#endif
+
+#include <chrono>      // std::chrono::sys_seconds
+#include <optional>    // std::optional
+#include <span>        // std::span
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace sourcemeta::one {
+
+// Bind a payload and an expiry under a keyed signature, producing a value that
+// is safe to transport as a cookie. Only a holder of the secret can produce or
+// alter such a value, though anyone can read its contents
+auto SOURCEMETA_ONE_AUTHENTICATION_EXPORT
+session_seal(std::string_view payload, std::string_view secret,
+             std::chrono::sys_seconds expiry) -> std::string;
+
+// Recover the payload of a sealed value, returning nothing for a value that
+// was not produced under one of the given secrets, was altered in any way, or
+// has expired. Accepting several secrets lets a newly introduced secret
+// coexist with the one it replaces until every value sealed under the old
+// secret has expired
+auto SOURCEMETA_ONE_AUTHENTICATION_EXPORT
+session_open(std::string_view value, std::span<const std::string_view> secrets,
+             std::chrono::sys_seconds now) -> std::optional<std::string>;
+
+} // namespace sourcemeta::one
+
+#endif

--- a/src/authentication/session.cc
+++ b/src/authentication/session.cc
@@ -1,0 +1,25 @@
+#include <sourcemeta/one/authentication_session.h>
+
+#include <chrono>      // std::chrono::sys_seconds
+#include <optional>    // std::optional, std::nullopt
+#include <span>        // std::span
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace sourcemeta::one {
+
+// Sessions only arise from interactive authentication, which is an enterprise
+// feature, so this edition never produces a sealed value and never accepts one
+auto session_seal(const std::string_view, const std::string_view,
+                  const std::chrono::sys_seconds) -> std::string {
+  return {};
+}
+
+auto session_open(const std::string_view,
+                  const std::span<const std::string_view>,
+                  const std::chrono::sys_seconds)
+    -> std::optional<std::string> {
+  return std::nullopt;
+}
+
+} // namespace sourcemeta::one


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

