### PR TITLE
Teach the authentication artifact an OIDC policy type

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -360,8 +360,9 @@ auto collect_jwt_identifiers(const std::span<const std::byte> metadata,
 }
 
 // The reference check treats two interactive policies as the same scope only
-// when they authenticate against the same provider client, so the identity
-// spans the issuer and the client identifier
+// when they authenticate against the same provider client, so the issuer and
+// client identifier count as one indivisible identity, never as separate
+// keys that several policies could satisfy piecewise or in swapped roles
 auto collect_oidc_identifiers(const std::span<const std::byte> metadata,
                               std::unordered_set<std::string_view> &keys)
     -> void {
@@ -373,8 +374,10 @@ auto collect_oidc_identifiers(const std::span<const std::byte> metadata,
     return;
   }
 
-  keys.emplace(issuer);
-  keys.emplace(client_id);
+  // The serialized pair itself is the key. Its length prefixes keep the two
+  // fields delimited, so exactly the equal pairs compare equal
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  keys.emplace(reinterpret_cast<const char *>(metadata.data()), cursor);
 }
 
 } // namespace

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -139,7 +139,7 @@ auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
           entry.metadata_length > size - metadata_cursor ||
           entry.algorithm >
               static_cast<std::uint8_t>(Authentication::Algorithm::Sha256) ||
-          entry.type > static_cast<std::uint8_t>(Authentication::Type::JWT)) {
+          entry.type > static_cast<std::uint8_t>(Authentication::Type::OIDC)) {
         return false;
       }
 
@@ -359,6 +359,24 @@ auto collect_jwt_identifiers(const std::span<const std::byte> metadata,
   keys.emplace(reinterpret_cast<const char *>(metadata.data() + cursor), count);
 }
 
+// The reference check treats two interactive policies as the same scope only
+// when they authenticate against the same provider client, so the identity
+// spans the issuer and the client identifier
+auto collect_oidc_identifiers(const std::span<const std::byte> metadata,
+                              std::unordered_set<std::string_view> &keys)
+    -> void {
+  std::size_t cursor{0};
+  std::string_view issuer;
+  std::string_view client_id;
+  if (!read_string(metadata, cursor, issuer) ||
+      !read_string(metadata, cursor, client_id)) {
+    return;
+  }
+
+  keys.emplace(issuer);
+  keys.emplace(client_id);
+}
+
 } // namespace
 
 namespace sourcemeta::one {
@@ -505,6 +523,11 @@ struct Authentication::Impl {
                   .principal = Authentication::Principal{
                       .type = type, .policy = static_cast<std::size_t>(index)}};
         }
