### PR TITLE
Serve the interactive login page in place at the denied URL

### DIFF
--- a/enterprise/e2e/auth-closed/hurl/denial.all.hurl
+++ b/enterprise/e2e/auth-closed/hurl/denial.all.hurl
@@ -129,23 +129,33 @@ Access-Control-Allow-Origin: *
   "detail": "This resource requires authentication"
 }
 
-# A browser navigating to a gated page is sent to begin a login rather than
-# shown a denial, since a single interactive policy governs the whole registry
+# A browser navigating to a gated page is shown its login in place rather than
+# a redirect, since a single interactive policy governs the whole registry
 GET {{base}}/
 Accept: text/html
-HTTP 303
-Location: /self/v1/auth/login/keycloak?to=%2F
+HTTP 401
 Cache-Control: no-store
+Content-Type: text/html; charset=utf-8
+WWW-Authenticate: Bearer realm="registry"
+[Captures]
+login_etag: header "ETag"
 [Asserts]
+header "Location" not exists
 header "Set-Cookie" not exists
+xpath "string(//title)" == "Sign In"
+xpath "string((//a[@data-sourcemeta-ui-login])[1]/@href)" == "/self/v1/auth/login/keycloak"
 
+# A nested directory is answered by the byte-identical page, so the whole gated
+# tree is indistinguishable from one denied path to the next
 GET {{base}}/catalog/
 Accept: text/html
-HTTP 303
-Location: /self/v1/auth/login/keycloak?to=%2Fcatalog%2F
+HTTP 401
 Cache-Control: no-store
+Content-Type: text/html; charset=utf-8
 [Asserts]
+header "Location" not exists
 header "Set-Cookie" not exists
+header "ETag" == {{login_etag}}
 
 # The same directories requested as JSON deny identically, the root included
 GET {{base}}/

--- a/enterprise/e2e/auth-path/hurl/sso.all.hurl
+++ b/enterprise/e2e/auth-path/hurl/sso.all.hurl
@@ -57,15 +57,20 @@ header "ETag" matches /^"[0-9a-f]{64}"$/
   "additionalProperties": false
 }
 
-# A browser navigating to the console page under the base path is sent to begin
-# a login, its redirect target rooted at the base path like every other link
+# A browser navigating to the console page under the base path is shown its
+# login in place, a 401 whose provider link is rooted at the base path like
+# every other link
 GET {{base}}/registry/console/
 Accept: text/html
-HTTP 303
-Location: /registry/self/v1/auth/login/keycloak?to=%2Fregistry%2Fconsole%2F
+HTTP 401
 Cache-Control: no-store
+Content-Type: text/html; charset=utf-8
+WWW-Authenticate: Bearer realm="registry"
 [Asserts]
+header "Location" not exists
 header "Set-Cookie" not exists
+xpath "string(//title)" == "Sign In"
+xpath "string((//a[@data-sourcemeta-ui-login])[1]/@href)" == "/registry/self/v1/auth/login/keycloak"
 
 # Starting a login redirects to the real provider, carrying a transaction cookie
 # scoped to the base path

--- a/enterprise/e2e/auth-sso/hurl/redirect.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/redirect.all.hurl
@@ -1,48 +1,93 @@
-# A browser navigating to a gated page is sent to begin a login, since a single
-# interactive policy governs the private tree. The denial a machine sees becomes
-# a redirect a person can follow.
+# A browser navigating to a gated page is shown that path's login page in place:
+# a 401 whose body is the login rather than the plain denial. A single
+# interactive policy governs the private tree, so the page offers just that one
+# provider, named by the title it falls back to.
 GET {{base}}/private/
 Accept: text/html
-HTTP 303
-Location: /self/v1/auth/login/keycloak?to=%2Fprivate%2F
+HTTP 401
 Cache-Control: no-store
+Content-Type: text/html; charset=utf-8
+WWW-Authenticate: Bearer realm="registry"
+Referrer-Policy: strict-origin-when-cross-origin
+Content-Security-Policy: frame-ancestors 'none'
+X-Frame-Options: DENY
+Vary: Accept, Accept-Encoding
+[Captures]
+login_etag: header "ETag"
 [Asserts]
+header "Location" not exists
 header "Set-Cookie" not exists
