### PR TITLE
Redirect unauthenticated browsers to SSO login at the gate

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -521,8 +521,9 @@ An `oidc` policy grants access to a user who signs in through an OpenID Connect
 provider in the browser. Where an `apiKey` or `jwt` policy admits a machine that
 presents a credential on every request, an `oidc` policy authenticates a user
 once at their provider and then relies on a session the instance establishes and
-signs itself. Until that session exists, a browser that reaches a governed path
-is denied like any other unauthenticated request.
+signs itself. Until that session exists, a browser that navigates to a governed
+page is sent to begin a login, while a request for the raw schema, or from a
+machine, is denied like any other unauthenticated request.
 
 The instance registers with the provider as a client, identified by its
 `clientId` and the client secret shared with it. It trusts the `issuer` both as

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -677,6 +677,45 @@ struct Authentication::Impl {
         .client_secret_variable = decoded.client_secret_variable};
   }
 
+  [[nodiscard]] auto
+  interactive_challenges(const std::string_view registry_path) const
+      -> std::vector<std::string_view> {
+    std::vector<std::string_view> result;
+    if (this->nodes_ == nullptr) {
+      return result;
+    }
+
+    const auto governing{this->match(registry_path)};
+    if (governing == 0) {
+      return result;
+    }
+
+    const auto *policies{
+        static_cast<const AuthenticationPolicyEntry *>(this->policies_)};
+    for (std::uint32_t index{0}; index < this->policy_count_; index += 1) {
+      if ((governing & (PolicySet{1} << index)) == 0) {
+        continue;
+      }
+
+      const auto &entry{policies[index]};
+      if (static_cast<Authentication::Type>(entry.type) !=
+              Authentication::Type::OIDC ||
+          entry.metadata_length == 0) {
+        continue;
+      }
+
+      const std::span<const std::byte> metadata{
+          this->view_->as<std::byte>(entry.metadata_offset),
+          entry.metadata_length};
+      OIDCPolicyMetadata decoded;
+      if (decode_oidc_metadata(metadata, decoded) && !decoded.name.empty()) {
+        result.push_back(decoded.name);
+      }
+    }
+
+    return result;
+  }
+
   // Split a secret variable's value into one secret per non-blank line. The
   // resulting views borrow from the given value, so it must outlive them, and
   // blank lines are skipped so a stray one cannot become a forgeable empty key
@@ -963,6 +1002,13 @@ auto Authentication::governing(const std::string_view registry_path,
   }
 
   return result;
+}
+
+auto Authentication::interactive_challenges(
+    const std::string_view registry_path,
+    const std::string_view base_path) const -> std::vector<std::string_view> {
+  return this->impl_->interactive_challenges(
+      strip_base_path(registry_path, base_path));
 }
 
 auto Authentication::reference_permitted(

--- a/enterprise/e2e/auth-closed/hurl/denial.all.hurl
+++ b/enterprise/e2e/auth-closed/hurl/denial.all.hurl
@@ -129,24 +129,23 @@ Access-Control-Allow-Origin: *
   "detail": "This resource requires authentication"
 }
 
-# The human directory pages render the 401 page rather than any listing
+# A browser navigating to a gated page is sent to begin a login rather than
+# shown a denial, since a single interactive policy governs the whole registry
 GET {{base}}/
 Accept: text/html
-HTTP 401
-Content-Type: text/html; charset=utf-8
-WWW-Authenticate: Bearer realm="registry"
+HTTP 303
+Location: /self/v1/auth/login/keycloak
+Cache-Control: no-store
 [Asserts]
-xpath "string(//title)" == "Unauthorized"
-xpath "string(//h2[@class='fw-bold'])" == "This page requires authentication"
+header "Set-Cookie" not exists
 
 GET {{base}}/catalog/
 Accept: text/html
-HTTP 401
-Content-Type: text/html; charset=utf-8
-WWW-Authenticate: Bearer realm="registry"
+HTTP 303
+Location: /self/v1/auth/login/keycloak
+Cache-Control: no-store
 [Asserts]