+      } else if (type == Authentication::Type::OIDC) {
+        // An interactive policy authenticates a person through a browser
+        // login, never a presented credential, so it can never open a path
+        // here
+        continue;
       } else if (admits_apikey(
                      metadata, credential,
                      static_cast<Authentication::Algorithm>(entry.algorithm))) {
@@ -620,9 +643,11 @@ struct Authentication::Impl {
         const std::span<const std::byte> metadata{
             this->view_->as<std::byte>(entry.metadata_offset),
             entry.metadata_length};
-        if (static_cast<Authentication::Type>(entry.type) ==
-            Authentication::Type::JWT) {
+        const auto type{static_cast<Authentication::Type>(entry.type)};
+        if (type == Authentication::Type::JWT) {
           collect_jwt_identifiers(metadata, result.keys);
+        } else if (type == Authentication::Type::OIDC) {
+          collect_oidc_identifiers(metadata, result.keys);
         } else {
           collect_keys(metadata, result.keys);
         }

--- a/enterprise/authentication/authentication_format.h
+++ b/enterprise/authentication/authentication_format.h
@@ -8,7 +8,7 @@
 namespace sourcemeta::one {
 
 constexpr std::uint32_t AUTHENTICATION_MAGIC{0x48545541};
-constexpr std::uint32_t AUTHENTICATION_VERSION{5};
+constexpr std::uint32_t AUTHENTICATION_VERSION{6};
 
 // The artifact begins with this header. Every variable-length section is
 // located through an absolute byte offset so the matcher can address it

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -73,6 +73,19 @@ auto encode_apikey_metadata(
   return result;
 }
 
+// The issuer, client identifier, and the name of the environment variable
+// holding the client secret are stored as length-prefixed strings
+auto encode_oidc_metadata(const std::string_view issuer,
+                          const std::string_view client_id,
+                          const std::string_view client_secret_variable)
+    -> std::vector<std::byte> {
+  std::vector<std::byte> result;
+  append_string(result, issuer);
+  append_string(result, client_id);
+  append_string(result, client_secret_variable);
+  return result;
+}
+
 // The issuer, audience, and key set location are stored as length-prefixed
 // strings, followed by the allow-listed signature algorithms as one byte each.
 // An empty key set location means the location is discovered from the issuer
@@ -187,6 +200,9 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
     if (policy.type == Authentication::Type::JWT) {
       policy_metadata = encode_jwt_metadata(policy.issuer, policy.audience,
                                             policy.jwks_uri, policy.algorithms);
+    } else if (policy.type == Authentication::Type::OIDC) {
+      policy_metadata = encode_oidc_metadata(policy.issuer, policy.client_id,
+                                             policy.client_secret_variable);
     } else if (!policy.keys.empty()) {
       policy_metadata = encode_apikey_metadata(policy.keys);
     }

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -990,6 +990,62 @@ TEST(reference_across_distinct_oidc_clients_is_rejected) {
   EXPECT_FALSE(authentication.reference_permitted("/beta/two", "/alpha/one"));
 }
 
+TEST(reference_across_swapped_oidc_identities_is_rejected) {
+  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
+  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
+  // One policy's issuer is the other's client identifier and vice versa, so
+  // the scopes share both strings yet denote different provider clients
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = alpha_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://login.test",
+        .client_id = "registry",
+        .client_secret_variable = "ONE_TEST_OIDC_REF_SWAP_ALPHA"},
+       {.paths = beta_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "registry",
+        .client_id = "https://login.test",
+        .client_secret_variable = "ONE_TEST_OIDC_REF_SWAP_BETA"}}};
+  const auto path{test_path("oidc_ref_swapped.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  EXPECT_FALSE(authentication.reference_permitted("/alpha/one", "/beta/two"));
+  EXPECT_FALSE(authentication.reference_permitted("/beta/two", "/alpha/one"));
+}
+
+TEST(reference_mixing_identities_across_oidc_policies_is_rejected) {
+  const std::array<std::string_view, 1> source_paths{{"/source"}};
+  const std::array<std::string_view, 1> target_paths{{"/target"}};
+  // The referrer pairs an issuer and a client identifier that the referent
+  // only carries through two different policies, so no single referent scope
+  // matches and the reference must not slip through their union
+  const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
+      {{.paths = source_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://alpha.test",
+        .client_id = "dashboard",
+        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_SOURCE"},
+       {.paths = target_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://alpha.test",
+        .client_id = "registry",
+        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_ONE"},
+       {.paths = target_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://beta.test",
+        .client_id = "dashboard",
+        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_TWO"}}};
+  const auto path{test_path("oidc_ref_mixed.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  EXPECT_FALSE(
+      authentication.reference_permitted("/source/one", "/target/two"));
+}
+
 TEST(admission_by_an_apikey_policy_identifies_the_principal) {
   setenv("ONE_TEST_KEY_PRINCIPAL", "principal-secret", 1);
   const std::array<std::string_view, 1> paths{{"/internal"}};

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -875,6 +875,121 @@ TEST(mixed_apikey_and_jwt_policies_admit_either_credential) {
   EXPECT_FALSE(authentication.admits("/both/x", "wrong").allowed);
 }
 
+TEST(oidc_policy_admits_no_presented_credential) {
+  setenv("ONE_TEST_OIDC_DENY", "confidential", 1);
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_DENY"}}};
+  const auto path{test_path("oidc_deny.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  // The provider is reachable and would verify the token, yet no presented
+  // credential opens the path, not even one the equivalent token policy
+  // would accept, and the provider is never contacted
+  const auto calls{std::make_shared<int>(0)};
+  const sourcemeta::one::Authentication authentication{
+      path,
+      stub_fetcher({{"acme/.well-known/openid-configuration",
+                     R"JSON({ "jwks_uri": "https://acme.test/keys" })JSON"},
+                    {"https://acme.test/keys", std::string{SIGNED_KEYS}}},
+                   calls)};
+
+  const auto empty_verdict{authentication.admits("/portal/x", "")};
+  EXPECT_FALSE(empty_verdict.allowed);
+  EXPECT_FALSE(empty_verdict.principal.has_value());
+
+  const auto secret_verdict{authentication.admits("/portal/x", "confidential")};
+  EXPECT_FALSE(secret_verdict.allowed);
+  EXPECT_FALSE(secret_verdict.principal.has_value());
+
+  const auto token_verdict{authentication.admits("/portal/x", SIGNED_TOKEN)};
+  EXPECT_FALSE(token_verdict.allowed);
+  EXPECT_FALSE(token_verdict.principal.has_value());
+
+  EXPECT_EQ(*calls, 0);
+}
+
+TEST(union_of_an_apikey_and_an_oidc_policy_admits_only_the_key) {
+  setenv("ONE_TEST_KEY_OIDC_UNION", "union-secret", 1);
+  const std::array<std::string_view, 1> paths{{"/both"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_OIDC_UNION"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = paths, .keys = keys},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_KEY_OIDC_UNION"}}};
+  const auto path{test_path("oidc_union.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+
+  const auto key_verdict{authentication.admits("/both/x", "union-secret")};
+  EXPECT_TRUE(key_verdict.allowed);
+  EXPECT_TRUE(key_verdict.principal.has_value());
+  EXPECT_EQ(key_verdict.principal.value().type,
+            sourcemeta::one::Authentication::Type::ApiKey);
+  EXPECT_EQ(key_verdict.principal.value().policy, std::size_t{0});
+
+  const auto token_verdict{authentication.admits("/both/x", SIGNED_TOKEN)};
+  EXPECT_FALSE(token_verdict.allowed);
+  EXPECT_FALSE(token_verdict.principal.has_value());
+}
+
+TEST(reference_within_the_same_oidc_scope_is_permitted) {
+  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
+  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
+  // The two policies name different environment variables for the secret,
+  // which does not affect who can authenticate, so the scopes stay equal
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = alpha_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://login.test",
+        .client_id = "registry",
+        .client_secret_variable = "ONE_TEST_OIDC_REF_SAME"},
+       {.paths = beta_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://login.test",
+        .client_id = "registry",
+        .client_secret_variable = "ONE_TEST_OIDC_REF_SAME_OTHER"}}};
+  const auto path{test_path("oidc_ref_same.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  EXPECT_TRUE(authentication.reference_permitted("/alpha/one", "/beta/two"));
+  EXPECT_TRUE(authentication.reference_permitted("/beta/two", "/alpha/one"));
+}
+
+TEST(reference_across_distinct_oidc_clients_is_rejected) {
+  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
+  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = alpha_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://login.test",
+        .client_id = "registry",
+        .client_secret_variable = "ONE_TEST_OIDC_REF_ALPHA"},
+       {.paths = beta_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://login.test",
+        .client_id = "dashboard",
+        .client_secret_variable = "ONE_TEST_OIDC_REF_BETA"}}};
+  const auto path{test_path("oidc_ref_distinct.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  EXPECT_FALSE(authentication.reference_permitted("/alpha/one", "/beta/two"));
+  EXPECT_FALSE(authentication.reference_permitted("/beta/two", "/alpha/one"));
+}
+
 TEST(admission_by_an_apikey_policy_identifies_the_principal) {
   setenv("ONE_TEST_KEY_PRINCIPAL", "principal-secret", 1);
   const std::array<std::string_view, 1> paths{{"/internal"}};

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -32,7 +32,7 @@ public:
   // Identity stores the key verbatim, every other algorithm stores it hashed
   enum class Algorithm : std::uint8_t { Identity = 0, Sha256 = 1 };
 
-  enum class Type : std::uint8_t { ApiKey = 0, JWT = 1 };
+  enum class Type : std::uint8_t { ApiKey = 0, JWT = 1, OIDC = 2 };
 
   // A policy gates a set of path prefixes. A path covered by no policy is
   // public
@@ -45,6 +45,9 @@ public:
     std::string_view audience{};
     std::string_view jwks_uri{};
     std::span<const sourcemeta::core::JWSAlgorithm> algorithms{};
+    std::string_view client_id{};
+    // The environment variable name holding the client secret
+    std::string_view client_secret_variable{};
   };
 
   // The identity of an admitted caller: the type of credential it presented


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