+xpath "string(//title)" == "Sign In"
+xpath "string(//h2[@class='fw-bold'])" == "This page requires authentication"
+xpath "count(//a[@data-sourcemeta-ui-login])" == 1
+xpath "string((//a[@data-sourcemeta-ui-login])[1]/@data-sourcemeta-ui-login)" == "keycloak"
+xpath "string((//a[@data-sourcemeta-ui-login])[1]/@href)" == "/self/v1/auth/login/keycloak"
+xpath "normalize-space((//a[@data-sourcemeta-ui-login])[1])" == "keycloak"
 
-# HEAD is a navigation too, and redirects identically with no body
+# HEAD is a navigation too: the same 401, with no body
 HEAD {{base}}/private/
 Accept: text/html
-HTTP 303
-Location: /self/v1/auth/login/keycloak?to=%2Fprivate%2F
+HTTP 401
 Cache-Control: no-store
+Content-Type: text/html; charset=utf-8
+WWW-Authenticate: Bearer realm="registry"
+[Asserts]
+header "Location" not exists
 
-# The extensionless schema page redirects the same way, carrying its own path
+# An existing schema page under the policy is answered by the byte-identical
+# login page, so a denial never reveals that the requested schema exists. The
+# ETag is the content hash, so an equal ETag proves an equal body
 GET {{base}}/private/secret
 Accept: text/html
-HTTP 303
-Location: /self/v1/auth/login/keycloak?to=%2Fprivate%2Fsecret
+HTTP 401
 Cache-Control: no-store
+Content-Type: text/html; charset=utf-8
+WWW-Authenticate: Bearer realm="registry"
+[Asserts]
+header "Location" not exists
+header "ETag" == {{login_etag}}
 
-# The query string of the denied page is preserved in the return target, so a
-# page whose state lives in its query comes back whole
+# A path that resolves to no schema at all returns the same page, so a missing
+# resource is indistinguishable from a real one under the same policy
+GET {{base}}/private/does-not-exist
+Accept: text/html
+HTTP 401
+Cache-Control: no-store
+Content-Type: text/html; charset=utf-8
+[Asserts]
+header "Location" not exists
+header "ETag" == {{login_etag}}
+
+# A nested path that does not exist resolves up through the nearest governing
+# directory, still to the identical page
+GET {{base}}/private/nope/deeper/still
+Accept: text/html
+HTTP 401
+Cache-Control: no-store
+[Asserts]
+header "ETag" == {{login_etag}}
+
+# The query string no longer changes the response: the page carries no return
+# target, so the login endpoint recovers it from the referring page instead
 GET {{base}}/private/?view=raw&page=2
 Accept: text/html
-HTTP 303
-Location: /self/v1/auth/login/keycloak?to=%2Fprivate%2F%3Fview%3Draw%26page%3D2
+HTTP 401
 Cache-Control: no-store
+[Asserts]
+header "ETag" == {{login_etag}}
 
-# A public page is served, never redirected, so the login only fronts what is
-# actually gated
+# A public page is served, never fronted by a login, so the page only guards
+# what is actually gated
 GET {{base}}/public/
 Accept: text/html
 HTTP 200
 Content-Type: text/html; charset=utf-8
 [Asserts]
 header "Location" not exists
-xpath "string(//title)" != "Unauthorized"
+xpath "string(//title)" != "Sign In"
 
-# A client asking for JSON is denied, never redirected, so scripting the API
-# still sees the honest 401
+# A client asking for JSON is denied plainly, never shown the login page, so
+# scripting the API still sees the honest 401
 GET {{base}}/private/secret.json
 Accept: application/json
 HTTP 401
@@ -72,8 +117,8 @@ Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
 [Asserts]
 jsonpath "$.valid" == true
 
-# The data representation stays JSON even for a browser: an explicit ".json"
-# asks for the schema, not the page, so it is denied rather than redirected
+# An explicit ".json" asks for the schema, not the page, so even a browser is
+# denied plainly rather than shown the login
 GET {{base}}/private/secret.json
 Accept: text/html
 HTTP 401

