### PR TITLE
Admit interactive sessions at the route gate in preparation for SSO

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -1,6 +1,7 @@
 #include <sourcemeta/one/authentication.h>
 
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/http.h>
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
@@ -398,8 +399,15 @@ struct Authentication::Impl {
   // empty set and admits no one. Opening the file covers the missing and
   // unreadable cases without a separate, throwing existence check
   Impl(const std::filesystem::path &path,
-       sourcemeta::core::JWKSProvider::Fetcher fetcher)
-      : fetcher_{std::move(fetcher)} {
+       sourcemeta::core::JWKSProvider::Fetcher fetcher,
+       const std::span<const std::string> session_secrets)
+      : fetcher_{std::move(fetcher)},
+        session_secrets_{session_secrets.begin(), session_secrets.end()} {
+    this->session_secret_views_.reserve(this->session_secrets_.size());
+    for (const auto &secret : this->session_secrets_) {
+      this->session_secret_views_.emplace_back(secret);
+    }
+
     std::unique_ptr<sourcemeta::core::FileView> view;
     try {
       view = std::make_unique<sourcemeta::core::FileView>(path);
@@ -489,7 +497,8 @@ struct Authentication::Impl {
   }
 
   [[nodiscard]] auto admits(const std::string_view registry_path,
-                            const std::string_view credential) const
+                            const std::string_view credential,
+                            const std::string_view cookies) const
       -> Authentication::Verdict {
     // A missing or structurally broken artifact leaves the section pointers
     // null and denies everything. Only a valid policy fails open below
@@ -527,10 +536,13 @@ struct Authentication::Impl {
                       .type = type, .policy = static_cast<std::size_t>(index)}};
         }
       } else if (type == Authentication::Type::OIDC) {
-        // An interactive policy authenticates a person through a browser
-        // login, never a presented credential, so it can never open a path
-        // here
-        continue;
+        // An interactive policy authenticates a person through the session
+        // its browser login established, never a presented credential
+        if (this->admits_session(metadata, cookies)) {
+          return {.allowed = true,
+                  .principal = Authentication::Principal{
+                      .type = type, .policy = static_cast<std::size_t>(index)}};
+        }
       } else if (admits_apikey(
                      metadata, credential,
                      static_cast<Authentication::Algorithm>(entry.algorithm))) {
@@ -559,6 +571,61 @@ struct Authentication::Impl {
     const auto error{provider->verify(token, policy.algorithms, policy.issuer,
                                       policy.audience)};
     return !error.has_value();
+  }
+
+  [[nodiscard]] auto admits_session(const std::span<const std::byte> metadata,
+                                    const std::string_view cookies) const
+      -> bool {
+    if (this->session_secret_views_.empty() || cookies.empty()) {
+      return false;
+    }
+
+    std::size_t cursor{0};
+    std::string_view issuer;
+    std::string_view client_id;
+    std::string_view client_secret_variable;
+    std::string_view policy_name;
+    if (!read_string(metadata, cursor, issuer) ||
+        !read_string(metadata, cursor, client_id) ||
+        !read_string(metadata, cursor, client_secret_variable) ||
+        !read_string(metadata, cursor, policy_name) || policy_name.empty()) {
+      return false;
+    }
+
+    std::string cookie_name{sourcemeta::one::SESSION_COOKIE_PREFIX};
+    cookie_name += policy_name;
+    std::string_view sealed;
+    sourcemeta::core::http_parse_cookies(
+        cookies,
+        [&cookie_name, &sealed](const std::string_view name,
+                                const std::string_view value) -> void {
+          if (name == cookie_name) {
+            sealed = value;
+          }
+        });
+    if (sealed.empty()) {
+      return false;
+    }
+
+    const auto now{std::chrono::time_point_cast<std::chrono::seconds>(
+        std::chrono::system_clock::now())};
+    const auto payload{sourcemeta::one::session_open(
+        sealed, this->session_secret_views_, now)};
+    if (!payload.has_value()) {
+      return false;
+    }
+
+    // Cookie names travel outside the signature, so the sealed payload
+    // itself declares the policy it was minted for, and a value re-presented
+    // under another policy's cookie name is rejected
+    const auto document{sourcemeta::core::try_parse_json(payload.value())};
+    if (!document.has_value() || !document.value().is_object()) {
+      return false;
+    }
+
+    const auto *minted_for{document.value().try_at("policy")};
+    return minted_for != nullptr && minted_for->is_string() &&
+           minted_for->to_string() == policy_name;
   }
 
   [[nodiscard]] auto provider_for(const std::string_view issuer,
@@ -703,24 +770,30 @@ struct Authentication::Impl {
   std::unique_ptr<sourcemeta::core::FileView> view_;
 
   sourcemeta::core::JWKSProvider::Fetcher fetcher_;
+  std::vector<std::string> session_secrets_;
+  std::vector<std::string_view> session_secret_views_;
   mutable std::mutex jwks_mutex_;
   mutable std::map<std::pair<std::string, std::string>,
                    std::unique_ptr<sourcemeta::core::JWKSProvider>>
       jwks_providers_;
 };
 
-Authentication::Authentication(const std::filesystem::path &path,
-                               sourcemeta::core::JWKSProvider::Fetcher fetcher)
-    : impl_{std::make_unique<Impl>(path, std::move(fetcher))} {}
+Authentication::Authentication(
+    const std::filesystem::path &path,
+    sourcemeta::core::JWKSProvider::Fetcher fetcher,
+    const std::span<const std::string> session_secrets)
+    : impl_{std::make_unique<Impl>(path, std::move(fetcher), session_secrets)} {
+}
 
 Authentication::~Authentication() = default;
 
 auto Authentication::admits(const std::string_view registry_path,
                             const std::string_view credential,
+                            const std::string_view cookies,
                             const std::string_view base_path) const
     -> Authentication::Verdict {
   return this->impl_->admits(strip_base_path(registry_path, base_path),
-                             credential);
+                             credential, cookies);
 }
 
 auto Authentication::governing(const std::string_view registry_path,

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -401,8 +401,16 @@ struct Authentication::Impl {
   Impl(const std::filesystem::path &path,
        sourcemeta::core::JWKSProvider::Fetcher fetcher,
        const std::span<const std::string_view> session_secrets)
-      : fetcher_{std::move(fetcher)},
-        session_secrets_{session_secrets.begin(), session_secrets.end()} {
+      : fetcher_{std::move(fetcher)} {
+    // A blank secret would let anyone mint valid sessions, so it is
+    // discarded rather than trusted
+    this->session_secrets_.reserve(session_secrets.size());
+    for (const auto secret : session_secrets) {
+      if (!secret.empty()) {
+        this->session_secrets_.emplace_back(secret);
+      }
+    }
+
     this->session_secret_views_.reserve(this->session_secrets_.size());
     for (const auto &secret : this->session_secrets_) {
       this->session_secret_views_.emplace_back(secret);

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -400,7 +400,7 @@ struct Authentication::Impl {
   // unreadable cases without a separate, throwing existence check
   Impl(const std::filesystem::path &path,
        sourcemeta::core::JWKSProvider::Fetcher fetcher,
-       const std::span<const std::string> session_secrets)
+       const std::span<const std::string_view> session_secrets)
       : fetcher_{std::move(fetcher)},
         session_secrets_{session_secrets.begin(), session_secrets.end()} {
     this->session_secret_views_.reserve(this->session_secrets_.size());
@@ -781,7 +781,7 @@ struct Authentication::Impl {
 Authentication::Authentication(
     const std::filesystem::path &path,
     sourcemeta::core::JWKSProvider::Fetcher fetcher,
-    const std::span<const std::string> session_secrets)
+    const std::span<const std::string_view> session_secrets)
     : impl_{std::make_unique<Impl>(path, std::move(fetcher), session_secrets)} {
 }
 

--- a/enterprise/authentication/authentication_format.h
+++ b/enterprise/authentication/authentication_format.h
@@ -8,7 +8,7 @@
 namespace sourcemeta::one {
 
 constexpr std::uint32_t AUTHENTICATION_MAGIC{0x48545541};
-constexpr std::uint32_t AUTHENTICATION_VERSION{6};
+constexpr std::uint32_t AUTHENTICATION_VERSION{7};
 
 // The artifact begins with this header. Every variable-length section is
 // located through an absolute byte offset so the matcher can address it

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -205,6 +205,13 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
       policy_metadata = encode_jwt_metadata(policy.issuer, policy.audience,
                                             policy.jwks_uri, policy.algorithms);
     } else if (policy.type == Authentication::Type::OIDC) {
+      // A nameless interactive policy could never match a session cookie, so
+      // it fails loudly here rather than silently denying at the gate
+      if (policy.name.empty()) {
+        throw std::runtime_error(
+            "Interactive authentication policies require a name");
+      }
+
       policy_metadata =
           encode_oidc_metadata(policy.issuer, policy.client_id,
                                policy.client_secret_variable, policy.name);

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -73,16 +73,20 @@ auto encode_apikey_metadata(
   return result;
 }
 
-// The issuer, client identifier, and the name of the environment variable
-// holding the client secret are stored as length-prefixed strings
+// The issuer, client identifier, the name of the environment variable
+// holding the client secret, and the policy name are stored as
+// length-prefixed strings. The policy name comes last so that the leading
+// bytes keep spanning exactly the provider client identity
 auto encode_oidc_metadata(const std::string_view issuer,
                           const std::string_view client_id,
-                          const std::string_view client_secret_variable)
+                          const std::string_view client_secret_variable,
+                          const std::string_view name)
     -> std::vector<std::byte> {
   std::vector<std::byte> result;
   append_string(result, issuer);
   append_string(result, client_id);
   append_string(result, client_secret_variable);
+  append_string(result, name);
   return result;
 }
 
@@ -201,8 +205,9 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
       policy_metadata = encode_jwt_metadata(policy.issuer, policy.audience,
                                             policy.jwks_uri, policy.algorithms);
     } else if (policy.type == Authentication::Type::OIDC) {
-      policy_metadata = encode_oidc_metadata(policy.issuer, policy.client_id,
-                                             policy.client_secret_variable);
+      policy_metadata =
+          encode_oidc_metadata(policy.issuer, policy.client_id,
+                               policy.client_secret_variable, policy.name);
     } else if (!policy.keys.empty()) {
       policy_metadata = encode_apikey_metadata(policy.keys);
     }

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -14,6 +14,7 @@
 #include <memory>      // std::shared_ptr, std::make_shared
 #include <optional>    // std::optional, std::nullopt
 #include <span>        // std::span
+#include <stdexcept>   // std::runtime_error
 #include <string>      // std::string
 #include <string_view> // std::string_view
 #include <utility>     // std::move
@@ -893,7 +894,8 @@ TEST(oidc_policy_admits_no_presented_credential) {
         .type = sourcemeta::one::Authentication::Type::OIDC,
         .issuer = "acme",
         .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_DENY"}}};
+        .client_secret_variable = "ONE_TEST_OIDC_DENY",
+        .name = "okta"}}};
   const auto path{test_path("oidc_deny.bin")};
   sourcemeta::one::Authentication::save(policies, path, path);
 
@@ -933,7 +935,8 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_only_the_key) {
         .type = sourcemeta::one::Authentication::Type::OIDC,
         .issuer = "acme",
         .client_id = "client",
-        .client_secret_variable = "ONE_TEST_KEY_OIDC_UNION"}}};
+        .client_secret_variable = "ONE_TEST_KEY_OIDC_UNION",
+        .name = "okta"}}};
   const auto path{test_path("oidc_union.bin")};
   sourcemeta::one::Authentication::save(policies, path, path);
 
