### PR TITLE
Support a human readable `title` in OIDC policies

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -534,6 +534,7 @@ follows is signed with a secret of the instance's own, unrelated to the provider
 
 | Property        | Type | Required | Default | Description |
 |-----------------|------|----------|---------|-------------|
+| `/title`        | String  | No | The policy name | A human readable version of the policy name |
 | `/issuer`       | String  | :red_circle: **Yes** | N/A | The OpenID Connect issuer to trust, matched against the identity token's `iss` claim and used to discover the provider's metadata, including the signing key set that verifies tokens |
 | `/clientId`     | String  | :red_circle: **Yes** | N/A | The client identifier registered with the provider for this instance |
 | `/clientSecret` | Object  | :red_circle: **Yes** | N/A | The client secret shared with the provider, read from an environment variable so that it never lives in the configuration file |
@@ -559,6 +560,7 @@ sign in through their identity provider to reach it:
     {
       "type": "oidc",
       "name": "console",
+      "title": "Acme Single Sign-On",
       "paths": [ "/console" ],
       "issuer": "https://accounts.example.com",
       "clientId": "schemas-registry",

--- a/src/configuration/include/sourcemeta/one/configuration.h
+++ b/src/configuration/include/sourcemeta/one/configuration.h
@@ -68,6 +68,8 @@ struct Configuration {
     Type type{Type::ApiKey};
     // The policy name
     sourcemeta::core::JSON::String name;
+    // A human readable version of the name
+    sourcemeta::core::JSON::String title;
     std::vector<sourcemeta::core::JSON::String> paths;
     Algorithm algorithm{Algorithm::Identity};
     // Environment variable names holding the keys

--- a/src/configuration/parse.cc
+++ b/src/configuration/parse.cc
@@ -176,6 +176,8 @@ auto Configuration::parse(const sourcemeta::core::JSON &data,
             entry.at("clientSecret").at("environmentVariable").to_string();
         parsed.session_secret_variable =
             entry.at("sessionSecret").at("environmentVariable").to_string();
+        const auto *title{entry.try_at("title")};
+        parsed.title = title == nullptr ? parsed.name : title->to_string();
       } else {
         parsed.type = Configuration::AuthenticationEntry::Type::ApiKey;
         parsed.algorithm =

--- a/src/configuration/parse.cc
+++ b/src/configuration/parse.cc
@@ -147,6 +147,7 @@ auto Configuration::parse(const sourcemeta::core::JSON &data,
     for (const auto &entry : data.at("authentication").as_array()) {
       Configuration::AuthenticationEntry parsed;
       parsed.name = entry.at("name").to_string();
+      parsed.title = parsed.name;
       for (const auto &path : entry.at("paths").as_array()) {
         parsed.paths.push_back(path.to_string());
       }
@@ -177,7 +178,9 @@ auto Configuration::parse(const sourcemeta::core::JSON &data,
         parsed.session_secret_variable =
             entry.at("sessionSecret").at("environmentVariable").to_string();
         const auto *title{entry.try_at("title")};
-        parsed.title = title == nullptr ? parsed.name : title->to_string();
+        if (title != nullptr) {
+          parsed.title = title->to_string();
+        }
       } else {
         parsed.type = Configuration::AuthenticationEntry::Type::ApiKey;
         parsed.algorithm =

--- a/src/configuration/schema/configuration.json
+++ b/src/configuration/schema/configuration.json
@@ -195,6 +195,10 @@
                 "type": "string",
                 "pattern": "^[a-z0-9-]+$"
               },
+              "title": {
+                "type": "string",
+                "minLength": 1
+              },
               "paths": {
                 "type": "array",
                 "minItems": 1,

--- a/test/cli/index/enterprise/fail-authentication-apikey-without-keys.sh
+++ b/test/cli/index/enterprise/fail-authentication-apikey-without-keys.sh
@@ -33,7 +33,7 @@ The object value was expected to validate against the defined properties subsche
 The value was expected to be an object that defines properties "algorithms", "audience", "issuer", "name", "paths", and "type"
   at instance location "/authentication/0"
   at evaluate path "/properties/authentication/items/anyOf/1/required"
-The object value was expected to only define properties "clientId", "clientSecret", "issuer", "name", "paths", "sessionSecret", and "type", but it also defines properties "algorithm", and "keys"
+The value was expected to be an object that defines properties "clientId", "clientSecret", "issuer", "name", "paths", "sessionSecret", and "type"
   at instance location "/authentication/0"
   at evaluate path "/properties/authentication/items/anyOf/2/required"
 The object value was expected to validate against at least one of the 3 given subschemas

--- a/test/cli/index/enterprise/fail-authentication-public-type.sh
+++ b/test/cli/index/enterprise/fail-authentication-public-type.sh
@@ -50,7 +50,7 @@ The object value was expected to validate against the defined properties subsche
 The value was expected to be an object that defines properties "algorithms", "audience", "issuer", "name", "paths", and "type"
   at instance location "/authentication/0"
   at evaluate path "/properties/authentication/items/anyOf/1/required"
-The object value was expected to only define properties "clientId", "clientSecret", "issuer", "name", "paths", "sessionSecret", and "type", but it also defines properties "algorithm", and "keys"
+The value was expected to be an object that defines properties "clientId", "clientSecret", "issuer", "name", "paths", "sessionSecret", and "type"
   at instance location "/authentication/0"
   at evaluate path "/properties/authentication/items/anyOf/2/required"
 The object value was expected to validate against at least one of the 3 given subschemas

--- a/test/cli/index/enterprise/fail-authentication-unknown-algorithm.sh
+++ b/test/cli/index/enterprise/fail-authentication-unknown-algorithm.sh
@@ -50,7 +50,7 @@ The object value was expected to validate against the defined properties subsche
 The value was expected to be an object that defines properties "algorithms", "audience", "issuer", "name", "paths", and "type"
   at instance location "/authentication/0"
   at evaluate path "/properties/authentication/items/anyOf/1/required"
-The object value was expected to only define properties "clientId", "clientSecret", "issuer", "name", "paths", "sessionSecret", and "type", but it also defines properties "algorithm", and "keys"
+The value was expected to be an object that defines properties "clientId", "clientSecret", "issuer", "name", "paths", "sessionSecret", and "type"
   at instance location "/authentication/0"
   at evaluate path "/properties/authentication/items/anyOf/2/required"
 The object value was expected to validate against at least one of the 3 given subschemas

--- a/test/unit/configuration/configuration_test.cc
+++ b/test/unit/configuration/configuration_test.cc
@@ -828,6 +828,7 @@ TEST(authentication_apikey_identity) {
   EXPECT_EQ(configuration.path, "/tmp/one.json");
   EXPECT_EQ(configuration.authentication.size(), 1);
   EXPECT_EQ(configuration.authentication.at(0).name, "internal");
+  EXPECT_EQ(configuration.authentication.at(0).title, "internal");
   EXPECT_EQ(configuration.authentication.at(0).paths,
             (std::vector<sourcemeta::core::JSON::String>{"/internal"}));
   EXPECT_EQ(
@@ -857,6 +858,7 @@ TEST(authentication_jwt) {
   EXPECT_EQ(entry.type,
             sourcemeta::one::Configuration::AuthenticationEntry::Type::JWT);
   EXPECT_EQ(entry.name, "ci");
+  EXPECT_EQ(entry.title, "ci");
   EXPECT_EQ(entry.paths,
             (std::vector<sourcemeta::core::JSON::String>{"/internal"}));
   EXPECT_EQ(entry.issuer, "https://acme.example.com");

--- a/test/unit/configuration/configuration_test.cc
+++ b/test/unit/configuration/configuration_test.cc
@@ -915,6 +915,7 @@ TEST(authentication_oidc) {
   EXPECT_EQ(entry.type,
             sourcemeta::one::Configuration::AuthenticationEntry::Type::OIDC);
   EXPECT_EQ(entry.name, "employees");
+  EXPECT_EQ(entry.title, "employees");
   EXPECT_EQ(entry.paths,
             (std::vector<sourcemeta::core::JSON::String>{"/internal"}));
   EXPECT_EQ(entry.issuer, "https://login.example.com");
@@ -925,6 +926,60 @@ TEST(authentication_oidc) {
   EXPECT_TRUE(entry.algorithms.empty());
   EXPECT_TRUE(entry.audience.empty());
   EXPECT_FALSE(entry.jwks_uri.has_value());
+}
+
+TEST(authentication_oidc_with_title) {
+  const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
+    "url": "https://example.com",
+    "authentication": [
+      {
+        "type": "oidc",
+        "name": "employees",
+        "title": "Acme Single Sign-On",
+        "paths": [ "/internal" ],
+        "issuer": "https://login.example.com",
+        "clientId": "registry",
+        "clientSecret": { "environmentVariable": "ONE_OIDC_CLIENT_SECRET" },
+        "sessionSecret": { "environmentVariable": "ONE_OIDC_SESSION_SECRET" }
+      }
+    ]
+  })JSON")};
+  const auto configuration{sourcemeta::one::Configuration::parse(
+      raw_configuration, "/tmp/one.json", ".")};
+
+  EXPECT_EQ(configuration.authentication.size(), 1);
+  const auto &entry{configuration.authentication.at(0)};
+  EXPECT_EQ(entry.type,
+            sourcemeta::one::Configuration::AuthenticationEntry::Type::OIDC);
+  EXPECT_EQ(entry.name, "employees");
+  EXPECT_EQ(entry.title, "Acme Single Sign-On");
+}
+
+TEST(authentication_rejects_oidc_with_empty_title) {
+  const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
+    "url": "https://example.com",
+    "authentication": [
+      {
+        "type": "oidc",
+        "name": "employees",
+        "title": "",
+        "paths": [ "/internal" ],
+        "issuer": "https://login.example.com",
+        "clientId": "registry",
+        "clientSecret": { "environmentVariable": "ONE_OIDC_CLIENT_SECRET" },
+        "sessionSecret": { "environmentVariable": "ONE_OIDC_SESSION_SECRET" }
+      }
+    ]
+  })JSON")};
+  try {
+    sourcemeta::one::Configuration::parse(raw_configuration, "/tmp/one.json",
+                                          ".");
+    FAIL();
+  } catch (const sourcemeta::one::ConfigurationValidationError &error) {
+    EXPECT_STREQ(error.what(), "Invalid configuration");
+  } catch (...) {
+    FAIL();
+  }
 }
 
 TEST(authentication_rejects_oidc_without_session_secret) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