--- a/enterprise/e2e/auth-sso/hurl/return-to-referer-foreign.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/return-to-referer-foreign.all.hurl
@@ -1,0 +1,35 @@
+# A cross-origin referring page is never honoured as a return target, so the
+# login cannot be turned into an open redirect by a crafted Referer. The login
+# falls back to what the policy governs instead. This runs its own login from a
+# fresh session so the provider presents its form.
+GET {{base}}/self/v1/auth/login/keycloak
+Referer: https://evil.example.com/private/secret
+HTTP 303
+Cache-Control: no-store
+[Captures]
+authorize_url: header "Location" replace "http://keycloak:8080" "http://localhost:8080"
+[Asserts]
+header "Set-Cookie" startsWith "sourcemeta_one_transaction_keycloak="
+
+GET {{authorize_url}}
+HTTP 200
+[Captures]
+login_action: xpath "string(//form[@id='kc-form-login']/@action)" replace "http://keycloak:8080" "http://localhost:8080"
+
+POST {{login_action}}
+[FormParams]
+username: jane
+password: jane-password
+HTTP 302
+[Captures]
+callback_url: header "Location"
+[Asserts]
+header "Location" contains "code="
+
+# The session lands on the policy's default page, never the foreign origin
+GET {{callback_url}}
+HTTP 303
+Location: /private
+Cache-Control: no-store
+[Asserts]
+cookie "sourcemeta_one_session_keycloak" exists

--- a/enterprise/e2e/auth-sso/hurl/return-to-referer.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/return-to-referer.all.hurl
@@ -1,0 +1,40 @@
+# A login started with no explicit target but a same-origin referring page
+# returns to that page once the session is established. When the login is served
+# in place, the referrer is exactly the denied page, so the return target needs
+# no query at all: the endpoint recovers it from the Referer. The referring
+# page's query string survives the round trip intact.
+GET {{base}}/self/v1/auth/login/keycloak
+Referer: {{base}}/private/secret?view=raw
+HTTP 303
+Cache-Control: no-store
+[Captures]
+authorize_url: header "Location" replace "http://keycloak:8080" "http://localhost:8080"
+[Asserts]
+header "Set-Cookie" startsWith "sourcemeta_one_transaction_keycloak="
+
+# The provider renders its login form
+GET {{authorize_url}}
+HTTP 200
+[Captures]
+login_action: xpath "string(//form[@id='kc-form-login']/@action)" replace "http://keycloak:8080" "http://localhost:8080"
+
+# Submitting the user's credentials returns to the callback with a code
+POST {{login_action}}
+[FormParams]
+username: jane
+password: jane-password
+HTTP 302
+[Captures]
+callback_url: header "Location"
+[Asserts]
+header "Location" contains "code="
+
+# The callback establishes the session and returns to the referring page, its
+# query string preserved, proving the Referer drove the return target
+GET {{callback_url}}
+HTTP 303
+Location: /private/secret?view=raw
+Cache-Control: no-store
+[Asserts]
+cookie "sourcemeta_one_session_keycloak" exists
+cookie "sourcemeta_one_transaction_keycloak[Max-Age]" == 0

--- a/enterprise/e2e/auth/hurl/sso.all.hurl
+++ b/enterprise/e2e/auth/hurl/sso.all.hurl
@@ -58,15 +58,21 @@ header "ETag" matches /^"[0-9a-f]{64}"$/
   "additionalProperties": false
 }
 
-# A browser navigating to the console page is sent to begin a login, while the
-# machine key above keeps working: one path, two audiences
+# A browser navigating to the console page is shown its login in place, a 401
+# whose body is the login page rather than a redirect, while the machine key
+# above keeps working: one path, two audiences
 GET {{base}}/console/
 Accept: text/html
-HTTP 303
-Location: /self/v1/auth/login/keycloak?to=%2Fconsole%2F
+HTTP 401
 Cache-Control: no-store
+Content-Type: text/html; charset=utf-8
+WWW-Authenticate: Bearer realm="registry"
 [Asserts]
+header "Location" not exists
 header "Set-Cookie" not exists
+xpath "string(//title)" == "Sign In"
+xpath "count(//a[@data-sourcemeta-ui-login])" == 1
+xpath "string((//a[@data-sourcemeta-ui-login])[1]/@href)" == "/self/v1/auth/login/keycloak"
 
 # Starting a login redirects to the real provider with the transaction cookie
 GET {{base}}/self/v1/auth/login/keycloak

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
@@ -134,18 +134,29 @@ public:
     payload.assign_assume_new(
         "verifier", sourcemeta::core::JSON{transaction.code_verifier});
     // The return target lets the login send the browser back to the page it