@@ -1151,6 +1154,53 @@ TEST(session_admitted_under_a_rotated_secret) {
   EXPECT_TRUE(authentication.admits("/portal/x", "", cookies).allowed);
 }
 
+TEST(blank_session_secrets_are_discarded) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_BLANK",
+        .name = "okta"}}};
+  const auto path{test_path("oidc_session_blank.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const std::array<std::string_view, 2> secrets{{"", "session-secret"}};
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr), secrets};
+
+  // A value sealed under the blank entry never verifies
+  const auto forged{sourcemeta::one::session_seal(
+      R"JSON({ "policy": "okta" })JSON", "", SESSION_EXPIRY)};
+  const std::string forged_cookies{"sourcemeta_one_session_okta=" + forged};
+  EXPECT_FALSE(authentication.admits("/portal/x", "", forged_cookies).allowed);
+
+  // The non-blank entry still admits
+  const auto sealed{sourcemeta::one::session_seal(
+      R"JSON({ "policy": "okta" })JSON", "session-secret", SESSION_EXPIRY)};
+  const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
+  EXPECT_TRUE(authentication.admits("/portal/x", "", cookies).allowed);
+}
+
+TEST(save_rejects_a_nameless_interactive_policy) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_NAMELESS"}}};
+  const auto path{test_path("oidc_nameless.bin")};
+  try {
+    sourcemeta::one::Authentication::save(policies, path, path);
+    FAIL();
+  } catch (const std::runtime_error &error) {
+    EXPECT_STREQ(error.what(),
+                 "Interactive authentication policies require a name");
+  }
+}
+
 TEST(union_of_an_apikey_and_an_oidc_policy_admits_key_or_session) {
   setenv("ONE_TEST_KEY_SESSION_UNION", "union-key", 1);
   const std::array<std::string_view, 1> paths{{"/both"}};
@@ -1210,19 +1260,22 @@ TEST(session_cookie_does_not_open_an_apikey_path) {
 TEST(reference_within_the_same_oidc_scope_is_permitted) {
   const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
   const std::array<std::string_view, 1> beta_paths{{"/beta"}};
-  // The two policies name different environment variables for the secret,
-  // which does not affect who can authenticate, so the scopes stay equal
+  // The two policies differ in name and in the environment variable holding
+  // the secret, neither of which affects who can authenticate, so the scopes
+  // stay equal
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
         .type = sourcemeta::one::Authentication::Type::OIDC,
         .issuer = "https://login.test",
         .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_SAME"},
+        .client_secret_variable = "ONE_TEST_OIDC_REF_SAME",
+        .name = "alpha"},
        {.paths = beta_paths,
         .type = sourcemeta::one::Authentication::Type::OIDC,
         .issuer = "https://login.test",
         .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_SAME_OTHER"}}};
+        .client_secret_variable = "ONE_TEST_OIDC_REF_SAME_OTHER",
+        .name = "beta"}}};
   const auto path{test_path("oidc_ref_same.bin")};
   sourcemeta::one::Authentication::save(policies, path, path);
 
