### PR TITLE
Fix debug symbol generation happening on every build

### DIFF
--- a/cmake/DebugSymbols.cmake
+++ b/cmake/DebugSymbols.cmake
@@ -60,7 +60,9 @@ function(sourcemeta_debug_symbols_extract TARGET_NAME)
     message(STATUS "Extracting debug symbols (.debug) for: ${TARGET_NAME}")
     # Stripping happens on a copy that atomically replaces the binary.
     # Rewriting the binary in place races against concurrent build steps
-    # that execute it, such as code generation, failing with ETXTBSY
+    # that execute it, such as code generation, failing with ETXTBSY.
+    # The final touch keeps the declared output newer than the binary the
+    # rule just replaced, otherwise the rule re-runs on every build
     add_custom_command(OUTPUT "${BINARY_PATH}.debug"
       COMMAND "${CMAKE_OBJCOPY}" --only-keep-debug
               "${BINARY_INPUT}" "${BINARY_PATH}.debug"
@@ -69,6 +71,7 @@ function(sourcemeta_debug_symbols_extract TARGET_NAME)
               "${BINARY_INPUT}" "${BINARY_PATH}.stripped"
       COMMAND "${CMAKE_COMMAND}" -E rename
               "${BINARY_PATH}.stripped" "${BINARY_PATH}"
+      COMMAND "${CMAKE_COMMAND}" -E touch "${BINARY_PATH}.debug"
       DEPENDS "${TARGET_NAME}"
       VERBATIM)
     add_custom_target("${TARGET_NAME}_debug_symbols" ALL


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

