### PR TITLE
Correctly fallback to OIDC nested policy paths

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -366,6 +366,7 @@ struct OIDCPolicyMetadata {
   std::string_view client_secret_variable;
   std::string_view name;
   std::string_view session_secret_variable;
+  std::string_view default_path;
 };
 
 auto decode_oidc_metadata(const std::span<const std::byte> metadata,
@@ -375,7 +376,8 @@ auto decode_oidc_metadata(const std::span<const std::byte> metadata,
          read_string(metadata, cursor, result.client_id) &&
          read_string(metadata, cursor, result.client_secret_variable) &&
          read_string(metadata, cursor, result.name) &&
-         read_string(metadata, cursor, result.session_secret_variable);
+         read_string(metadata, cursor, result.session_secret_variable) &&
+         read_string(metadata, cursor, result.default_path);
 }
 
 // The reference check treats two interactive policies as the same scope only
@@ -674,7 +676,8 @@ struct Authentication::Impl {
     return Authentication::InteractivePolicy{
         .issuer = decoded.issuer,
         .client_id = decoded.client_id,
-        .client_secret_variable = decoded.client_secret_variable};
+        .client_secret_variable = decoded.client_secret_variable,
+        .default_path = decoded.default_path};
   }
 
   [[nodiscard]] auto

--- a/enterprise/authentication/authentication_format.h
+++ b/enterprise/authentication/authentication_format.h
@@ -8,7 +8,7 @@
 namespace sourcemeta::one {
 
 constexpr std::uint32_t AUTHENTICATION_MAGIC{0x48545541};
-constexpr std::uint32_t AUTHENTICATION_VERSION{8};
+constexpr std::uint32_t AUTHENTICATION_VERSION{9};
 
 // The artifact begins with this header. Every variable-length section is
 // located through an absolute byte offset so the matcher can address it

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -73,10 +73,9 @@ auto encode_apikey_metadata(
   return result;
 }
 
-// The issuer, client identifier, the names of the environment variables
-// holding the client secret and the session secret, and the policy name are
-// stored as length-prefixed strings. The issuer and client identifier lead so
-// that their bytes keep spanning exactly the provider client identity
+// Every field is stored as a length-prefixed string. The issuer and client
+// identifier lead so that their bytes keep spanning exactly the provider
+// client identity
 auto encode_oidc_metadata(const std::string_view issuer,
                           const std::string_view client_id,
                           const std::string_view client_secret_variable,

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -81,7 +81,8 @@ auto encode_oidc_metadata(const std::string_view issuer,
                           const std::string_view client_id,
                           const std::string_view client_secret_variable,
                           const std::string_view name,
-                          const std::string_view session_secret_variable)
+                          const std::string_view session_secret_variable,
+                          const std::string_view default_path)
     -> std::vector<std::byte> {
   std::vector<std::byte> result;
   append_string(result, issuer);
@@ -89,6 +90,7 @@ auto encode_oidc_metadata(const std::string_view issuer,
   append_string(result, client_secret_variable);
   append_string(result, name);
   append_string(result, session_secret_variable);
+  append_string(result, default_path);
   return result;
 }
 
@@ -222,7 +224,8 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
 
       policy_metadata = encode_oidc_metadata(
           policy.issuer, policy.client_id, policy.client_secret_variable,
-          policy.name, policy.session_secret_variable);
+          policy.name, policy.session_secret_variable,
+          policy.paths.empty() ? std::string_view{} : policy.paths.front());
     } else if (!policy.keys.empty()) {
       policy_metadata = encode_apikey_metadata(policy.keys);
     }

--- a/enterprise/e2e/auth-path/hurl/sso.all.hurl
+++ b/enterprise/e2e/auth-path/hurl/sso.all.hurl
@@ -104,10 +104,12 @@ header "Location" startsWith "http://localhost:8000/registry/self/v1/auth/callba
 header "Location" contains "code="
 header "Location" contains "state="
 
-# The callback establishes the session and clears the transaction
+# The callback establishes the session and clears the transaction. This login
+# named no target, so it lands on what the policy governs, rooted at the base
+# path
 GET {{callback_url}}
 HTTP 303
-Location: /registry
+Location: /registry/console
 Cache-Control: no-store
 [Asserts]
 cookie "sourcemeta_one_session_keycloak" exists

--- a/enterprise/e2e/auth-sso/hurl/login.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/login.all.hurl
@@ -36,6 +36,35 @@ header "Set-Cookie" not exists
   "detail": "This resource requires authentication"
 }
 