@@ -1240,12 +1293,14 @@ TEST(reference_across_distinct_oidc_clients_is_rejected) {
         .type = sourcemeta::one::Authentication::Type::OIDC,
         .issuer = "https://login.test",
         .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_ALPHA"},
+        .client_secret_variable = "ONE_TEST_OIDC_REF_ALPHA",
+        .name = "alpha"},
        {.paths = beta_paths,
         .type = sourcemeta::one::Authentication::Type::OIDC,
         .issuer = "https://login.test",
         .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_BETA"}}};
+        .client_secret_variable = "ONE_TEST_OIDC_REF_BETA",
+        .name = "beta"}}};
   const auto path{test_path("oidc_ref_distinct.bin")};
   sourcemeta::one::Authentication::save(policies, path, path);
 
@@ -1265,12 +1320,14 @@ TEST(reference_across_swapped_oidc_identities_is_rejected) {
         .type = sourcemeta::one::Authentication::Type::OIDC,
         .issuer = "https://login.test",
         .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_SWAP_ALPHA"},
+        .client_secret_variable = "ONE_TEST_OIDC_REF_SWAP_ALPHA",
+        .name = "alpha"},
        {.paths = beta_paths,
         .type = sourcemeta::one::Authentication::Type::OIDC,
         .issuer = "registry",
         .client_id = "https://login.test",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_SWAP_BETA"}}};
+        .client_secret_variable = "ONE_TEST_OIDC_REF_SWAP_BETA",
+        .name = "beta"}}};
   const auto path{test_path("oidc_ref_swapped.bin")};
   sourcemeta::one::Authentication::save(policies, path, path);
 