-    // was denied. The query value arrives already percent-decoded, so it is
-    // taken as-is, and only a same-origin local path is honoured, so the login
-    // cannot be turned into an open redirect. Anything else falls back to what
-    // the policy governs
+    // was denied. An explicit `to` query wins, then the referring page, which
+    // for a login served in place is exactly that denied page and so needs no
+    // query, then what the policy governs. Only a same-origin local path is
+    // ever honoured, so the login cannot be turned into an open redirect
+    std::optional<std::string> target;
     const auto destination{request.query("to")};
     if (!destination.empty() && sourcemeta::one::is_local_path(destination)) {
-      payload.assign_assume_new(
-          "to", sourcemeta::core::JSON{std::string{destination}});
-    } else if (!policy->default_path.empty()) {
+      target = std::string{destination};
+    } else if (const auto referer{request.header("referer")};
+               referer.starts_with(this->server_uri())) {
+      std::string candidate{this->server_uri_base_path()};
+      candidate += referer.substr(this->server_uri().size());
+      if (sourcemeta::one::is_local_path(candidate)) {
+        target = std::move(candidate);
+      }
+    }
+    if (!target.has_value() && !policy->default_path.empty()) {
       std::string fallback{this->server_uri_base_path()};
       fallback += policy->default_path;
-      payload.assign_assume_new("to", sourcemeta::core::JSON{fallback});
+      target = std::move(fallback);
+    }
+    if (target.has_value()) {
+      payload.assign_assume_new("to", sourcemeta::core::JSON{target.value()});
     }
     std::ostringstream payload_text;
     sourcemeta::core::stringify(payload, payload_text);