+# The archive catalog is governed by that same policy, so it denies identically
+GET {{base}}/archive/record.json
+HTTP 401
+Cache-Control: no-store
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+Link: </self/v1/schemas/api/error>; rel="describedby"
+Access-Control-Allow-Origin: *
+[Captures]
+archive_denied: body
+[Asserts]
+header "Set-Cookie" not exists
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{archive_denied}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
 POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
 ```
 {{anonymous_denied}}
@@ -85,7 +114,8 @@ header "Location" contains "state="
 
 # The callback redeems the code, establishes the session, and clears the
 # transaction. This login named no target, so it lands on what the policy
-# governs rather than the instance root
+# governs rather than the instance root. The policy governs two collections and
+# lands on the one it declares first, which is not the one that sorts first
 GET {{callback_url}}
 HTTP 303
 Location: /private
@@ -113,6 +143,23 @@ header "ETag" exists
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "{{base}}/private/secret",
   "type": "object"
+}
+
+# The one session opens every collection the policy governs, not only the one
+# the login landed on
+GET {{base}}/archive/record.json
+HTTP 200
+Cache-Control: private, max-age=0, must-revalidate
+Content-Type: application/schema+json
+Link: <https://json-schema.org/draft/2020-12/schema>; rel="describedby"
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+[Asserts]
+header "ETag" exists
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "{{base}}/archive/record",
+  "type": "array"
 }
 
 # Logging out clears the session

--- a/enterprise/e2e/auth-sso/hurl/login.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/login.all.hurl
@@ -84,10 +84,11 @@ header "Location" contains "code="
 header "Location" contains "state="
 
 # The callback redeems the code, establishes the session, and clears the
-# transaction, redirecting back to the instance
+# transaction. This login named no target, so it lands on what the policy
+# governs rather than the instance root
 GET {{callback_url}}
 HTTP 303
-Location: /
+Location: /private
 Cache-Control: no-store
 [Asserts]
 cookie "sourcemeta_one_session_keycloak" exists

--- a/enterprise/e2e/auth-sso/hurl/return-to-denied.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/return-to-denied.all.hurl
@@ -1,8 +1,8 @@
 # A return target that is not a same-origin local path cannot be used to bounce
 # the browser off-site. Each of the classic open-redirect payloads is crafted
 # directly onto the login as an attacker would, travels through the full
-# unescape-and-validate path, is dropped rather than sealed, and the callback
-# falls back to the instance root, never the attacker's host.
+# validation path, and is dropped rather than sealed, so the session lands on
+# what the policy governs, never on the attacker's host.
 
 # Protocol-relative. The first login authenticates against the form.
 GET {{base}}/self/v1/auth/login/keycloak?to=%2F%2Fevil.example.com
@@ -28,7 +28,7 @@ callback_url: header "Location"
 
 GET {{callback_url}}
 HTTP 303
-Location: /
+Location: /private
 Cache-Control: no-store
 [Asserts]
 cookie "sourcemeta_one_session_keycloak" exists
@@ -49,7 +49,7 @@ callback_backslash: header "Location"
 
 GET {{callback_backslash}}
 HTTP 303
-Location: /
+Location: /private
 Cache-Control: no-store
 
 # An absolute URL with a scheme, which is not a rooted path at all
@@ -66,5 +66,5 @@ callback_scheme: header "Location"
 
 GET {{callback_scheme}}
 HTTP 303
-Location: /
+Location: /private
 Cache-Control: no-store

--- a/enterprise/e2e/auth-sso/one.json
+++ b/enterprise/e2e/auth-sso/one.json
@@ -2,13 +2,13 @@
   "url": "http://localhost:8000",
   "html": {
     "name": "SSO Sandbox",
-    "description": "A registry whose private catalog is gated by a single interactive OpenID Connect policy"
+    "description": "A registry whose private catalogs are gated by a single interactive OpenID Connect policy"
   },
   "authentication": [
     {
       "type": "oidc",
       "name": "keycloak",
-      "paths": [ "/private" ],
+      "paths": [ "/private", "/archive" ],
       "issuer": "http://keycloak:8080/realms/main",
       "clientId": "registry",
       "clientSecret": { "environmentVariable": "ONE_E2E_OIDC_CLIENT_SECRET" },
@@ -21,6 +21,9 @@
     },
     "private": {
       "path": "./schemas/private"
+    },
+    "archive": {
+      "path": "./schemas/archive"
     }
   }
 }

--- a/enterprise/e2e/auth-sso/schemas/archive/record.json
+++ b/enterprise/e2e/auth-sso/schemas/archive/record.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array"
+}

--- a/enterprise/e2e/auth/hurl/sso.all.hurl
+++ b/enterprise/e2e/auth/hurl/sso.all.hurl
@@ -103,10 +103,11 @@ header "Location" startsWith "http://localhost:8000/self/v1/auth/callback/keyclo
 header "Location" contains "code="
 header "Location" contains "state="
 
-# The callback establishes the session and clears the transaction
+# The callback establishes the session and clears the transaction. This login
+# named no target, so it lands on what the policy governs
 GET {{callback_url}}
 HTTP 303
-Location: /
+Location: /console
 Cache-Control: no-store
 [Asserts]
 cookie "sourcemeta_one_session_keycloak" exists

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
@@ -137,8 +137,7 @@ public:
     // was denied. The query value arrives already percent-decoded, so it is
     // taken as-is, and only a same-origin local path is honoured, so the login
     // cannot be turned into an open redirect. Anything else falls back to what
-    // the policy governs. It is sealed into the transaction so that the
-    // callback trusts it
+    // the policy governs
     const auto destination{request.query("to")};
     if (!destination.empty() && sourcemeta::one::is_local_path(destination)) {
       payload.assign_assume_new(

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
@@ -133,15 +133,20 @@ public:
                               sourcemeta::core::JSON{transaction.nonce});
     payload.assign_assume_new(
         "verifier", sourcemeta::core::JSON{transaction.code_verifier});
-    // An optional return target lets the login send the browser back to the
-    // page it was denied. The query value arrives already percent-decoded, so
-    // it is taken as-is. It is sealed into the transaction so the callback
-    // trusts it, and only a same-origin local path is honoured, so the login
-    // cannot be turned into an open redirect
+    // The return target lets the login send the browser back to the page it
+    // was denied. The query value arrives already percent-decoded, so it is
+    // taken as-is, and only a same-origin local path is honoured, so the login
+    // cannot be turned into an open redirect. Anything else falls back to what
+    // the policy governs. It is sealed into the transaction so that the
+    // callback trusts it
     const auto destination{request.query("to")};
     if (!destination.empty() && sourcemeta::one::is_local_path(destination)) {
       payload.assign_assume_new(
           "to", sourcemeta::core::JSON{std::string{destination}});
+    } else if (!policy->default_path.empty()) {
+      std::string fallback{this->server_uri_base_path()};
+      fallback += policy->default_path;
+      payload.assign_assume_new("to", sourcemeta::core::JSON{fallback});
     }
     std::ostringstream payload_text;
     sourcemeta::core::stringify(payload, payload_text);

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -1386,15 +1386,40 @@ TEST(interactive_returns_the_policy_by_name) {
   EXPECT_EQ(okta.value().issuer, "https://login.test");
   EXPECT_EQ(okta.value().client_id, "registry");
   EXPECT_EQ(okta.value().client_secret_variable, "ONE_TEST_OIDC_LOOKUP_A");
+  EXPECT_EQ(okta.value().default_path, "/alpha");
 
   const auto google{authentication.interactive("google")};
   EXPECT_TRUE(google.has_value());
   EXPECT_EQ(google.value().issuer, "https://accounts.test");
   EXPECT_EQ(google.value().client_id, "dashboard");
   EXPECT_EQ(google.value().client_secret_variable, "ONE_TEST_OIDC_LOOKUP_B");
+  EXPECT_EQ(google.value().default_path, "/beta");
 
   EXPECT_FALSE(authentication.interactive("github").has_value());
   EXPECT_FALSE(authentication.interactive("").has_value());
+}
+
+TEST(interactive_default_path_is_the_first_path_declared) {
+  // Declared out of alphabetical order, so that the first declared path wins
+  // rather than the first sorted one
+  const std::array<std::string_view, 2> paths{{"/zeta", "/alpha"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://login.test",
+        .client_id = "registry",
+        .client_secret_variable = "ONE_TEST_OIDC_MULTI",
+        .name = "okta",
+        .session_secret_variable = "ONE_TEST_OIDC_SESSION_UNUSED"}}};
+  const auto path{test_path("oidc_default_path.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+
+  const auto okta{authentication.interactive("okta")};
+  EXPECT_TRUE(okta.has_value());
+  EXPECT_EQ(okta.value().default_path, "/zeta");
 }
 
 TEST(interactive_through_a_broken_artifact_is_empty) {

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -132,6 +132,8 @@ public:
     std::string_view client_id{};
     // The environment variable name holding the client secret
     std::string_view client_secret_variable{};
+    // The first registry path the policy governs
+    std::string_view default_path{};
   };
 
   // The interactive policy declared under the given name, if any

--- a/test/unit/configuration/configuration_test.cc
+++ b/test/unit/configuration/configuration_test.cc
@@ -784,6 +784,8 @@ TEST(authentication_inherited_from_extends) {
 }
 
 TEST(authentication_explicit_paths) {
+  // Declared out of alphabetical order, so that the paths keep the order they
+  // were declared in rather than a sorted one
   const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
     "url": "https://example.com",
     "authentication": [
@@ -791,7 +793,7 @@ TEST(authentication_explicit_paths) {
         "type": "apiKey",
         "algorithm": "identity",
         "name": "internal",
-        "paths": [ "/internal", "/vendor" ],
+        "paths": [ "/vendor", "/internal" ],
         "keys": [ { "environmentVariable": "ONE_KEY" } ]
       }
     ]
@@ -803,7 +805,7 @@ TEST(authentication_explicit_paths) {
   EXPECT_EQ(configuration.authentication.size(), 1);
   EXPECT_EQ(
       configuration.authentication.at(0).paths,
-      (std::vector<sourcemeta::core::JSON::String>{"/internal", "/vendor"}));
+      (std::vector<sourcemeta::core::JSON::String>{"/vendor", "/internal"}));
 }
 
 TEST(authentication_apikey_identity) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