@@ -1291,17 +1348,20 @@ TEST(reference_mixing_identities_across_oidc_policies_is_rejected) {
         .type = sourcemeta::one::Authentication::Type::OIDC,
         .issuer = "https://alpha.test",
         .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_SOURCE"},
+        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_SOURCE",
+        .name = "source"},
        {.paths = target_paths,
         .type = sourcemeta::one::Authentication::Type::OIDC,
         .issuer = "https://alpha.test",
         .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_ONE"},
+        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_ONE",
+        .name = "target-one"},
        {.paths = target_paths,
         .type = sourcemeta::one::Authentication::Type::OIDC,
         .issuer = "https://beta.test",
         .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_TWO"}}};
+        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_TWO",
+        .name = "target-two"}}};
   const auto path{test_path("oidc_ref_mixed.bin")};
   sourcemeta::one::Authentication::save(policies, path, path);
 

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -5,6 +5,7 @@
 #include <sourcemeta/core/test.h>
 
 #include <array>       // std::array
+#include <chrono>      // std::chrono::sys_seconds, std::chrono::seconds
 #include <cstddef>     // std::byte, std::size_t
 #include <cstdlib>     // setenv
 #include <filesystem>  // std::filesystem::path
@@ -40,6 +41,12 @@ static constexpr std::string_view SIGNED_KEYS{
     R"JSON({ "keys": [ { "kty": "RSA", "n": "oHTpl-jfNfBuXmBp58sW8s_77UP6j2jA0mjjKjhDkxhp7Agk-xLNGgfPCS_bjdZ6YU6FGeab8uVjkSgo9_0OCJUaF4vzEGwXmNuGawANxnZtiYjWvbJlq-2mn_L7rsqGQcSkMmyM0g4aX7dF8wB6DVrXShJ78fcrNtpeoU72YGEdjehA8qVclDFwBdpCGynxxnWJePk72lQb6gkVMqKMc3jBF8GkWf8oP_sjss-fpOjSUMR1c8_0JlTYWO46KWOZa0EO2t8H1V3imMyzbhoxRd_qZHmo46gJkG-ZdebjX0vGQllaCwu0z4kLcXIfAZhqPEkdssDGhC_txwJuhaPDFQ", "e": "AQAB" } ] })JSON"};
 static constexpr std::string_view UNRELATED_KEYS{
     R"JSON({ "keys": [ { "kty": "RSA", "n": "ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddxHmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMsD1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSHSXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdVMTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ", "e": "AQAB" } ] })JSON"};