--- a/src/actions/action_default_v1.h
+++ b/src/actions/action_default_v1.h
@@ -250,9 +250,9 @@ private:
           &browser_security,
       sourcemeta::one::HTTPRequest &request,
       sourcemeta::one::HTTPResponse &response) -> void {
-    // A browser denied a page is sent to begin a login when a single
-    // interactive policy governs the path, rather than shown the denial page
-    if (this->redirect_to_login(request, response)) {
+    // A browser denied a page under an interactive policy is shown that path's
+    // login page in place, rather than the plain denial
+    if (this->serve_login(request, response)) {
       return;
     }
 

--- a/src/router/artifact.cc
+++ b/src/router/artifact.cc
@@ -171,6 +171,38 @@ auto RouterAction::artifact_resolve_path_unauthenticated(
   return ResolvedArtifact{std::move(located).value()};
 }
 
+auto RouterAction::artifact_resolve_ancestor(
+    const std::string_view input, const Tree tree,
+    const std::string_view artifact_name) const
+    -> std::optional<ResolvedArtifact> {
+  std::string_view remaining{input};
+  if (remaining.ends_with("/")) {
+    remaining.remove_suffix(1);
+  }
+
+  while (true) {
+    auto located{this->artifact_resolve_path_unauthenticated(remaining, tree,
+                                                             artifact_name)};
+    if (located.has_value()) {
+      const sourcemeta::core::FileView view{located.value().path()};
+      const auto info{sourcemeta::one::metapack_info(view)};
+      // Text artifacts always carry a trailing newline, so an empty placeholder
+      // is a lone byte while a real page is a whole document
+      if (info.has_value() && info->content_bytes > 1) {
+        return located;
+      }
+    }
+
+    if (remaining.empty()) {
+      return std::nullopt;
+    }
+
+    const auto slash{remaining.find_last_of('/')};
+    remaining = slash == std::string_view::npos ? std::string_view{}
+                                                : remaining.substr(0, slash);
+  }
+}
+
 auto RouterAction::artifact_resolve_static(
     const std::filesystem::path &root, const std::string_view relative) const
     -> ArtifactResolution {

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -88,12 +88,15 @@ public:
     return false;
   }
 
-  // Send an unauthenticated browser navigating to a path that exactly one
-  // interactive policy governs to begin a login, returning true when it wrote
-  // the redirect so the caller stops. Machines, non-navigations, and paths
-  // with no or several interactive policies fall through to the plain denial
-  [[nodiscard]] auto redirect_to_login(HTTPRequest &request,
-                                       HTTPResponse &response) const -> bool;
+  // Serve, in place, the login page for an unauthenticated browser navigating
+  // to a path an interactive policy governs, returning true when it wrote the
+  // response so the caller stops. The page is a per-directory artifact resolved
+  // from the nearest governing directory above the path, so it is identical for
+  // every path under the same policies and a denial never reveals whether a
+  // schema exists. Machines, non-navigations, and paths with no interactive
+  // policy fall through to the plain denial
+  [[nodiscard]] auto serve_login(HTTPRequest &request,
+                                 HTTPResponse &response) const -> bool;
 
   [[nodiscard]] auto server_uri_base_path() const noexcept -> std::string_view {
     return this->server_uri_base_path_;

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -193,6 +193,17 @@ private:
                                      std::string_view artifact_name) const
       -> std::optional<std::filesystem::path>;
 
+  // Resolve a named artifact by walking up from the input path to the nearest
+  // ancestor directory whose copy has content, skipping the empty placeholders
+  // that mark directories the artifact does not apply to. This lets a
+  // per-directory page answer any path beneath it, including one that resolves
+  // to no resource at all. Like the unauthenticated resolver it bypasses
+  // authorisation, so it is only for denial pages that are public by design
+  [[nodiscard]] auto
+  artifact_resolve_ancestor(std::string_view input, Tree tree,
+                            std::string_view artifact_name) const
+      -> std::optional<ResolvedArtifact>;
+
   [[nodiscard]] auto blaze_template(Credentials credentials,
                                     std::string_view schema_uri,
                                     sourcemeta::blaze::Mode mode) const

--- a/src/router/router.cc
+++ b/src/router/router.cc
@@ -1,8 +1,6 @@
 #include <sourcemeta/core/http.h>
-#include <sourcemeta/core/io.h>
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/uri.h>
-#include <sourcemeta/one/metapack.h>
 #include <sourcemeta/one/router.h>
 
 #include <chrono>      // std::chrono::seconds
@@ -158,44 +156,22 @@ auto RouterAction::serve_login(sourcemeta::one::HTTPRequest &request,
 
   // The login page is a per-directory artifact, so a schema or a non-existent
   // path is answered by the nearest directory above it that offers a login.
-  // Empty artifacts mark a directory no interactive policy governs, so they are
-  // skipped. Because every login page under the same policies is
-  // byte-identical, this walk never betrays whether a deeper path exists
+  // Because every login page under the same policies is byte-identical, this
+  // never betrays whether a deeper path exists
   const auto stripped{sourcemeta::core::URI::strip_path_prefix(
       request.path(), this->server_uri_base_path())};
-  std::string_view remaining{stripped.has_value()
-                                 ? std::string_view{stripped.value()}
-                                 : request.path()};
-  if (remaining.ends_with("/")) {
-    remaining.remove_suffix(1);
+  const auto page{this->artifact_resolve_ancestor(
+      stripped.has_value() ? std::string_view{stripped.value()}
+                           : request.path(),
+      Tree::Explorer, "login-html")};
+  if (!page.has_value()) {
+    return false;
   }
 
-  while (true) {
-    const auto page{this->artifact_resolve_path_unauthenticated(
-        remaining, Tree::Explorer, "login-html")};
-    if (page.has_value()) {
-      const sourcemeta::core::FileView view{page.value().path()};
-      const auto info{sourcemeta::one::metapack_info(view)};
-      // A directory no interactive policy governs gets a placeholder page with
-      // no content. Text artifacts always carry a trailing newline, so that
-      // placeholder is a lone byte, while a real login page is a full document
-      if (info.has_value() && info->content_bytes > 1) {
-        this->artifact_serve(page.value(),
-                             sourcemeta::core::HTTP_STATUS_UNAUTHORIZED, false,
-                             {}, {}, SECURITY, request, response, {},
-                             "no-store", "Accept, Accept-Encoding");
-        return true;
-      }
-    }
-
-    if (remaining.empty()) {
-      return false;
-    }
-
-    const auto slash{remaining.find_last_of('/')};
-    remaining = slash == std::string_view::npos ? std::string_view{}
-                                                : remaining.substr(0, slash);
-  }
+  this->artifact_serve(page.value(), sourcemeta::core::HTTP_STATUS_UNAUTHORIZED,
+                       false, {}, {}, SECURITY, request, response, {},
+                       "no-store", "Accept, Accept-Encoding");
+  return true;
 }
 
 } // namespace sourcemeta::one

--- a/src/router/router.cc
+++ b/src/router/router.cc
@@ -1,6 +1,8 @@
 #include <sourcemeta/core/http.h>
+#include <sourcemeta/core/io.h>
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/uri.h>
+#include <sourcemeta/one/metapack.h>
 #include <sourcemeta/one/router.h>
 
 #include <chrono>      // std::chrono::seconds
@@ -128,7 +130,7 @@ auto Router::dispatch(
            .admits(request.path(), credential, request.header("cookie"),
                    instance->server_uri_base_path())
            .allowed) {
-    if (instance->redirect_to_login(request, response)) {
+    if (instance->serve_login(request, response)) {
       return;
     }
 
@@ -140,35 +142,60 @@ auto Router::dispatch(
   instance->rest(matches, credential, request, response);
 }
 
-auto RouterAction::redirect_to_login(
-    sourcemeta::one::HTTPRequest &request,
-    sourcemeta::one::HTTPResponse &response) const -> bool {
+auto RouterAction::serve_login(sourcemeta::one::HTTPRequest &request,
+                               sourcemeta::one::HTTPResponse &response) const
+    -> bool {
   if ((request.method() != "get" && request.method() != "head") ||
       !sourcemeta::one::prefers_html(request.header("accept"))) {
     return false;
   }
 
-  const auto challenges{
-      this->dispatcher().authentication().interactive_challenges(
-          request.path(), this->server_uri_base_path())};
-  if (challenges.size() != 1) {
-    return false;
+  static constexpr BrowserSecurityHeaders SECURITY{
+      .referrer_policy = "strict-origin-when-cross-origin",
+      .frame_ancestors = "'none'",
+      .x_frame_options = "DENY",
+  };
+
+  // The login page is a per-directory artifact, so a schema or a non-existent
+  // path is answered by the nearest directory above it that offers a login.
+  // Empty artifacts mark a directory no interactive policy governs, so they are
+  // skipped. Because every login page under the same policies is
+  // byte-identical, this walk never betrays whether a deeper path exists
+  const auto stripped{sourcemeta::core::URI::strip_path_prefix(
+      request.path(), this->server_uri_base_path())};
+  std::string_view remaining{stripped.has_value()
+                                 ? std::string_view{stripped.value()}
+                                 : request.path()};
+  if (remaining.ends_with("/")) {
+    remaining.remove_suffix(1);
   }
 
-  std::string location{this->server_uri_base_path()};
-  location += "/self/v1/auth/login/";
-  location += challenges.front();
-  // Carry the page the browser was denied, its query string included, so the
-  // login can return it there. It is percent-encoded so the whole target
-  // travels intact through this query
-  location += "?to=";
-  sourcemeta::core::URI::escape(request.target(), location);
-  response.write_status(sourcemeta::core::HTTP_STATUS_SEE_OTHER);
-  response.write_header("Location", location);
-  response.write_header("Cache-Control", "no-store");
-  sourcemeta::one::send_response(sourcemeta::core::HTTP_STATUS_SEE_OTHER,
-                                 request, response);
-  return true;
+  while (true) {
+    const auto page{this->artifact_resolve_path_unauthenticated(
+        remaining, Tree::Explorer, "login-html")};
+    if (page.has_value()) {
+      const sourcemeta::core::FileView view{page.value().path()};
+      const auto info{sourcemeta::one::metapack_info(view)};
+      // A directory no interactive policy governs gets a placeholder page with
+      // no content. Text artifacts always carry a trailing newline, so that
+      // placeholder is a lone byte, while a real login page is a full document
+      if (info.has_value() && info->content_bytes > 1) {
+        this->artifact_serve(page.value(),
+                             sourcemeta::core::HTTP_STATUS_UNAUTHORIZED, false,
+                             {}, {}, SECURITY, request, response, {},
+                             "no-store", "Accept, Accept-Encoding");
+        return true;
+      }
+    }
+
+    if (remaining.empty()) {
+      return false;
+    }
+
+    const auto slash{remaining.find_last_of('/')};
+    remaining = slash == std::string_view::npos ? std::string_view{}
+                                                : remaining.substr(0, slash);
+  }
 }
 
 } // namespace sourcemeta::one


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