-xpath "string(//title)" == "Unauthorized"
-xpath "string(//h2[@class='fw-bold'])" == "This page requires authentication"
+header "Set-Cookie" not exists
 
 # The same directories requested as JSON deny identically, the root included
 GET {{base}}/

--- a/enterprise/e2e/auth-path/hurl/sso.all.hurl
+++ b/enterprise/e2e/auth-path/hurl/sso.all.hurl
@@ -57,6 +57,16 @@ header "ETag" matches /^"[0-9a-f]{64}"$/
   "additionalProperties": false
 }
 
+# A browser navigating to the console page under the base path is sent to begin
+# a login, its redirect target rooted at the base path like every other link
+GET {{base}}/registry/console/
+Accept: text/html
+HTTP 303
+Location: /registry/self/v1/auth/login/keycloak
+Cache-Control: no-store
+[Asserts]
+header "Set-Cookie" not exists
+
 # Starting a login redirects to the real provider, carrying a transaction cookie
 # scoped to the base path
 GET {{base}}/registry/self/v1/auth/login/keycloak

--- a/enterprise/e2e/auth-sso/hurl/redirect.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/redirect.all.hurl
@@ -65,8 +65,7 @@ Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
 jsonpath "$.valid" == true
 
 # The data representation stays JSON even for a browser: an explicit ".json"
-# asks for the schema, not the page, so it is denied rather than redirected, the
-# body byte-identical to the machine denial above
+# asks for the schema, not the page, so it is denied rather than redirected
 GET {{base}}/private/secret.json
 Accept: text/html
 HTTP 401
@@ -74,6 +73,8 @@ Cache-Control: no-store
 Content-Type: application/problem+json
 WWW-Authenticate: Bearer realm="registry"
 Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+browser_json_denied: body
 [Asserts]
 header "Location" not exists
 {
@@ -82,3 +83,13 @@ header "Location" not exists
   "status": 401,
   "detail": "This resource requires authentication"
 }
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{browser_json_denied}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true

--- a/enterprise/e2e/auth-sso/hurl/redirect.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/redirect.all.hurl
@@ -1,0 +1,84 @@
+# A browser navigating to a gated page is sent to begin a login, since a single
+# interactive policy governs the private tree. The denial a machine sees becomes
+# a redirect a person can follow.
+GET {{base}}/private/
+Accept: text/html
+HTTP 303
+Location: /self/v1/auth/login/keycloak
+Cache-Control: no-store
+[Asserts]
+header "Set-Cookie" not exists
+
+# HEAD is a navigation too, and redirects identically with no body
+HEAD {{base}}/private/
+Accept: text/html
+HTTP 303
+Location: /self/v1/auth/login/keycloak
+Cache-Control: no-store
+
+# The extensionless schema page redirects the same way
+GET {{base}}/private/secret
+Accept: text/html
+HTTP 303
+Location: /self/v1/auth/login/keycloak
+Cache-Control: no-store
+
+# A public page is served, never redirected, so the login only fronts what is
+# actually gated
+GET {{base}}/public/
+Accept: text/html
+HTTP 200
+Content-Type: text/html; charset=utf-8
+[Asserts]
+header "Location" not exists
+xpath "string(//title)" != "Unauthorized"
+
+# A client asking for JSON is denied, never redirected, so scripting the API
+# still sees the honest 401
+GET {{base}}/private/secret.json
+Accept: application/json
+HTTP 401
+Cache-Control: no-store
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+machine_denied: body
+error_schema: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "Location" not exists
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{machine_denied}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# The data representation stays JSON even for a browser: an explicit ".json"
+# asks for the schema, not the page, so it is denied rather than redirected, the
+# body byte-identical to the machine denial above
+GET {{base}}/private/secret.json
+Accept: text/html
+HTTP 401
+Cache-Control: no-store
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Asserts]
+header "Location" not exists
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}

--- a/enterprise/e2e/auth/hurl/sso.all.hurl
+++ b/enterprise/e2e/auth/hurl/sso.all.hurl
@@ -58,6 +58,16 @@ header "ETag" matches /^"[0-9a-f]{64}"$/
   "additionalProperties": false
 }
 