+
+// A session expiry far enough in the future to outlive any test run
+static constexpr std::chrono::sys_seconds SESSION_EXPIRY{
+    std::chrono::seconds{2000000000}};
+
+static const std::array<std::string, 1> SESSION_SECRETS{{"session-secret"}};
 
 static auto stub_fetcher(std::map<std::string, std::string> responses,
                          std::shared_ptr<int> calls)
@@ -366,14 +373,15 @@ TEST(base_path_is_stripped_before_matching) {
       path, stub_fetcher({}, nullptr)};
   // With the base path stripped, the registry path under it is matched. The
   // uncovered public path is admitted, the covered one is gated
-  EXPECT_TRUE(authentication.admits("/registry/public/string", "", "/registry")
-                  .allowed);
+  EXPECT_TRUE(
+      authentication.admits("/registry/public/string", "", {}, "/registry")
+          .allowed);
   EXPECT_FALSE(
-      authentication.admits("/registry/private/secret", "", "/registry")
+      authentication.admits("/registry/private/secret", "", {}, "/registry")
           .allowed);
   EXPECT_TRUE(
       authentication
-          .admits("/registry/private/secret", "base-secret", "/registry")
+          .admits("/registry/private/secret", "base-secret", {}, "/registry")
           .allowed);
 
   // An empty base path strips nothing
@@ -383,12 +391,13 @@ TEST(base_path_is_stripped_before_matching) {
   // A base path that is not a whole-segment prefix is left in place, so the
   // path is covered by no policy and is public
   EXPECT_TRUE(
-      authentication.admits("/registryextra/public/string", "", "/registry")
+      authentication.admits("/registryextra/public/string", "", {}, "/registry")
           .allowed);
 
   // A request outside the base path is left in place and covered by no policy
-  EXPECT_TRUE(authentication.admits("/elsewhere/public/string", "", "/registry")
-                  .allowed);
+  EXPECT_TRUE(
+      authentication.admits("/elsewhere/public/string", "", {}, "/registry")
+          .allowed);
 }
 
 TEST(apikey_admits_matching_credential) {
@@ -940,6 +949,261 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_only_the_key) {
   const auto token_verdict{authentication.admits("/both/x", SIGNED_TOKEN)};
   EXPECT_FALSE(token_verdict.allowed);
   EXPECT_FALSE(token_verdict.principal.has_value());
+}
+
+TEST(oidc_policy_admits_its_session_cookie) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_SESSION",
+        .name = "okta"}}};
+  const auto path{test_path("oidc_session.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const auto calls{std::make_shared<int>(0)};
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, calls), SESSION_SECRETS};
+
+  const auto sealed{sourcemeta::one::session_seal(
+      R"JSON({ "policy": "okta", "subject": "jane@acme.test" })JSON",
+      "session-secret", SESSION_EXPIRY)};
+  const std::string cookies{"theme=dark; sourcemeta_one_session_okta=" +
+                            sealed};
+
+  const auto verdict{authentication.admits("/portal/x", "", cookies)};
+  EXPECT_TRUE(verdict.allowed);
+  EXPECT_TRUE(verdict.principal.has_value());
+  EXPECT_EQ(verdict.principal.value().type,
+            sourcemeta::one::Authentication::Type::OIDC);
+  EXPECT_EQ(verdict.principal.value().policy, std::size_t{0});
+  EXPECT_EQ(*calls, 0);
+
+  const auto anonymous_verdict{authentication.admits("/portal/x", "")};
+  EXPECT_FALSE(anonymous_verdict.allowed);
+  EXPECT_FALSE(anonymous_verdict.principal.has_value());
+}
+
+TEST(session_cookie_is_bound_to_the_policy_it_was_minted_for) {
+  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
+  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = alpha_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_BIND_A",
+        .name = "okta"},
+       {.paths = beta_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_BIND_B",
+        .name = "google"}}};
+  const auto path{test_path("oidc_session_bound.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr), SESSION_SECRETS};
+
+  const auto sealed{sourcemeta::one::session_seal(
+      R"JSON({ "policy": "okta" })JSON", "session-secret", SESSION_EXPIRY)};
+
+  // The session opens the path its policy governs
+  const std::string okta_cookies{"sourcemeta_one_session_okta=" + sealed};
+  EXPECT_TRUE(authentication.admits("/alpha/x", "", okta_cookies).allowed);
+
+  // The same session does not open a path governed by another policy
+  EXPECT_FALSE(authentication.admits("/beta/x", "", okta_cookies).allowed);
+
+  // Nor does re-presenting the value under the other policy's cookie name
+  const std::string renamed_cookies{"sourcemeta_one_session_google=" + sealed};
+  EXPECT_FALSE(authentication.admits("/beta/x", "", renamed_cookies).allowed);
+}
+
+TEST(expired_session_cookie_is_denied) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_EXPIRED",
+        .name = "okta"}}};
+  const auto path{test_path("oidc_session_expired.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr), SESSION_SECRETS};
+
+  const std::chrono::sys_seconds past{std::chrono::seconds{1000}};
+  const auto sealed{sourcemeta::one::session_seal(
+      R"JSON({ "policy": "okta" })JSON", "session-secret", past)};
+  const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
+  EXPECT_FALSE(authentication.admits("/portal/x", "", cookies).allowed);
+}
+
+TEST(forged_session_cookie_is_denied) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_FORGED",
+        .name = "okta"}}};
+  const auto path{test_path("oidc_session_forged.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr), SESSION_SECRETS};
+
+  // A value sealed under a secret this instance does not hold
+  const auto foreign{sourcemeta::one::session_seal(
+      R"JSON({ "policy": "okta" })JSON", "other-secret", SESSION_EXPIRY)};
+  const std::string foreign_cookies{"sourcemeta_one_session_okta=" + foreign};
+  EXPECT_FALSE(authentication.admits("/portal/x", "", foreign_cookies).allowed);
+
+  // A value whose signature no longer matches its contents
+  auto tampered{sourcemeta::one::session_seal(
+      R"JSON({ "policy": "okta" })JSON", "session-secret", SESSION_EXPIRY)};
+  tampered.back() = tampered.back() == 'A' ? 'B' : 'A';
+  const std::string tampered_cookies{"sourcemeta_one_session_okta=" + tampered};
+  EXPECT_FALSE(
+      authentication.admits("/portal/x", "", tampered_cookies).allowed);
+
+  // A value that is not a sealed session at all
+  EXPECT_FALSE(
+      authentication
+          .admits("/portal/x", "", "sourcemeta_one_session_okta=garbage")
+          .allowed);
+}
+
+TEST(session_payload_must_declare_its_policy) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_PAYLOAD",
+        .name = "okta"}}};
+  const auto path{test_path("oidc_session_payload.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr), SESSION_SECRETS};
+
+  const std::array<std::string_view, 4> payloads{
+      {"not json", "[ 1, 2 ]", R"JSON({ "subject": "jane" })JSON",
+       R"JSON({ "policy": "google" })JSON"}};
+  for (const auto payload : payloads) {
+    const auto sealed{sourcemeta::one::session_seal(payload, "session-secret",
+                                                    SESSION_EXPIRY)};
+    const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
+    EXPECT_FALSE(authentication.admits("/portal/x", "", cookies).allowed);
+  }
+}
+
+TEST(session_cookie_without_configured_secrets_is_denied) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_NO_SECRETS",
+        .name = "okta"}}};
+  const auto path{test_path("oidc_session_no_secrets.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+
+  const auto sealed{sourcemeta::one::session_seal(
+      R"JSON({ "policy": "okta" })JSON", "session-secret", SESSION_EXPIRY)};
+  const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
+  EXPECT_FALSE(authentication.admits("/portal/x", "", cookies).allowed);
+}
+
+TEST(session_admitted_under_a_rotated_secret) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_ROTATED",
+        .name = "okta"}}};
+  const auto path{test_path("oidc_session_rotated.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const std::array<std::string, 2> rotated{{"new-secret", "old-secret"}};
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr), rotated};
+
+  const auto sealed{sourcemeta::one::session_seal(
+      R"JSON({ "policy": "okta" })JSON", "old-secret", SESSION_EXPIRY)};
+  const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
+  EXPECT_TRUE(authentication.admits("/portal/x", "", cookies).allowed);
+}
+
+TEST(union_of_an_apikey_and_an_oidc_policy_admits_key_or_session) {
+  setenv("ONE_TEST_KEY_SESSION_UNION", "union-key", 1);
+  const std::array<std::string_view, 1> paths{{"/both"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_SESSION_UNION"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = paths, .keys = keys},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_SESSION_UNION",
+        .name = "okta"}}};
+  const auto path{test_path("oidc_session_union.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr), SESSION_SECRETS};
+
+  const auto key_verdict{authentication.admits("/both/x", "union-key")};
+  EXPECT_TRUE(key_verdict.allowed);
+  EXPECT_TRUE(key_verdict.principal.has_value());
+  EXPECT_EQ(key_verdict.principal.value().type,
+            sourcemeta::one::Authentication::Type::ApiKey);
+  EXPECT_EQ(key_verdict.principal.value().policy, std::size_t{0});
+
+  const auto sealed{sourcemeta::one::session_seal(
+      R"JSON({ "policy": "okta" })JSON", "session-secret", SESSION_EXPIRY)};
+  const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
+  const auto session_verdict{authentication.admits("/both/x", "", cookies)};
+  EXPECT_TRUE(session_verdict.allowed);
+  EXPECT_TRUE(session_verdict.principal.has_value());
+  EXPECT_EQ(session_verdict.principal.value().type,
+            sourcemeta::one::Authentication::Type::OIDC);
+  EXPECT_EQ(session_verdict.principal.value().policy, std::size_t{1});
+
+  EXPECT_FALSE(authentication.admits("/both/x", "").allowed);
+}
+
+TEST(session_cookie_does_not_open_an_apikey_path) {
+  setenv("ONE_TEST_KEY_NO_SESSION", "key-only", 1);
+  const std::array<std::string_view, 1> paths{{"/internal"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_NO_SESSION"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{paths, keys}}};
+  const auto path{test_path("oidc_session_apikey.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr), SESSION_SECRETS};
+
+  const auto sealed{sourcemeta::one::session_seal(
+      R"JSON({ "policy": "okta" })JSON", "session-secret", SESSION_EXPIRY)};
+  const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
+  EXPECT_FALSE(authentication.admits("/internal/x", "", cookies).allowed);
 }
 
 TEST(reference_within_the_same_oidc_scope_is_permitted) {

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -46,7 +46,8 @@ static constexpr std::string_view UNRELATED_KEYS{
 static constexpr std::chrono::sys_seconds SESSION_EXPIRY{
     std::chrono::seconds{2000000000}};
 
-static const std::array<std::string, 1> SESSION_SECRETS{{"session-secret"}};
+static constexpr std::array<std::string_view, 1> SESSION_SECRETS{
+    {"session-secret"}};
 
 static auto stub_fetcher(std::map<std::string, std::string> responses,
                          std::shared_ptr<int> calls)
@@ -1140,7 +1141,7 @@ TEST(session_admitted_under_a_rotated_secret) {
   const auto path{test_path("oidc_session_rotated.bin")};
   sourcemeta::one::Authentication::save(policies, path, path);
 
-  const std::array<std::string, 2> rotated{{"new-secret", "old-secret"}};
+  const std::array<std::string_view, 2> rotated{{"new-secret", "old-secret"}};
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr), rotated};
 

--- a/src/authentication/CMakeLists.txt
+++ b/src/authentication/CMakeLists.txt
@@ -8,6 +8,7 @@ if(ONE_ENTERPRISE)
       "${PROJECT_SOURCE_DIR}/enterprise/authentication/discovery.cc")
   target_compile_definitions(sourcemeta_one_authentication PUBLIC SOURCEMETA_ONE_ENTERPRISE)
   target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::crypto)
+  target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::http)
 else()
   sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME authentication
     PRIVATE_HEADERS error.h session.h discovery.h

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -6,6 +6,8 @@
 #include <cstddef>    // std::byte, std::size_t
 #include <filesystem> // std::filesystem::create_directories
 #include <optional>   // std::nullopt
+#include <span>       // std::span
+#include <string>     // std::string
 #include <vector>     // std::vector
 
 namespace sourcemeta::one {
@@ -37,12 +39,14 @@ auto Authentication::save(const Configuration &configuration,
 
 // NOLINTBEGIN(performance-unnecessary-value-param)
 Authentication::Authentication(const std::filesystem::path &,
-                               sourcemeta::core::JWKSProvider::Fetcher) {}
+                               sourcemeta::core::JWKSProvider::Fetcher,
+                               const std::span<const std::string>) {}
 // NOLINTEND(performance-unnecessary-value-param)
 
 Authentication::~Authentication() = default;
 
 auto Authentication::admits(const std::string_view, const std::string_view,
+                            const std::string_view,
                             const std::string_view) const
     -> Authentication::Verdict {
   return {.allowed = true, .principal = std::nullopt};

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -3,12 +3,12 @@
 
 #include <sourcemeta/core/io.h>
 
-#include <cstddef>    // std::byte, std::size_t
-#include <filesystem> // std::filesystem::create_directories
-#include <optional>   // std::nullopt
-#include <span>       // std::span
-#include <string>     // std::string
-#include <vector>     // std::vector
+#include <cstddef>     // std::byte, std::size_t
+#include <filesystem>  // std::filesystem::create_directories
+#include <optional>    // std::nullopt
+#include <span>        // std::span
+#include <string_view> // std::string_view
+#include <vector>      // std::vector
 
 namespace sourcemeta::one {
 
@@ -40,7 +40,7 @@ auto Authentication::save(const Configuration &configuration,
 // NOLINTBEGIN(performance-unnecessary-value-param)
 Authentication::Authentication(const std::filesystem::path &,
                                sourcemeta::core::JWKSProvider::Fetcher,
-                               const std::span<const std::string>) {}
+                               const std::span<const std::string_view>) {}
 // NOLINTEND(performance-unnecessary-value-param)
 
 Authentication::~Authentication() = default;

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -19,7 +19,6 @@
 #include <memory>      // std::unique_ptr
 #include <optional>    // std::optional
 #include <span>        // std::span
-#include <string>      // std::string
 #include <string_view> // std::string_view
 #include <vector>      // std::vector
 
@@ -77,10 +76,11 @@ public:
                    const std::filesystem::path &destination) -> void;
 
   // The session secrets verify the cookies that interactive logins mint. An
-  // instance given none never admits a session
+  // instance given none never admits a session. The secrets are copied, so
+  // the caller's storage only needs to outlive this constructor
   Authentication(const std::filesystem::path &path,
                  sourcemeta::core::JWKSProvider::Fetcher fetcher,
-                 std::span<const std::string> session_secrets = {});
+                 std::span<const std::string_view> session_secrets = {});
 
   ~Authentication();
 

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -19,6 +19,7 @@
 #include <memory>      // std::unique_ptr
 #include <optional>    // std::optional
 #include <span>        // std::span
+#include <string>      // std::string
 #include <string_view> // std::string_view
 #include <vector>      // std::vector
 
@@ -48,6 +49,9 @@ public:
     std::string_view client_id{};
     // The environment variable name holding the client secret
     std::string_view client_secret_variable{};
+    // The policy name, which interactive policies carry so their session
+    // cookies can be recognised at the gate
+    std::string_view name{};
   };
 
   // The identity of an admitted caller: the type of credential it presented
@@ -72,8 +76,11 @@ public:
                    const sourcemeta::core::URITemplateRouterView &routes,
                    const std::filesystem::path &destination) -> void;
 
+  // The session secrets verify the cookies that interactive logins mint. An
+  // instance given none never admits a session
   Authentication(const std::filesystem::path &path,
-                 sourcemeta::core::JWKSProvider::Fetcher fetcher);
+                 sourcemeta::core::JWKSProvider::Fetcher fetcher,
+                 std::span<const std::string> session_secrets = {});
 
   ~Authentication();
 
@@ -84,9 +91,12 @@ public:
   auto operator=(Authentication &&) -> Authentication & = delete;
 
   // A non-empty base path is stripped off the input before matching, turning a
-  // request URL path into a registry path
+  // request URL path into a registry path. The credential is a presented
+  // bearer value and the cookies are the raw request cookie header, either of
+  // which may admit the caller under a covering policy
   [[nodiscard]] auto admits(std::string_view registry_path,
                             std::string_view credential,
+                            std::string_view cookies = {},
                             std::string_view base_path = {}) const -> Verdict;
 
   // The configuration declaration indices of the policies that govern a path,

--- a/src/router/router.cc
+++ b/src/router/router.cc
@@ -121,7 +121,8 @@ auto Router::dispatch(
   // path. A credential-less CORS preflight is never gated
   if (identifier != 0 && request.method() != "options" &&
       !this->authentication_
-           .admits(request.path(), credential, instance->server_uri_base_path())
+           .admits(request.path(), credential, request.header("cookie"),
+                   instance->server_uri_base_path())
            .allowed) {
     sourcemeta::one::json_error_unauthorized(request, response,
                                              this->default_error_schema_, "*");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