+# A browser navigating to the console page is sent to begin a login, while the
+# machine key above keeps working: one path, two audiences
+GET {{base}}/console/
+Accept: text/html
+HTTP 303
+Location: /self/v1/auth/login/keycloak
+Cache-Control: no-store
+[Asserts]
+header "Set-Cookie" not exists
+
 # Starting a login redirects to the real provider with the transaction cookie
 GET {{base}}/self/v1/auth/login/keycloak
 HTTP 303

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -960,6 +960,59 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_only_the_key) {
   EXPECT_FALSE(token_verdict.principal.has_value());
 }
 
+TEST(interactive_challenges_names_the_covering_interactive_policies) {
+  setenv("ONE_TEST_CHALLENGE_KEY", "key-secret", 1);
+  const std::array<std::string_view, 2> key_paths{{"/both", "/machine"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_CHALLENGE_KEY"}};
+  const std::array<std::string_view, 1> portal{{"/portal"}};
+  const std::array<std::string_view, 1> both{{"/both"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 4> policies{
+      {{.paths = key_paths, .keys = keys},
+       {.paths = portal,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_CHALLENGE_KEY",
+        .name = "okta",
+        .session_secret_variable = "ONE_TEST_OIDC_SESSION_UNUSED"},
+       {.paths = both,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_CHALLENGE_KEY",
+        .name = "azure",
+        .session_secret_variable = "ONE_TEST_OIDC_SESSION_UNUSED"},
+       {.paths = portal,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_CHALLENGE_KEY",
+        .name = "second",
+        .session_secret_variable = "ONE_TEST_OIDC_SESSION_UNUSED"}}};
+  const auto path{test_path("interactive_challenges.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+
+  // An apiKey-only path offers no interactive login
+  EXPECT_EQ(authentication.interactive_challenges("/machine/x"),
+            (std::vector<std::string_view>{}));
+
+  // A single interactive policy names one challenge, ignoring the apiKey
+  // policy that also covers the path
+  EXPECT_EQ(authentication.interactive_challenges("/both/x"),
+            (std::vector<std::string_view>{"azure"}));
+
+  // Several interactive policies covering a path are named in declaration order
+  EXPECT_EQ(authentication.interactive_challenges("/portal/x"),
+            (std::vector<std::string_view>{"okta", "second"}));
+
+  // An ungoverned path has none
+  EXPECT_EQ(authentication.interactive_challenges("/public"),
+            (std::vector<std::string_view>{}));
+}
+
 TEST(oidc_policy_admits_its_session_cookie) {
   setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
   const std::array<std::string_view, 1> paths{{"/portal"}};

--- a/src/actions/action_default_v1.h
+++ b/src/actions/action_default_v1.h
@@ -102,9 +102,7 @@ public:
         return;
       }
       const auto serve_html{
-          sourcemeta::core::http_match_accept(
-              request.header("accept"), {"application/json", "text/html"}) ==
-          "text/html"};
+          sourcemeta::one::prefers_html(request.header("accept"))};
       const auto root_html{this->artifact_resolve_path(
           {.bearer = credential, .cookies = request.header("cookie")}, "",
           Tree::Explorer, "directory-html")};
@@ -145,9 +143,7 @@ public:
     }
 
     if (request.method() == "get" || request.method() == "head") {
-      if (sourcemeta::core::http_match_accept(
-              request.header("accept"), {"application/json", "text/html"}) ==
-          "text/html") {
+      if (sourcemeta::one::prefers_html(request.header("accept"))) {
         const auto schema_html{this->artifact_resolve_path(
             {.bearer = credential, .cookies = request.header("cookie")}, path,
             Tree::Explorer, "schema-html")};
@@ -254,6 +250,12 @@ private:
           &browser_security,
       sourcemeta::one::HTTPRequest &request,
       sourcemeta::one::HTTPResponse &response) -> void {
+    // A browser denied a page is sent to begin a login when a single
+    // interactive policy governs the path, rather than shown the denial page
+    if (this->redirect_to_login(request, response)) {
+      return;
+    }
+
     const auto unauthorized{
         this->artifact_resolve_path_unauthenticated("", Tree::Explorer, "401")};
     if (unauthorized.has_value()) {

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -59,6 +59,12 @@ auto Authentication::governing(const std::string_view,
   return {};
 }
 
+auto Authentication::interactive_challenges(const std::string_view,
+                                            const std::string_view) const
+    -> std::vector<std::string_view> {
+  return {};
+}
+
 auto Authentication::interactive(const std::string_view) const
     -> std::optional<Authentication::InteractivePolicy> {
   return std::nullopt;

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -115,6 +115,15 @@ public:
                                std::string_view base_path = {}) const
       -> std::vector<std::size_t>;
 
+  // The names of the interactive policies that govern a path, in declaration
+  // order. An unauthenticated browser that a policy would otherwise deny can be
+  // sent to begin a login when exactly one such policy covers the path. The
+  // views point into the artifact and outlive the call
+  [[nodiscard]] auto
+  interactive_challenges(std::string_view registry_path,
+                         std::string_view base_path = {}) const
+      -> std::vector<std::string_view>;
+
   // What an interactive policy declares about its provider client. The views
   // point into the artifact and remain valid for the lifetime of this
   // instance

--- a/src/http/include/sourcemeta/one/http_helpers.h
+++ b/src/http/include/sourcemeta/one/http_helpers.h
@@ -185,6 +185,15 @@ inline auto json_error(const HTTPRequest &request, HTTPResponse &response,
   send_response(status, request, response, output.str(), Encoding::Identity);
 }
 
+// Whether the caller prefers an HTML representation over JSON. The Accept
+// header is negotiated with quality values rather than matched literally, so a
+// browser presenting its full Accept list is recognised, while a client that
+// asks for JSON, or asks for nothing, is not
+[[nodiscard]] inline auto prefers_html(const std::string_view accept) -> bool {
+  return sourcemeta::core::http_match_accept(
+             accept, {"application/json", "text/html"}) == "text/html";
+}
+
 // The single shape of an authentication denial on the HTTP surface, so
 // every protected resource answers identically
 inline auto json_error_unauthorized(const HTTPRequest &request,

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -88,6 +88,13 @@ public:
     return false;
   }
 
+  // Send an unauthenticated browser navigating to a path that exactly one
+  // interactive policy governs to begin a login, returning true when it wrote
+  // the redirect so the caller stops. Machines, non-navigations, and paths
+  // with no or several interactive policies fall through to the plain denial
+  [[nodiscard]] auto redirect_to_login(HTTPRequest &request,
+                                       HTTPResponse &response) const -> bool;
+
   [[nodiscard]] auto server_uri_base_path() const noexcept -> std::string_view {
     return this->server_uri_base_path_;
   }

--- a/src/router/router.cc
+++ b/src/router/router.cc
@@ -127,12 +127,42 @@ auto Router::dispatch(
            .admits(request.path(), credential, request.header("cookie"),
                    instance->server_uri_base_path())
            .allowed) {
+    if (instance->redirect_to_login(request, response)) {
+      return;
+    }
+
     sourcemeta::one::json_error_unauthorized(request, response,
                                              this->default_error_schema_, "*");
     return;
   }
 
   instance->rest(matches, credential, request, response);
+}
+
+auto RouterAction::redirect_to_login(
+    sourcemeta::one::HTTPRequest &request,
+    sourcemeta::one::HTTPResponse &response) const -> bool {
+  if ((request.method() != "get" && request.method() != "head") ||
+      !sourcemeta::one::prefers_html(request.header("accept"))) {
+    return false;
+  }
+
+  const auto challenges{
+      this->dispatcher().authentication().interactive_challenges(
+          request.path(), this->server_uri_base_path())};
+  if (challenges.size() != 1) {
+    return false;
+  }
+
+  std::string location{this->server_uri_base_path()};
+  location += "/self/v1/auth/login/";
+  location += challenges.front();
+  response.write_status(sourcemeta::core::HTTP_STATUS_SEE_OTHER);
+  response.write_header("Location", location);
+  response.write_header("Cache-Control", "no-store");
+  sourcemeta::one::send_response(sourcemeta::core::HTTP_STATUS_SEE_OTHER,
+                                 request, response);
+  return true;
 }
 
 } // namespace sourcemeta::one


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

