### PR TITLE
Introduce a new `Authentication::Path` abstraction

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -35,7 +35,8 @@ namespace {
 constexpr std::uint32_t NO_CHILD{std::numeric_limits<std::uint32_t>::max()};
 
 // A base that is not a whole-segment prefix is left in place, where it matches
-// no policy and is denied
+// no policy. The spelling is otherwise untouched, since a route is matched on
+// the target as it arrived
 auto strip_base_path(const std::string_view path,
                      const std::string_view base) noexcept -> std::string_view {
   if (base.empty() || !path.starts_with(base)) {
@@ -940,13 +941,11 @@ Authentication::Authentication(const std::filesystem::path &path,
 
 Authentication::~Authentication() = default;
 
-auto Authentication::admits(const std::string_view registry_path,
-                            const std::string_view credential,
-                            const std::string_view cookies,
-                            const std::string_view base_path) const
+auto Authentication::admits(const Authentication::Path &path,
+                            const Credentials &credentials) const
     -> Authentication::Verdict {
-  return this->impl_->admits(strip_base_path(registry_path, base_path),
-                             credential, cookies);
+  return this->impl_->admits(path.value(), credentials.bearer,
+                             credentials.cookies);
 }
 
 auto Authentication::interactive(const std::string_view name) const
@@ -967,10 +966,17 @@ auto Authentication::open(const std::string_view policy,
   return this->impl_->open(policy, value);
 }
 
-auto Authentication::governing(const std::string_view registry_path,
-                               const std::string_view base_path) const
+auto Authentication::admits_route(const std::string_view target,
+                                  const std::string_view base_path,
+                                  const Credentials &credentials) const
+    -> Authentication::Verdict {
+  return this->impl_->admits(strip_base_path(target, base_path),
+                             credentials.bearer, credentials.cookies);
+}
+
+auto Authentication::governing(const Authentication::Path &path) const
     -> std::vector<std::size_t> {
-  auto mask{this->impl_->match(strip_base_path(registry_path, base_path))};
+  auto mask{this->impl_->match(path.value())};
   std::vector<std::size_t> result;
   while (mask != 0) {
     result.push_back(static_cast<std::size_t>(std::countr_zero(mask)));
@@ -981,9 +987,9 @@ auto Authentication::governing(const std::string_view registry_path,
 }
 
 auto Authentication::reference_permitted(
-    const std::string_view referrer_path,
-    const std::string_view referent_path) const -> bool {
-  return this->impl_->reference_permitted(referrer_path, referent_path);
+    const Authentication::Path &referrer,
+    const Authentication::Path &referent) const -> bool {
+  return this->impl_->reference_permitted(referrer.value(), referent.value());
 }
 
 } // namespace sourcemeta::one

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -133,11 +133,17 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
   for (std::size_t index{0}; index < policies.size(); index += 1) {
     const auto bit{static_cast<std::uint64_t>(1) << index};
     for (const auto &policy_path : policies[index].paths) {
+      // The trie is keyed by the same spelling a request resolves to, so a
+      // configured path is canonicalised here rather than stored as written.
+      // Otherwise a path that only differs cosmetically would build segments
+      // no request could ever traverse, and its target would be left public
+      const auto canonical{Authentication::Path::relative(policy_path)};
+      const auto value{canonical.value()};
       std::uint32_t current{0};
       std::size_t cursor{0};
-      for (auto segment{authentication_next_segment(policy_path, cursor)};
+      for (auto segment{authentication_next_segment(value, cursor)};
            !segment.empty();
-           segment = authentication_next_segment(policy_path, cursor)) {
+           segment = authentication_next_segment(value, cursor)) {
         current = find_or_create_child(nodes, current, segment);
       }
 

--- a/enterprise/e2e/auth-path/hurl/enumeration.all.hurl
+++ b/enterprise/e2e/auth-path/hurl/enumeration.all.hurl
@@ -1,0 +1,114 @@
+# Every surface that enumerates schemas has to filter against the caller's
+# credential, and under a base path those surfaces once answered with the whole
+# catalogue because the path they checked still carried the base path, which no
+# policy is declared with. Each surface is asked anonymously and then with a
+# credential, so filtering is proven to distinguish the two rather than to
+# refuse everything.
+
+# The gated schema itself is denied anonymously
+GET {{base}}/registry/private/secret.json
+HTTP 401
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+
+# Search does not disclose it
+GET {{base}}/registry/self/v1/api/schemas/search?q=secret
+HTTP 200
+Content-Type: application/json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+[Asserts]
+jsonpath "$" count == 0
+
+# Nor does a query that would match it by name fragment
+GET {{base}}/registry/self/v1/api/schemas/search?q=private
+HTTP 200
+Content-Type: application/json
+[Asserts]
+jsonpath "$" count == 0
+
+# The public schema is disclosed, so the filter is not simply refusing all
+GET {{base}}/registry/self/v1/api/schemas/search?q=string
+HTTP 200
+Content-Type: application/json
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].path" == "/registry/public/string"
+jsonpath "$[0].identifier" == "http://localhost:8000/registry/public/string"
+
+# With the credential the gated schema becomes visible through the same query
+GET {{base}}/registry/self/v1/api/schemas/search?q=secret
+Authorization: Bearer content-secret-key
+HTTP 200
+Content-Type: application/json
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].path" == "/registry/private/secret"
+jsonpath "$[0].identifier" == "http://localhost:8000/registry/private/secret"
+
+# The MCP resource listing does not disclose the gated schema anonymously
+POST {{base}}/registry/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "resources/list"
+}
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+MCP-Protocol-Version: 2025-11-25
+[Asserts]
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 1
+jsonpath "$.result.resources[*].uri" not includes "http://localhost:8000/registry/private/secret"
+jsonpath "$.result.resources[*].uri" includes "http://localhost:8000/registry/public/string"
+
+# With the credential it appears, so the listing filters rather than truncates
+POST {{base}}/registry/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+Authorization: Bearer content-secret-key
+```
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "resources/list"
+}
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+MCP-Protocol-Version: 2025-11-25
+[Asserts]
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 2
+jsonpath "$.result.resources[*].uri" includes "http://localhost:8000/registry/private/secret"
+jsonpath "$.result.resources[*].uri" includes "http://localhost:8000/registry/public/string"
+
+# The MCP search tool filters on the same basis
+POST {{base}}/registry/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": { "name": "search_schemas", "arguments": { "q": "secret" } }
+}
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+MCP-Protocol-Version: 2025-11-25
+[Asserts]
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 3
+jsonpath "$.result.structuredContent.results" count == 0

--- a/enterprise/e2e/auth-path/hurl/enumeration.all.hurl
+++ b/enterprise/e2e/auth-path/hurl/enumeration.all.hurl
@@ -16,15 +16,16 @@ Access-Control-Expose-Headers: Link, ETag
 Link: </registry/self/v1/schemas/api/error>; rel="describedby"
 [Captures]
 denied_body: body
-denied_schema: header "Link" regex "<([^>]+)>"
-```
+denied_schema: header "Link" regex "</registry([^>]+)>"
+[Asserts]
+header "ETag" not exists
+header "Last-Modified" not exists
 {
   "type": "urn:sourcemeta:one:authentication-required",
   "title": "Unauthorized",
   "status": 401,
   "detail": "This resource requires authentication"
 }
-```
 
 POST {{base}}/registry/self/v1/api/schemas/evaluate{{denied_schema}}
 ```
@@ -37,17 +38,16 @@ jsonpath "$.valid" == true
 # Search does not disclose it, and the empty result is the whole body
 GET {{base}}/registry/self/v1/api/schemas/search?q=secret
 HTTP 200
-Cache-Control: no-store
+Cache-Control: public, max-age=60
 Content-Type: application/json
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: Link, ETag
 Link: </registry/self/v1/schemas/api/schemas/search/response>; rel="describedby"
 [Captures]
 empty_search: body
-empty_search_schema: header "Link" regex "<([^>]+)>"
-```
-[]
-```
+empty_search_schema: header "Link" regex "</registry([^>]+)>"
+[Asserts]
+jsonpath "$" count == 0
 
 POST {{base}}/registry/self/v1/api/schemas/evaluate{{empty_search_schema}}
 ```
@@ -60,22 +60,21 @@ jsonpath "$.valid" == true
 # Nor does a query naming the gated collection itself
 GET {{base}}/registry/self/v1/api/schemas/search?q=private
 HTTP 200
-Cache-Control: no-store
+Cache-Control: public, max-age=60
 Content-Type: application/json
 Link: </registry/self/v1/schemas/api/schemas/search/response>; rel="describedby"
-```
-[]
-```
+[Asserts]
+jsonpath "$" count == 0
 
 # The public schema is disclosed in full, so the filter is not refusing all
 GET {{base}}/registry/self/v1/api/schemas/search?q=string
 HTTP 200
-Cache-Control: no-store
+Cache-Control: public, max-age=60
 Content-Type: application/json
 Link: </registry/self/v1/schemas/api/schemas/search/response>; rel="describedby"
 [Captures]
 public_search: body
-public_search_schema: header "Link" regex "<([^>]+)>"
+public_search_schema: header "Link" regex "</registry([^>]+)>"
 [Asserts]
 jsonpath "$" count == 1
 jsonpath "$[0].path" == "/registry/public/string"
@@ -97,12 +96,12 @@ jsonpath "$.valid" == true
 GET {{base}}/registry/self/v1/api/schemas/search?q=secret
 Authorization: Bearer content-secret-key
 HTTP 200
-Cache-Control: no-store
+Cache-Control: private, max-age=60
 Content-Type: application/json
 Link: </registry/self/v1/schemas/api/schemas/search/response>; rel="describedby"
 [Captures]
 admitted_search: body
-admitted_search_schema: header "Link" regex "<([^>]+)>"
+admitted_search_schema: header "Link" regex "</registry([^>]+)>"
 [Asserts]
 jsonpath "$" count == 1
 jsonpath "$[0].path" == "/registry/private/secret"
@@ -138,7 +137,7 @@ Link: </registry/self/v1/schemas/mcp/response>; rel="describedby"
 MCP-Protocol-Version: 2025-11-25
 [Captures]
 anonymous_resources: body
-anonymous_resources_schema: header "Link" regex "<([^>]+)>"
+anonymous_resources_schema: header "Link" regex "</registry([^>]+)>"
 [Asserts]
 jsonpath "$.jsonrpc" == "2.0"
 jsonpath "$.id" == 1
@@ -174,7 +173,7 @@ Link: </registry/self/v1/schemas/mcp/response>; rel="describedby"
 MCP-Protocol-Version: 2025-11-25
 [Captures]
 admitted_resources: body
-admitted_resources_schema: header "Link" regex "<([^>]+)>"
+admitted_resources_schema: header "Link" regex "</registry([^>]+)>"
 [Asserts]
 jsonpath "$.result.resources[*].uri" includes "http://localhost:8000/registry/private/secret"
 jsonpath "$.result.resources[*].uri" includes "http://localhost:8000/registry/public/string"
@@ -207,7 +206,7 @@ Link: </registry/self/v1/schemas/mcp/response>; rel="describedby"
 MCP-Protocol-Version: 2025-11-25
 [Captures]
 anonymous_tool: body
-anonymous_tool_schema: header "Link" regex "<([^>]+)>"
+anonymous_tool_schema: header "Link" regex "</registry([^>]+)>"
 [Asserts]
 jsonpath "$.jsonrpc" == "2.0"
 jsonpath "$.id" == 1

--- a/enterprise/e2e/auth-path/hurl/enumeration.all.hurl
+++ b/enterprise/e2e/auth-path/hurl/enumeration.all.hurl
@@ -1,50 +1,123 @@
 # Every surface that enumerates schemas has to filter against the caller's
 # credential, and under a base path those surfaces once answered with the whole
-# catalogue because the path they checked still carried the base path, which no
-# policy is declared with. Each surface is asked anonymously and then with a
-# credential, so filtering is proven to distinguish the two rather than to
-# refuse everything.
+# catalogue because the location they checked still carried the base path,
+# which no policy is declared with. Each surface is asked anonymously and then
+# with the key, so filtering is proven to distinguish the two rather than to
+# refuse everything, and every response is asserted whole.
 
 # The gated schema itself is denied anonymously
 GET {{base}}/registry/private/secret.json
 HTTP 401
+Cache-Control: no-store
 Content-Type: application/problem+json
 WWW-Authenticate: Bearer realm="registry"
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </registry/self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+denied_body: body
+denied_schema: header "Link" regex "<([^>]+)>"
+```
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}
+```
 
-# Search does not disclose it
+POST {{base}}/registry/self/v1/api/schemas/evaluate{{denied_schema}}
+```
+{{denied_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# Search does not disclose it, and the empty result is the whole body
 GET {{base}}/registry/self/v1/api/schemas/search?q=secret
 HTTP 200
+Cache-Control: no-store
 Content-Type: application/json
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: Link, ETag
-[Asserts]
-jsonpath "$" count == 0
+Link: </registry/self/v1/schemas/api/schemas/search/response>; rel="describedby"
+[Captures]
+empty_search: body
+empty_search_schema: header "Link" regex "<([^>]+)>"
+```
+[]
+```
 
-# Nor does a query that would match it by name fragment
+POST {{base}}/registry/self/v1/api/schemas/evaluate{{empty_search_schema}}
+```
+{{empty_search}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# Nor does a query naming the gated collection itself
 GET {{base}}/registry/self/v1/api/schemas/search?q=private
 HTTP 200
+Cache-Control: no-store
 Content-Type: application/json
-[Asserts]
-jsonpath "$" count == 0
+Link: </registry/self/v1/schemas/api/schemas/search/response>; rel="describedby"
+```
+[]
+```
 
-# The public schema is disclosed, so the filter is not simply refusing all
+# The public schema is disclosed in full, so the filter is not refusing all
 GET {{base}}/registry/self/v1/api/schemas/search?q=string
 HTTP 200
+Cache-Control: no-store
 Content-Type: application/json
+Link: </registry/self/v1/schemas/api/schemas/search/response>; rel="describedby"
+[Captures]
+public_search: body
+public_search_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
 jsonpath "$" count == 1
 jsonpath "$[0].path" == "/registry/public/string"
 jsonpath "$[0].identifier" == "http://localhost:8000/registry/public/string"
+jsonpath "$[0].title" == ""
+jsonpath "$[0].description" == ""
+jsonpath "$[0].priority" == 50
 
-# With the credential the gated schema becomes visible through the same query
+POST {{base}}/registry/self/v1/api/schemas/evaluate{{public_search_schema}}
+```
+{{public_search}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# With the key the gated schema becomes visible through the same query, so the
+# earlier empty answer was filtering rather than an absent index
 GET {{base}}/registry/self/v1/api/schemas/search?q=secret
 Authorization: Bearer content-secret-key
 HTTP 200
+Cache-Control: no-store
 Content-Type: application/json
+Link: </registry/self/v1/schemas/api/schemas/search/response>; rel="describedby"
+[Captures]
+admitted_search: body
+admitted_search_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
 jsonpath "$" count == 1
 jsonpath "$[0].path" == "/registry/private/secret"
 jsonpath "$[0].identifier" == "http://localhost:8000/registry/private/secret"
+jsonpath "$[0].title" == ""
+jsonpath "$[0].description" == ""
+jsonpath "$[0].priority" == 50
+
+POST {{base}}/registry/self/v1/api/schemas/evaluate{{admitted_search_schema}}
+```
+{{admitted_search}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
 
 # The MCP resource listing does not disclose the gated schema anonymously
 POST {{base}}/registry/self/v1/mcp
@@ -61,14 +134,27 @@ Content-Type: application/json
 HTTP 200
 Cache-Control: no-store
 Content-Type: application/json
+Link: </registry/self/v1/schemas/mcp/response>; rel="describedby"
 MCP-Protocol-Version: 2025-11-25
+[Captures]
+anonymous_resources: body
+anonymous_resources_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
 jsonpath "$.jsonrpc" == "2.0"
 jsonpath "$.id" == 1
+jsonpath "$.error" not exists
 jsonpath "$.result.resources[*].uri" not includes "http://localhost:8000/registry/private/secret"
 jsonpath "$.result.resources[*].uri" includes "http://localhost:8000/registry/public/string"
 
-# With the credential it appears, so the listing filters rather than truncates
+POST {{base}}/registry/self/v1/api/schemas/evaluate{{anonymous_resources_schema}}
+```
+{{anonymous_resources}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# With the key it appears, so the listing filters rather than truncates
 POST {{base}}/registry/self/v1/mcp
 Accept: application/json, text/event-stream
 MCP-Protocol-Version: 2025-11-25
@@ -77,21 +163,31 @@ Authorization: Bearer content-secret-key
 ```
 {
   "jsonrpc": "2.0",
-  "id": 2,
+  "id": 1,
   "method": "resources/list"
 }
 ```
 HTTP 200
 Cache-Control: no-store
 Content-Type: application/json
+Link: </registry/self/v1/schemas/mcp/response>; rel="describedby"
 MCP-Protocol-Version: 2025-11-25
+[Captures]
+admitted_resources: body
+admitted_resources_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
-jsonpath "$.jsonrpc" == "2.0"
-jsonpath "$.id" == 2
 jsonpath "$.result.resources[*].uri" includes "http://localhost:8000/registry/private/secret"
 jsonpath "$.result.resources[*].uri" includes "http://localhost:8000/registry/public/string"
 
-# The MCP search tool filters on the same basis
+POST {{base}}/registry/self/v1/api/schemas/evaluate{{admitted_resources_schema}}
+```
+{{admitted_resources}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# The MCP search tool filters on the same basis, asserted as a whole envelope
 POST {{base}}/registry/self/v1/mcp
 Accept: application/json, text/event-stream
 MCP-Protocol-Version: 2025-11-25
@@ -99,7 +195,7 @@ Content-Type: application/json
 ```
 {
   "jsonrpc": "2.0",
-  "id": 3,
+  "id": 1,
   "method": "tools/call",
   "params": { "name": "search_schemas", "arguments": { "q": "secret" } }
 }
@@ -107,8 +203,22 @@ Content-Type: application/json
 HTTP 200
 Cache-Control: no-store
 Content-Type: application/json
+Link: </registry/self/v1/schemas/mcp/response>; rel="describedby"
 MCP-Protocol-Version: 2025-11-25
+[Captures]
+anonymous_tool: body
+anonymous_tool_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
 jsonpath "$.jsonrpc" == "2.0"
-jsonpath "$.id" == 3
+jsonpath "$.id" == 1
+jsonpath "$.error" not exists
+jsonpath "$.result.isError" == false
 jsonpath "$.result.structuredContent.results" count == 0
+
+POST {{base}}/registry/self/v1/api/schemas/evaluate{{anonymous_tool_schema}}
+```
+{{anonymous_tool}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true

--- a/enterprise/e2e/auth-path/hurl/enumeration.all.hurl
+++ b/enterprise/e2e/auth-path/hurl/enumeration.all.hurl
@@ -62,6 +62,8 @@ GET {{base}}/registry/self/v1/api/schemas/search?q=private
 HTTP 200
 Cache-Control: public, max-age=60
 Content-Type: application/json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
 Link: </registry/self/v1/schemas/api/schemas/search/response>; rel="describedby"
 [Asserts]
 jsonpath "$" count == 0
@@ -71,6 +73,8 @@ GET {{base}}/registry/self/v1/api/schemas/search?q=string
 HTTP 200
 Cache-Control: public, max-age=60
 Content-Type: application/json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
 Link: </registry/self/v1/schemas/api/schemas/search/response>; rel="describedby"
 [Captures]
 public_search: body
@@ -98,6 +102,8 @@ Authorization: Bearer content-secret-key
 HTTP 200
 Cache-Control: private, max-age=60
 Content-Type: application/json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
 Link: </registry/self/v1/schemas/api/schemas/search/response>; rel="describedby"
 [Captures]
 admitted_search: body

--- a/enterprise/e2e/auth/hurl/bypass-mcp.all.hurl
+++ b/enterprise/e2e/auth/hurl/bypass-mcp.all.hurl
@@ -1,9 +1,10 @@
-# The MCP tools take a path as an argument rather than as a request target, so
-# they reach the gate through their own route. A spelling that names a gated
-# location has to be denied there too, and once answered a listing through this
-# tool once because the argument reached the gate uncanonicalised.
+# The MCP tools take a location as an argument rather than as a request target,
+# so they reach the gate through their own route. A spelling that names a gated
+# location has to be refused there too, and one such spelling once answered
+# with the listing because the argument reached the gate as written.
 
-# The canonical spelling of a gated directory is refused
+# The canonical spelling of a gated directory is refused, and the whole
+# envelope is asserted so a listing cannot hide inside it
 POST {{base}}/self/v1/mcp
 Accept: application/json, text/event-stream
 MCP-Protocol-Version: 2025-11-25
@@ -19,21 +20,112 @@ Content-Type: application/json
 HTTP 200
 Cache-Control: no-store
 Content-Type: application/json
+Access-Control-Allow-Origin: {{base}}
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
 MCP-Protocol-Version: 2025-11-25
+[Captures]
+canonical_denial: body
+canonical_denial_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
-jsonpath "$.jsonrpc" == "2.0"
-jsonpath "$.id" == 1
-jsonpath "$.error" not exists
-jsonpath "$.result.isError" == true
-jsonpath "$.result.content" count == 1
-jsonpath "$.result.content[0].type" == "text"
-jsonpath "$.result.content[0].text" == "Authentication required"
+header "Vary" not exists
+```
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Authentication required"
+      }
+    ],
+    "isError": true
+  }
+}
+```
 
-# An upper-cased spelling of the same directory is refused identically
+POST {{base}}/self/v1/api/schemas/evaluate{{canonical_denial_schema}}
+```
+{{canonical_denial}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# An upper-cased spelling of the same directory answers byte for byte the same,
+# so it cannot be told apart from the canonical refusal
 POST {{base}}/self/v1/mcp
 Accept: application/json, text/event-stream
 MCP-Protocol-Version: 2025-11-25
 Content-Type: application/json
+```
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": { "name": "list_directory", "arguments": { "path": "/PRIVATE" } }
+}
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+MCP-Protocol-Version: 2025-11-25
+[Asserts]
+body == {{canonical_denial}}
+
+# So does a spelling carrying a repeated separator and a dot segment
+POST {{base}}/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": { "name": "list_directory", "arguments": { "path": "//PRIVATE/./" } }
+}
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+MCP-Protocol-Version: 2025-11-25
+[Asserts]
+body == {{canonical_denial}}
+
+# And a traversal that lands on the gated directory from a public one
+POST {{base}}/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": { "name": "list_directory", "arguments": { "path": "/public/../private" } }
+}
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+MCP-Protocol-Version: 2025-11-25
+[Asserts]
+body == {{canonical_denial}}
+
+# The key opens the same directory through a non-canonical spelling, so the
+# tool reads the location the policy governs rather than refusing every unusual
+# argument. The whole listing is asserted, then round-tripped through the
+# response schema the surface advertises
+POST {{base}}/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+Authorization: Bearer primary-secret-key
 ```
 {
   "jsonrpc": "2.0",
@@ -45,71 +137,34 @@ Content-Type: application/json
 HTTP 200
 Cache-Control: no-store
 Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
 MCP-Protocol-Version: 2025-11-25
+[Captures]
+admitted_listing: body
+admitted_listing_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
 jsonpath "$.jsonrpc" == "2.0"
 jsonpath "$.id" == 2
 jsonpath "$.error" not exists
-jsonpath "$.result.isError" == true
+jsonpath "$.result.isError" == false
 jsonpath "$.result.content" count == 1
 jsonpath "$.result.content[0].type" == "text"
-jsonpath "$.result.content[0].text" == "Authentication required"
+jsonpath "$.result.structuredContent.name" == "private"
+jsonpath "$.result.structuredContent.type" == "directory"
+jsonpath "$.result.structuredContent.entries" count == 2
+jsonpath "$.result.structuredContent.entries[0].name" == "open"
+jsonpath "$.result.structuredContent.entries[1].name" == "secret"
 
-# So is a spelling carrying a repeated separator and a dot segment
-POST {{base}}/self/v1/mcp
-Accept: application/json, text/event-stream
-MCP-Protocol-Version: 2025-11-25
-Content-Type: application/json
+POST {{base}}/self/v1/api/schemas/evaluate{{admitted_listing_schema}}
 ```
-{
-  "jsonrpc": "2.0",
-  "id": 3,
-  "method": "tools/call",
-  "params": { "name": "list_directory", "arguments": { "path": "//PRIVATE/./" } }
-}
+{{admitted_listing}}
 ```
 HTTP 200
-Cache-Control: no-store
-Content-Type: application/json
-MCP-Protocol-Version: 2025-11-25
 [Asserts]
-jsonpath "$.jsonrpc" == "2.0"
-jsonpath "$.id" == 3
-jsonpath "$.error" not exists
-jsonpath "$.result.isError" == true
-jsonpath "$.result.content" count == 1
-jsonpath "$.result.content[0].type" == "text"
-jsonpath "$.result.content[0].text" == "Authentication required"
+jsonpath "$.valid" == true
 
-# And a traversal that lands on the gated directory from a public one
-POST {{base}}/self/v1/mcp
-Accept: application/json, text/event-stream
-MCP-Protocol-Version: 2025-11-25
-Content-Type: application/json
-```
-{
-  "jsonrpc": "2.0",
-  "id": 4,
-  "method": "tools/call",
-  "params": { "name": "list_directory", "arguments": { "path": "/public/../private" } }
-}
-```
-HTTP 200
-Cache-Control: no-store
-Content-Type: application/json
-MCP-Protocol-Version: 2025-11-25
-[Asserts]
-jsonpath "$.jsonrpc" == "2.0"
-jsonpath "$.id" == 4
-jsonpath "$.error" not exists
-jsonpath "$.result.isError" == true
-jsonpath "$.result.content" count == 1
-jsonpath "$.result.content[0].type" == "text"
-jsonpath "$.result.content[0].text" == "Authentication required"
-
-# The credential opens the same directory through a non-canonical spelling, so
-# the tool is reading the location the gate governs rather than refusing every
-# unusual argument
+# The canonical spelling returns that same listing to that same caller, so
+# admission does not depend on how the location was written either
 POST {{base}}/self/v1/mcp
 Accept: application/json, text/event-stream
 MCP-Protocol-Version: 2025-11-25
@@ -118,18 +173,15 @@ Authorization: Bearer primary-secret-key
 ```
 {
   "jsonrpc": "2.0",
-  "id": 5,
+  "id": 2,
   "method": "tools/call",
-  "params": { "name": "list_directory", "arguments": { "path": "/PRIVATE" } }
+  "params": { "name": "list_directory", "arguments": { "path": "/private" } }
 }
 ```
 HTTP 200
 Cache-Control: no-store
 Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
 MCP-Protocol-Version: 2025-11-25
 [Asserts]
-jsonpath "$.jsonrpc" == "2.0"
-jsonpath "$.id" == 5
-jsonpath "$.error" not exists
-jsonpath "$.result.isError" == false
-jsonpath "$.result.content[0].text" contains "secret"
+body == {{admitted_listing}}

--- a/enterprise/e2e/auth/hurl/bypass-mcp.all.hurl
+++ b/enterprise/e2e/auth/hurl/bypass-mcp.all.hurl
@@ -1,0 +1,135 @@
+# The MCP tools take a path as an argument rather than as a request target, so
+# they reach the gate through their own route. A spelling that names a gated
+# location has to be denied there too, and once answered a listing through this
+# tool once because the argument reached the gate uncanonicalised.
+
+# The canonical spelling of a gated directory is refused
+POST {{base}}/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": { "name": "list_directory", "arguments": { "path": "/private" } }
+}
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+MCP-Protocol-Version: 2025-11-25
+[Asserts]
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 1
+jsonpath "$.error" not exists
+jsonpath "$.result.isError" == true
+jsonpath "$.result.content" count == 1
+jsonpath "$.result.content[0].type" == "text"
+jsonpath "$.result.content[0].text" == "Authentication required"
+
+# An upper-cased spelling of the same directory is refused identically
+POST {{base}}/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": { "name": "list_directory", "arguments": { "path": "/PRIVATE" } }
+}
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+MCP-Protocol-Version: 2025-11-25
+[Asserts]
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 2
+jsonpath "$.error" not exists
+jsonpath "$.result.isError" == true
+jsonpath "$.result.content" count == 1
+jsonpath "$.result.content[0].type" == "text"
+jsonpath "$.result.content[0].text" == "Authentication required"
+
+# So is a spelling carrying a repeated separator and a dot segment
+POST {{base}}/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": { "name": "list_directory", "arguments": { "path": "//PRIVATE/./" } }
+}
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+MCP-Protocol-Version: 2025-11-25
+[Asserts]
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 3
+jsonpath "$.error" not exists
+jsonpath "$.result.isError" == true
+jsonpath "$.result.content" count == 1
+jsonpath "$.result.content[0].type" == "text"
+jsonpath "$.result.content[0].text" == "Authentication required"
+
+# And a traversal that lands on the gated directory from a public one
+POST {{base}}/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "tools/call",
+  "params": { "name": "list_directory", "arguments": { "path": "/public/../private" } }
+}
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+MCP-Protocol-Version: 2025-11-25
+[Asserts]
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 4
+jsonpath "$.error" not exists
+jsonpath "$.result.isError" == true
+jsonpath "$.result.content" count == 1
+jsonpath "$.result.content[0].type" == "text"
+jsonpath "$.result.content[0].text" == "Authentication required"
+
+# The credential opens the same directory through a non-canonical spelling, so
+# the tool is reading the location the gate governs rather than refusing every
+# unusual argument
+POST {{base}}/self/v1/mcp
+Accept: application/json, text/event-stream
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+Authorization: Bearer primary-secret-key
+```
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "tools/call",
+  "params": { "name": "list_directory", "arguments": { "path": "/PRIVATE" } }
+}
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+MCP-Protocol-Version: 2025-11-25
+[Asserts]
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 5
+jsonpath "$.error" not exists
+jsonpath "$.result.isError" == false
+jsonpath "$.result.content[0].text" contains "secret"

--- a/enterprise/e2e/auth/hurl/bypass-mcp.all.hurl
+++ b/enterprise/e2e/auth/hurl/bypass-mcp.all.hurl
@@ -29,7 +29,6 @@ canonical_denial: body
 canonical_denial_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
 header "Vary" not exists
-```
 {
   "jsonrpc": "2.0",
   "id": 1,
@@ -43,7 +42,6 @@ header "Vary" not exists
     "isError": true
   }
 }
-```
 
 POST {{base}}/self/v1/api/schemas/evaluate{{canonical_denial_schema}}
 ```
@@ -147,10 +145,11 @@ jsonpath "$.jsonrpc" == "2.0"
 jsonpath "$.id" == 2
 jsonpath "$.error" not exists
 jsonpath "$.result.isError" == false
-jsonpath "$.result.content" count == 1
+jsonpath "$.result.content" count == 2
 jsonpath "$.result.content[0].type" == "text"
-jsonpath "$.result.structuredContent.name" == "private"
-jsonpath "$.result.structuredContent.type" == "directory"
+jsonpath "$.result.content[1].type" == "resource_link"
+jsonpath "$.result.content[1].uri" == "http://localhost:8000/private/secret"
+jsonpath "$.result.structuredContent.schemas" == 2
 jsonpath "$.result.structuredContent.entries" count == 2
 jsonpath "$.result.structuredContent.entries[0].name" == "open"
 jsonpath "$.result.structuredContent.entries[1].name" == "secret"

--- a/enterprise/e2e/auth/hurl/bypass.all.hurl
+++ b/enterprise/e2e/auth/hurl/bypass.all.hurl
@@ -74,14 +74,12 @@ upper_slash_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
 header "ETag" not exists
 header "Last-Modified" not exists
-```
 {
   "type": "urn:sourcemeta:one:authentication-required",
   "title": "Unauthorized",
   "status": 401,
   "detail": "This resource requires authentication"
 }
-```
 
 POST {{base}}/self/v1/api/schemas/evaluate{{upper_slash_schema}}
 ```
@@ -108,14 +106,12 @@ triple_slash_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
 header "ETag" not exists
 header "Last-Modified" not exists
-```
 {
   "type": "urn:sourcemeta:one:authentication-required",
   "title": "Unauthorized",
   "status": 401,
   "detail": "This resource requires authentication"
 }
-```
 
 POST {{base}}/self/v1/api/schemas/evaluate{{triple_slash_schema}}
 ```
@@ -142,14 +138,12 @@ upper_dot_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
 header "ETag" not exists
 header "Last-Modified" not exists
-```
 {
   "type": "urn:sourcemeta:one:authentication-required",
   "title": "Unauthorized",
   "status": 401,
   "detail": "This resource requires authentication"
 }
-```
 
 POST {{base}}/self/v1/api/schemas/evaluate{{upper_dot_schema}}
 ```
@@ -176,14 +170,12 @@ upper_extension_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
 header "ETag" not exists
 header "Last-Modified" not exists
-```
 {
   "type": "urn:sourcemeta:one:authentication-required",
   "title": "Unauthorized",
   "status": 401,
   "detail": "This resource requires authentication"
 }
-```
 
 POST {{base}}/self/v1/api/schemas/evaluate{{upper_extension_schema}}
 ```
@@ -210,14 +202,12 @@ upper_jwt_schema: header "Link" regex "<([^>]+)>"
 [Asserts]
 header "ETag" not exists
 header "Last-Modified" not exists
-```
 {
   "type": "urn:sourcemeta:one:authentication-required",
   "title": "Unauthorized",
   "status": 401,
   "detail": "This resource requires authentication"
 }
-```
 
 POST {{base}}/self/v1/api/schemas/evaluate{{upper_jwt_schema}}
 ```
@@ -230,9 +220,9 @@ jsonpath "$.valid" == true
 # The same spelling admits the caller that holds the key, so the gate reads the
 # location the policy governs rather than merely refusing anything unusual
 GET {{base}}//PRIVATE/secret.json
+Authorization: Bearer primary-secret-key
 [Options]
 path-as-is: true
-Authorization: Bearer primary-secret-key
 HTTP 200
 Cache-Control: private, max-age=0, must-revalidate
 Content-Type: application/schema+json
@@ -241,12 +231,18 @@ Access-Control-Expose-Headers: Link, ETag
 Link: <https://json-schema.org/draft/2020-12/schema>; rel="describedby"
 [Asserts]
 header "ETag" exists
-jsonpath "$.$schema" == "https://json-schema.org/draft/2020-12/schema"
-jsonpath "$.$id" == "http://localhost:8000/private/secret"
-jsonpath "$.type" == "object"
-jsonpath "$.required" count == 1
-jsonpath "$.required[0]" == "token"
-jsonpath "$.properties.token.type" == "string"
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "{{base}}/private/secret",
+  "type": "object",
+  "required": [ "token" ],
+  "properties": {
+    "token": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}
 
 # The gated directory listing is denied through the same spelling
 GET {{base}}//PRIVATE/
@@ -262,14 +258,15 @@ Link: </self/v1/schemas/api/error>; rel="describedby"
 [Captures]
 upper_directory_body: body
 upper_directory_schema: header "Link" regex "<([^>]+)>"
-```
+[Asserts]
+header "ETag" not exists
+header "Last-Modified" not exists
 {
   "type": "urn:sourcemeta:one:authentication-required",
   "title": "Unauthorized",
   "status": 401,
   "detail": "This resource requires authentication"
 }
-```
 
 POST {{base}}/self/v1/api/schemas/evaluate{{upper_directory_schema}}
 ```

--- a/enterprise/e2e/auth/hurl/bypass.all.hurl
+++ b/enterprise/e2e/auth/hurl/bypass.all.hurl
@@ -54,3 +54,50 @@ HTTP 200
 Content-Type: application/schema+json
 [Asserts]
 jsonpath "$.type" == "string"
+
+# Repeated leading slash combined with an upper-cased prefix. Each half of this
+# spelling is covered above on its own, and the pair once slipped past the gate
+# because the path reached the policy trie in a spelling the trie never holds
+GET {{base}}//PRIVATE/secret.json
+HTTP 401
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+
+# The same pair against a directory rather than a schema
+GET {{base}}//PRIVATE/
+HTTP 401
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+
+# Repeated leading slash, upper case, and a dot segment together
+GET {{base}}//PRIVATE/./secret.json
+HTTP 401
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+
+# Three leading slashes with an upper-cased prefix
+GET {{base}}///PRIVATE/secret.json
+HTTP 401
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+
+# An upper-cased extension names the same representation
+GET {{base}}//PRIVATE/SECRET.JSON
+HTTP 401
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+
+# A JWT-gated prefix is reached through the same spelling, and denied the same
+GET {{base}}//MACHINE/config.json
+HTTP 401
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+
+# The credential still admits the caller through a non-canonical spelling, so
+# the gate is reading the same location rather than merely refusing oddities
+GET {{base}}//PRIVATE/secret.json
+Authorization: Bearer primary-secret-key
+HTTP 200
+Content-Type: application/schema+json
+[Asserts]
+jsonpath "$.type" == "object"

--- a/enterprise/e2e/auth/hurl/bypass.all.hurl
+++ b/enterprise/e2e/auth/hurl/bypass.all.hurl
@@ -55,49 +55,226 @@ Content-Type: application/schema+json
 [Asserts]
 jsonpath "$.type" == "string"
 
-# Repeated leading slash combined with an upper-cased prefix. Each half of this
-# spelling is covered above on its own, and the pair once slipped past the gate
-# because the path reached the policy trie in a spelling the trie never holds
+# Repeated leading slash combined with an upper-cased prefix. Each half of
+# this spelling is covered above on its own, and the pair once reached the
+# policy trie in a spelling the trie never holds, which left the resource open
 GET {{base}}//PRIVATE/secret.json
+[Options]
+path-as-is: true
 HTTP 401
+Cache-Control: no-store
 Content-Type: application/problem+json
 WWW-Authenticate: Bearer realm="registry"
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+upper_slash_body: body
+upper_slash_schema: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "ETag" not exists
+header "Last-Modified" not exists
+```
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}
+```
 
-# The same pair against a directory rather than a schema
-GET {{base}}//PRIVATE/
-HTTP 401
-Content-Type: application/problem+json
-WWW-Authenticate: Bearer realm="registry"
-
-# Repeated leading slash, upper case, and a dot segment together
-GET {{base}}//PRIVATE/./secret.json
-HTTP 401
-Content-Type: application/problem+json
-WWW-Authenticate: Bearer realm="registry"
+POST {{base}}/self/v1/api/schemas/evaluate{{upper_slash_schema}}
+```
+{{upper_slash_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
 
 # Three leading slashes with an upper-cased prefix
 GET {{base}}///PRIVATE/secret.json
+[Options]
+path-as-is: true
 HTTP 401
+Cache-Control: no-store
 Content-Type: application/problem+json
 WWW-Authenticate: Bearer realm="registry"
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+triple_slash_body: body
+triple_slash_schema: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "ETag" not exists
+header "Last-Modified" not exists
+```
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}
+```
 
-# An upper-cased extension names the same representation
-GET {{base}}//PRIVATE/SECRET.JSON
+POST {{base}}/self/v1/api/schemas/evaluate{{triple_slash_schema}}
+```
+{{triple_slash_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# Repeated leading slash, upper case, and a dot segment together
+GET {{base}}//PRIVATE/./secret.json
+[Options]
+path-as-is: true
 HTTP 401
+Cache-Control: no-store
 Content-Type: application/problem+json
 WWW-Authenticate: Bearer realm="registry"
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+upper_dot_body: body
+upper_dot_schema: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "ETag" not exists
+header "Last-Modified" not exists
+```
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}
+```
+
+POST {{base}}/self/v1/api/schemas/evaluate{{upper_dot_schema}}
+```
+{{upper_dot_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# An upper-cased extension names the same representation of the same resource
+GET {{base}}//PRIVATE/SECRET.JSON
+[Options]
+path-as-is: true
+HTTP 401
+Cache-Control: no-store
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+upper_extension_body: body
+upper_extension_schema: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "ETag" not exists
+header "Last-Modified" not exists
+```
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}
+```
+
+POST {{base}}/self/v1/api/schemas/evaluate{{upper_extension_schema}}
+```
+{{upper_extension_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
 
 # A JWT-gated prefix is reached through the same spelling, and denied the same
 GET {{base}}//MACHINE/config.json
+[Options]
+path-as-is: true
 HTTP 401
+Cache-Control: no-store
 Content-Type: application/problem+json
 WWW-Authenticate: Bearer realm="registry"
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+upper_jwt_body: body
+upper_jwt_schema: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "ETag" not exists
+header "Last-Modified" not exists
+```
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}
+```
 
-# The credential still admits the caller through a non-canonical spelling, so
-# the gate is reading the same location rather than merely refusing oddities
+POST {{base}}/self/v1/api/schemas/evaluate{{upper_jwt_schema}}
+```
+{{upper_jwt_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# The same spelling admits the caller that holds the key, so the gate reads the
+# location the policy governs rather than merely refusing anything unusual
 GET {{base}}//PRIVATE/secret.json
+[Options]
+path-as-is: true
 Authorization: Bearer primary-secret-key
 HTTP 200
+Cache-Control: private, max-age=0, must-revalidate
 Content-Type: application/schema+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: <https://json-schema.org/draft/2020-12/schema>; rel="describedby"
 [Asserts]
+header "ETag" exists
+jsonpath "$.$schema" == "https://json-schema.org/draft/2020-12/schema"
+jsonpath "$.$id" == "http://localhost:8000/private/secret"
 jsonpath "$.type" == "object"
+jsonpath "$.required" count == 1
+jsonpath "$.required[0]" == "token"
+jsonpath "$.properties.token.type" == "string"
+
+# The gated directory listing is denied through the same spelling
+GET {{base}}//PRIVATE/
+[Options]
+path-as-is: true
+HTTP 401
+Cache-Control: no-store
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+upper_directory_body: body
+upper_directory_schema: header "Link" regex "<([^>]+)>"
+```
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}
+```
+
+POST {{base}}/self/v1/api/schemas/evaluate{{upper_directory_schema}}
+```
+{{upper_directory_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
@@ -339,7 +339,10 @@ private:
         0, this->search_view_.count(),
         [this, credential, &authentication, &resources, &admitted,
          offset](const sourcemeta::one::SearchListEntry &entry) -> void {
-          if (!authentication.admits(entry.path, credential).allowed) {
+          const auto location{this->canonical_path(entry.path)};
+          if (!location.has_value() ||
+              !authentication.admits(location.value(), {.bearer = credential})
+                   .allowed) {
             return;
           }
 

--- a/enterprise/unit/authentication/CMakeLists.txt
+++ b/enterprise/unit/authentication/CMakeLists.txt
@@ -1,5 +1,6 @@
 sourcemeta_test(NAMESPACE sourcemeta PROJECT one NAME enterprise_authentication
-  SOURCES authentication_test.cc session_test.cc)
+  SOURCES authentication_test.cc session_test.cc
+    "${PROJECT_SOURCE_DIR}/test/unit/authentication/authentication_path_test.cc")
 
 target_link_libraries(sourcemeta_one_enterprise_authentication_unit
   PRIVATE sourcemeta::one::authentication)

--- a/enterprise/unit/authentication/CMakeLists.txt
+++ b/enterprise/unit/authentication/CMakeLists.txt
@@ -1,6 +1,5 @@
 sourcemeta_test(NAMESPACE sourcemeta PROJECT one NAME enterprise_authentication
-  SOURCES authentication_test.cc session_test.cc
-    "${PROJECT_SOURCE_DIR}/test/unit/authentication/authentication_path_test.cc")
+  SOURCES authentication_path_test.cc authentication_test.cc session_test.cc)
 
 target_link_libraries(sourcemeta_one_enterprise_authentication_unit
   PRIVATE sourcemeta::one::authentication)

--- a/enterprise/unit/authentication/authentication_path_test.cc
+++ b/enterprise/unit/authentication/authentication_path_test.cc
@@ -158,6 +158,19 @@ TEST(a_path_outside_the_base_path_names_nowhere_here) {
   EXPECT_FALSE(parse("/elsewhere/private", BASED, "/registry").has_value());
 }
 
+TEST(a_base_path_is_matched_as_configured_rather_than_case_insensitively) {
+  // The base path is how the instance is deployed rather than a location
+  // inside it, so it is removed before anything is lowercased. A target that
+  // spells it differently names nowhere here, which is the closed answer
+  EXPECT_FALSE(
+      parse("/REGISTRY/private/secret", BASED, "/registry").has_value());
+  EXPECT_FALSE(
+      parse("/Registry/private/secret", BASED, "/registry").has_value());
+  // While the segments below it are canonicalised as anywhere else
+  EXPECT_EQ(value("/registry/PRIVATE/SECRET", BASED, "/registry"),
+            "private/secret");
+}
+
 TEST(a_base_path_is_matched_on_whole_segments) {
   EXPECT_FALSE(parse("/registrynot/private", BASED, "/registry").has_value());
 }
@@ -240,4 +253,9 @@ TEST(a_relative_path_that_climbs_reads_as_the_request_form_does) {
                 "/public/../private/secret")
                 .value(),
             "private/secret");
+}
+
+TEST(a_url_on_this_instance_but_outside_the_base_path_names_nowhere_here) {
+  EXPECT_FALSE(parse("http://localhost:8000/private/secret", BASED, "/registry")
+                   .has_value());
 }

--- a/enterprise/unit/authentication/authentication_path_test.cc
+++ b/enterprise/unit/authentication/authentication_path_test.cc
@@ -161,7 +161,7 @@ TEST(a_path_outside_the_base_path_names_nowhere_here) {
 TEST(a_base_path_is_matched_as_configured_rather_than_case_insensitively) {
   // The base path is how the instance is deployed rather than a location
   // inside it, so it is removed before anything is lowercased. A target that
-  // spells it differently names nowhere here, which is the closed answer
+  // spells it differently names nowhere here, which fails closed
   EXPECT_FALSE(
       parse("/REGISTRY/private/secret", BASED, "/registry").has_value());
   EXPECT_FALSE(

--- a/enterprise/unit/authentication/authentication_path_test.cc
+++ b/enterprise/unit/authentication/authentication_path_test.cc
@@ -106,16 +106,24 @@ TEST(every_spelling_of_one_location_agrees) {
   EXPECT_EQ(value("http://localhost:8000/private/secret.json"), representation);
 }
 
-TEST(canonicalisation_is_idempotent) {
-  for (const std::string_view input :
-       {"/private/secret.json", "//PRIVATE//secret", "/./a/../b/c.JSON", "/",
-        "/a/b/"}) {
-    const auto once{parse(input)};
-    EXPECT_TRUE(once.has_value());
-    const auto twice{parse(once.value().value())};
-    EXPECT_TRUE(twice.has_value());
-    EXPECT_EQ(once.value().value(), twice.value().value());
-  }
+TEST(canonicalising_a_representation_twice_changes_nothing) {
+  EXPECT_EQ(value(value("/private/secret.json")), "private/secret.json");
+}
+
+TEST(canonicalising_repeated_separators_twice_changes_nothing) {
+  EXPECT_EQ(value(value("//PRIVATE//secret")), "private/secret");
+}
+
+TEST(canonicalising_relative_segments_twice_changes_nothing) {
+  EXPECT_EQ(value(value("/./a/../b/c.JSON")), "b/c.json");
+}
+
+TEST(canonicalising_the_root_twice_changes_nothing) {
+  EXPECT_EQ(value(value("/")), "");
+}
+
+TEST(canonicalising_a_trailing_separator_twice_changes_nothing) {
+  EXPECT_EQ(value(value("/a/b/")), "a/b");
 }
 
 TEST(a_url_on_this_instance_reduces_to_its_path) {
@@ -154,18 +162,39 @@ TEST(a_base_path_is_matched_on_whole_segments) {
   EXPECT_FALSE(parse("/registrynot/private", BASED, "/registry").has_value());
 }
 
-TEST(hostile_spellings_never_escape_their_location) {
-  // Each of these was a gate bypass attempt, and every one has to reduce to
-  // the same governed location rather than to something a policy would miss
-  for (const std::string_view input :
-       {"//PRIVATE/secret", "/PRIVATE/secret", "//private/secret",
-        "///PRIVATE///SECRET", "/./PRIVATE/secret",
-        "/private/../PRIVATE/secret", "/%50RIVATE/secret",
-        "/public/../PRIVATE/secret"}) {
-    const auto result{parse(input)};
-    EXPECT_TRUE(result.has_value());
-    EXPECT_EQ(result.value().value(), "private/secret");
-  }
+// Each of the spellings below was a gate bypass attempt. Every one has to name
+// the governed location rather than something a policy would miss
+
+TEST(a_repeated_leading_separator_with_upper_case_names_the_location) {
+  EXPECT_EQ(value("//PRIVATE/secret"), "private/secret");
+}
+
+TEST(an_upper_cased_prefix_names_the_location) {
+  EXPECT_EQ(value("/PRIVATE/secret"), "private/secret");
+}
+
+TEST(a_repeated_leading_separator_names_the_location) {
+  EXPECT_EQ(value("//private/secret"), "private/secret");
+}
+
+TEST(repeated_separators_throughout_with_upper_case_name_the_location) {
+  EXPECT_EQ(value("///PRIVATE///SECRET"), "private/secret");
+}
+
+TEST(a_leading_dot_segment_with_upper_case_names_the_location) {
+  EXPECT_EQ(value("/./PRIVATE/secret"), "private/secret");
+}
+
+TEST(climbing_back_into_an_upper_cased_prefix_names_the_location) {
+  EXPECT_EQ(value("/private/../PRIVATE/secret"), "private/secret");
+}
+
+TEST(an_escaped_letter_in_the_prefix_names_the_location) {
+  EXPECT_EQ(value("/%50RIVATE/secret"), "private/secret");
+}
+
+TEST(climbing_from_a_public_prefix_into_an_upper_cased_one_names_the_location) {
+  EXPECT_EQ(value("/public/../PRIVATE/secret"), "private/secret");
 }
 
 TEST(two_paths_compare_by_their_canonical_spelling) {
@@ -188,11 +217,27 @@ TEST(input_already_relative_to_the_root_is_canonicalised_as_is) {
   EXPECT_EQ(sourcemeta::one::Authentication::Path::relative("").value(), "");
 }
 
-TEST(a_relative_path_is_canonicalised_the_same_way_a_request_is) {
-  for (const std::string_view input :
-       {"/PRIVATE/secret", "//private//secret", "/private/./secret",
-        "/public/../private/secret"}) {
-    EXPECT_EQ(sourcemeta::one::Authentication::Path::relative(input).value(),
-              parse("/private/secret").value().value());
-  }
+TEST(a_relative_upper_cased_path_reads_as_the_request_form_does) {
+  EXPECT_EQ(sourcemeta::one::Authentication::Path::relative("/PRIVATE/secret")
+                .value(),
+            "private/secret");
+}
+
+TEST(a_relative_path_with_repeated_separators_reads_as_the_request_form_does) {
+  EXPECT_EQ(sourcemeta::one::Authentication::Path::relative("//private//secret")
+                .value(),
+            "private/secret");
+}
+
+TEST(a_relative_path_with_a_dot_segment_reads_as_the_request_form_does) {
+  EXPECT_EQ(sourcemeta::one::Authentication::Path::relative("/private/./secret")
+                .value(),
+            "private/secret");
+}
+
+TEST(a_relative_path_that_climbs_reads_as_the_request_form_does) {
+  EXPECT_EQ(sourcemeta::one::Authentication::Path::relative(
+                "/public/../private/secret")
+                .value(),
+            "private/secret");
 }

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -461,18 +461,25 @@ TEST(base_path_is_stripped_before_matching) {
                    .admits(at("/private/secret"), {.bearer = "", .cookies = ""})
                    .allowed);
 
-  // A base path that is not a whole-segment prefix is left in place, so the
-  // path is covered by no policy and is public
+  // A base that is not a whole-segment prefix of the target is left in place,
+  // where it is covered by no policy. An explicit route is matched on the
+  // target as it arrived, so this is asked the way the surface gate asks it
   EXPECT_TRUE(authentication
-                  .admits(at("/registryextra/public/string"),
-                          {.bearer = "", .cookies = {}})
+                  .admits_route("/registryextra/private/secret", "/registry",
+                                {.bearer = "", .cookies = {}})
                   .allowed);
 
-  // A request outside the base path is left in place and covered by no policy
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/elsewhere/public/string"), {.bearer = "", .cookies = {}})
-          .allowed);
+  // A target outside the base path is likewise covered by no policy
+  EXPECT_TRUE(authentication
+                  .admits_route("/elsewhere/private/secret", "/registry",
+                                {.bearer = "", .cookies = {}})
+                  .allowed);
+
+  // While one that does carry the base path is governed by the policy under it
+  EXPECT_FALSE(authentication
+                   .admits_route("/registry/private/secret", "/registry",
+                                 {.bearer = "", .cookies = {}})
+                   .allowed);
 }
 
 TEST(apikey_admits_matching_credential) {

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -20,6 +20,24 @@
 #include <utility>     // std::move
 #include <vector>      // std::vector
 
+// Every gate question is asked about a canonical location, so the tests name
+// one the same way a request would
+static auto at(const std::string_view input)
+    -> sourcemeta::one::Authentication::Path {
+  return sourcemeta::one::Authentication::Path::parse(
+             input, "http://localhost:8000", "")
+      .value();
+}
+
+// The same location named through an instance that is served under a base path
+static auto at_base(const std::string_view input, const std::string_view base)
+    -> sourcemeta::one::Authentication::Path {
+  const std::string instance{std::string{"http://localhost:8000"} +
+                             std::string{base}};
+  return sourcemeta::one::Authentication::Path::parse(input, instance, base)
+      .value();
+}
+
 static auto test_path(const std::string &name) -> std::filesystem::path {
   return std::filesystem::path{AUTHENTICATION_TEST_DIRECTORY} / name;
 }
@@ -77,9 +95,9 @@ TEST(missing_artifact_denies_everything) {
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"},
       stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits("/", "").allowed);
-  EXPECT_FALSE(authentication.admits("/acme/foo", "").allowed);
-  EXPECT_FALSE(authentication.admits("", "").allowed);
+  EXPECT_FALSE(authentication.admits(at("/"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.admits(at("/acme/foo"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.admits(at(""), {.bearer = ""}).allowed);
 }
 
 TEST(malformed_artifact_denies_everything) {
@@ -91,8 +109,8 @@ TEST(malformed_artifact_denies_everything) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits("/", "").allowed);
-  EXPECT_FALSE(authentication.admits("/acme/foo", "").allowed);
+  EXPECT_FALSE(authentication.admits(at("/"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.admits(at("/acme/foo"), {.bearer = ""}).allowed);
 }
 
 TEST(structurally_corrupt_artifact_denies_everything) {
@@ -110,8 +128,9 @@ TEST(structurally_corrupt_artifact_denies_everything) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits("/", "").allowed);
-  EXPECT_FALSE(authentication.admits("/internal/foo", "").allowed);
+  EXPECT_FALSE(authentication.admits(at("/"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
 }
 
 TEST(artifact_exceeding_the_policy_ceiling_denies_everything) {
@@ -132,8 +151,8 @@ TEST(artifact_exceeding_the_policy_ceiling_denies_everything) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits("/", "").allowed);
-  EXPECT_FALSE(authentication.admits("/acme/foo", "").allowed);
+  EXPECT_FALSE(authentication.admits(at("/"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.admits(at("/acme/foo"), {.bearer = ""}).allowed);
 }
 
 TEST(corrupted_section_offset_denies_everything) {
@@ -153,8 +172,9 @@ TEST(corrupted_section_offset_denies_everything) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits("/internal/foo", "").allowed);
-  EXPECT_FALSE(authentication.admits("/", "").allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.admits(at("/"), {.bearer = ""}).allowed);
 }
 
 TEST(zero_policies_admits_every_path) {
@@ -164,11 +184,13 @@ TEST(zero_policies_admits_every_path) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(authentication.admits("/", "").allowed);
-  EXPECT_TRUE(authentication.admits("", "").allowed);
-  EXPECT_TRUE(authentication.admits("/acme/foo/bar", "").allowed);
-  EXPECT_EQ(authentication.governing("/"), (std::vector<std::size_t>{}));
-  EXPECT_EQ(authentication.governing("/acme"), (std::vector<std::size_t>{}));
+  EXPECT_TRUE(authentication.admits(at("/"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.admits(at(""), {.bearer = ""}).allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/acme/foo/bar"), {.bearer = ""}).allowed);
+  EXPECT_EQ(authentication.governing(at("/")), (std::vector<std::size_t>{}));
+  EXPECT_EQ(authentication.governing(at("/acme")),
+            (std::vector<std::size_t>{}));
 }
 
 TEST(uncovered_paths_are_public_around_a_gated_scope) {
@@ -183,14 +205,18 @@ TEST(uncovered_paths_are_public_around_a_gated_scope) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The covered subtree is gated
-  EXPECT_FALSE(authentication.admits("/internal", "").allowed);
-  EXPECT_FALSE(authentication.admits("/internal/foo", "").allowed);
-  EXPECT_TRUE(authentication.admits("/internal", "scope-secret").allowed);
-  EXPECT_TRUE(authentication.admits("/internal/foo", "scope-secret").allowed);
+  EXPECT_FALSE(authentication.admits(at("/internal"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.admits(at("/internal"), {.bearer = "scope-secret"})
+                  .allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/internal/foo"), {.bearer = "scope-secret"})
+          .allowed);
   // Everything outside it is public
-  EXPECT_TRUE(authentication.admits("/", "").allowed);
-  EXPECT_TRUE(authentication.admits("/vendor", "").allowed);
-  EXPECT_TRUE(authentication.admits("/vendor/foo", "").allowed);
+  EXPECT_TRUE(authentication.admits(at("/"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.admits(at("/vendor"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.admits(at("/vendor/foo"), {.bearer = ""}).allowed);
 }
 
 TEST(scope_matches_whole_segments_only) {
@@ -204,12 +230,14 @@ TEST(scope_matches_whole_segments_only) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The scope gates its own segment
-  EXPECT_FALSE(authentication.admits("/internal", "").allowed);
+  EXPECT_FALSE(authentication.admits(at("/internal"), {.bearer = ""}).allowed);
   // A textual prefix that is not a whole segment is a different path, so it is
   // uncovered and public
-  EXPECT_TRUE(authentication.admits("/internalish", "").allowed);
-  EXPECT_TRUE(authentication.admits("/int", "").allowed);
-  EXPECT_TRUE(authentication.admits("/internal-team", "").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/internalish"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.admits(at("/int"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/internal-team"), {.bearer = ""}).allowed);
 }
 
 TEST(distinct_policies_each_gate_their_scope) {
@@ -226,11 +254,12 @@ TEST(distinct_policies_each_gate_their_scope) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits("/alpha/one", "").allowed);
-  EXPECT_FALSE(authentication.admits("/beta/two", "").allowed);
-  EXPECT_FALSE(authentication.admits("/gamma/three", "").allowed);
+  EXPECT_FALSE(authentication.admits(at("/alpha/one"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.admits(at("/beta/two"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/gamma/three"), {.bearer = ""}).allowed);
   // Between the scopes the registry is public
-  EXPECT_TRUE(authentication.admits("/delta", "").allowed);
+  EXPECT_TRUE(authentication.admits(at("/delta"), {.bearer = ""}).allowed);
 }
 
 TEST(nested_prefixes_gate_their_subtrees) {
@@ -245,12 +274,16 @@ TEST(nested_prefixes_gate_their_subtrees) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits("/internal", "").allowed);
-  EXPECT_FALSE(authentication.admits("/internal/other", "").allowed);
-  EXPECT_FALSE(authentication.admits("/internal/secret", "").allowed);
-  EXPECT_FALSE(authentication.admits("/internal/secret/deep", "").allowed);
-  EXPECT_TRUE(authentication.admits("/", "").allowed);
-  EXPECT_TRUE(authentication.admits("/public", "").allowed);
+  EXPECT_FALSE(authentication.admits(at("/internal"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/other"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/secret"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/secret/deep"), {.bearer = ""})
+          .allowed);
+  EXPECT_TRUE(authentication.admits(at("/"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.admits(at("/public"), {.bearer = ""}).allowed);
 }
 
 TEST(nested_inner_key_widens_access) {
@@ -268,11 +301,19 @@ TEST(nested_inner_key_widens_access) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The inner path is covered by both, so either key admits it
-  EXPECT_TRUE(authentication.admits("/internal/secret", "wo-secret").allowed);
-  EXPECT_TRUE(authentication.admits("/internal/secret", "wi-secret").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/internal/secret"), {.bearer = "wo-secret"})
+          .allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/internal/secret"), {.bearer = "wi-secret"})
+          .allowed);
   // The outer path is covered only by the outer policy
-  EXPECT_TRUE(authentication.admits("/internal/other", "wo-secret").allowed);
-  EXPECT_FALSE(authentication.admits("/internal/other", "wi-secret").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/internal/other"), {.bearer = "wo-secret"})
+          .allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/other"), {.bearer = "wi-secret"})
+          .allowed);
 }
 
 TEST(single_policy_with_multiple_prefixes) {
@@ -285,9 +326,11 @@ TEST(single_policy_with_multiple_prefixes) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits("/internal/foo", "").allowed);
-  EXPECT_FALSE(authentication.admits("/vendor/bar", "").allowed);
-  EXPECT_TRUE(authentication.admits("/public", "").allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/vendor/bar"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.admits(at("/public"), {.bearer = ""}).allowed);
 }
 
 TEST(extensionless_policy_gates_every_representation) {
@@ -302,23 +345,35 @@ TEST(extensionless_policy_gates_every_representation) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The resource, every representation of it, and its subtree are all governed
-  EXPECT_FALSE(authentication.admits("/secret/data", "").allowed);
-  EXPECT_FALSE(authentication.admits("/secret/data.json", "").allowed);
-  EXPECT_FALSE(authentication.admits("/secret/data.xml", "").allowed);
-  EXPECT_FALSE(authentication.admits("/secret/data/nested", "").allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secret/data"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secret/data.json"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secret/data.xml"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secret/data/nested"), {.bearer = ""}).allowed);
   EXPECT_TRUE(
-      authentication.admits("/secret/data", "representation-secret").allowed);
-  EXPECT_TRUE(
-      authentication.admits("/secret/data.json", "representation-secret")
+      authentication
+          .admits(at("/secret/data"), {.bearer = "representation-secret"})
           .allowed);
-  EXPECT_TRUE(authentication.admits("/secret/data.xml", "representation-secret")
+  EXPECT_TRUE(
+      authentication
+          .admits(at("/secret/data.json"), {.bearer = "representation-secret"})
+          .allowed);
+  EXPECT_TRUE(
+      authentication
+          .admits(at("/secret/data.xml"), {.bearer = "representation-secret"})
+          .allowed);
+  EXPECT_TRUE(authentication
+                  .admits(at("/secret/data/nested"),
+                          {.bearer = "representation-secret"})
                   .allowed);
-  EXPECT_TRUE(
-      authentication.admits("/secret/data/nested", "representation-secret")
-          .allowed);
   // A sibling sharing a textual prefix is covered by no policy, so it is public
-  EXPECT_TRUE(authentication.admits("/secret/database", "").allowed);
-  EXPECT_TRUE(authentication.admits("/secret/data2.json", "").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/secret/database"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/secret/data2.json"), {.bearer = ""}).allowed);
 }
 
 TEST(extension_specific_policy_gates_only_that_representation) {
@@ -333,15 +388,21 @@ TEST(extension_specific_policy_gates_only_that_representation) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // Only the named representation is gated
-  EXPECT_FALSE(authentication.admits("/secret/data.json", "").allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secret/data.json"), {.bearer = ""}).allowed);
   EXPECT_TRUE(
-      authentication.admits("/secret/data.json", "specific-secret").allowed);
+      authentication
+          .admits(at("/secret/data.json"), {.bearer = "specific-secret"})
+          .allowed);
   EXPECT_TRUE(
-      authentication.admits("/secret/data.json/nested", "specific-secret")
+      authentication
+          .admits(at("/secret/data.json/nested"), {.bearer = "specific-secret"})
           .allowed);
   // The bare resource and other representations are uncovered, so public
-  EXPECT_TRUE(authentication.admits("/secret/data", "").allowed);
-  EXPECT_TRUE(authentication.admits("/secret/data.xml", "").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/secret/data"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/secret/data.xml"), {.bearer = ""}).allowed);
 }
 
 TEST(extension_handling_is_confined_to_the_terminal_segment) {
@@ -355,14 +416,15 @@ TEST(extension_handling_is_confined_to_the_terminal_segment) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The policy on /v1 gates its own subtree
-  EXPECT_FALSE(authentication.admits("/v1", "").allowed);
-  EXPECT_FALSE(authentication.admits("/v1/secret", "").allowed);
+  EXPECT_FALSE(authentication.admits(at("/v1"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.admits(at("/v1/secret"), {.bearer = ""}).allowed);
   // As a terminal segment, /v1.0 is a representation of /v1 under the
   // content-negotiation rule, the same way /person.json represents /person
-  EXPECT_FALSE(authentication.admits("/v1.0", "").allowed);
+  EXPECT_FALSE(authentication.admits(at("/v1.0"), {.bearer = ""}).allowed);
   // But as an intermediate segment it is a distinct directory that does not
   // descend into the /v1 subtree, so its children are uncovered and public
-  EXPECT_TRUE(authentication.admits("/v1.0/secret", "").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/v1.0/secret"), {.bearer = ""}).allowed);
 }
 
 TEST(base_path_is_stripped_before_matching) {
@@ -378,30 +440,38 @@ TEST(base_path_is_stripped_before_matching) {
       path, stub_fetcher({}, nullptr)};
   // With the base path stripped, the registry path under it is matched. The
   // uncovered public path is admitted, the covered one is gated
-  EXPECT_TRUE(
-      authentication.admits("/registry/public/string", "", {}, "/registry")
-          .allowed);
-  EXPECT_FALSE(
-      authentication.admits("/registry/private/secret", "", {}, "/registry")
-          .allowed);
-  EXPECT_TRUE(
-      authentication
-          .admits("/registry/private/secret", "base-secret", {}, "/registry")
-          .allowed);
+  EXPECT_TRUE(authentication
+                  .admits(at_base("/registry/public/string", "/registry"),
+                          {.bearer = "", .cookies = {}})
+                  .allowed);
+  EXPECT_FALSE(authentication
+                   .admits(at_base("/registry/private/secret", "/registry"),
+                           {.bearer = "", .cookies = {}})
+                   .allowed);
+  EXPECT_TRUE(authentication
+                  .admits(at_base("/registry/private/secret", "/registry"),
+                          {.bearer = "base-secret", .cookies = {}})
+                  .allowed);
 
   // An empty base path strips nothing
-  EXPECT_TRUE(authentication.admits("/public/string", "", "").allowed);
-  EXPECT_FALSE(authentication.admits("/private/secret", "", "").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/public/string"), {.bearer = "", .cookies = ""})
+          .allowed);
+  EXPECT_FALSE(authentication
+                   .admits(at("/private/secret"), {.bearer = "", .cookies = ""})
+                   .allowed);
 
   // A base path that is not a whole-segment prefix is left in place, so the
   // path is covered by no policy and is public
-  EXPECT_TRUE(
-      authentication.admits("/registryextra/public/string", "", {}, "/registry")
-          .allowed);
+  EXPECT_TRUE(authentication
+                  .admits(at("/registryextra/public/string"),
+                          {.bearer = "", .cookies = {}})
+                  .allowed);
 
   // A request outside the base path is left in place and covered by no policy
   EXPECT_TRUE(
-      authentication.admits("/elsewhere/public/string", "", {}, "/registry")
+      authentication
+          .admits(at("/elsewhere/public/string"), {.bearer = "", .cookies = {}})
           .allowed);
 }
 
@@ -416,9 +486,13 @@ TEST(apikey_admits_matching_credential) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(authentication.admits("/internal/foo", "secret-match").allowed);
-  EXPECT_FALSE(authentication.admits("/internal/foo", "wrong").allowed);
-  EXPECT_FALSE(authentication.admits("/internal/foo", "").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/internal/foo"), {.bearer = "secret-match"})
+          .allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/foo"), {.bearer = "wrong"}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
 }
 
 TEST(apikey_with_multiple_keys_admits_any) {
@@ -434,9 +508,12 @@ TEST(apikey_with_multiple_keys_admits_any) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(authentication.admits("/internal/foo", "key-a").allowed);
-  EXPECT_TRUE(authentication.admits("/internal/foo", "key-b").allowed);
-  EXPECT_FALSE(authentication.admits("/internal/foo", "key-c").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/internal/foo"), {.bearer = "key-a"}).allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/internal/foo"), {.bearer = "key-b"}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/foo"), {.bearer = "key-c"}).allowed);
 }
 
 TEST(apikey_with_unset_variable_denies) {
@@ -449,8 +526,11 @@ TEST(apikey_with_unset_variable_denies) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits("/internal/foo", "anything").allowed);
-  EXPECT_FALSE(authentication.admits("/internal/foo", "").allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/foo"), {.bearer = "anything"})
+          .allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
 }
 
 TEST(sha256_policy_admits_the_matching_credential) {
@@ -465,12 +545,16 @@ TEST(sha256_policy_admits_the_matching_credential) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(authentication.admits("/secret/foo", raw).allowed);
-  EXPECT_FALSE(authentication.admits("/secret/foo", "wrong").allowed);
-  EXPECT_FALSE(authentication.admits("/secret/foo", "").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/secret/foo"), {.bearer = raw}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secret/foo"), {.bearer = "wrong"}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secret/foo"), {.bearer = ""}).allowed);
   // Presenting the stored hash itself does not authenticate
   EXPECT_FALSE(
-      authentication.admits("/secret/foo", sourcemeta::core::sha256(raw))
+      authentication
+          .admits(at("/secret/foo"), {.bearer = sourcemeta::core::sha256(raw)})
           .allowed);
 }
 
@@ -493,9 +577,11 @@ TEST(mixed_algorithms_admit_either_key_with_identity_first) {
       path, stub_fetcher({}, nullptr)};
   // Either key type opens the path regardless of declaration order. The sha256
   // key must work even though the identity policy is checked first and fails
-  EXPECT_TRUE(authentication.admits("/mixed/x", "plain-a").allowed);
-  EXPECT_TRUE(authentication.admits("/mixed/x", raw).allowed);
-  EXPECT_FALSE(authentication.admits("/mixed/x", "neither").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/mixed/x"), {.bearer = "plain-a"}).allowed);
+  EXPECT_TRUE(authentication.admits(at("/mixed/x"), {.bearer = raw}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/mixed/x"), {.bearer = "neither"}).allowed);
 }
 
 TEST(mixed_algorithms_admit_either_key_with_sha256_first) {
@@ -515,9 +601,11 @@ TEST(mixed_algorithms_admit_either_key_with_sha256_first) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The identity key must work even though the sha256 policy is checked first
-  EXPECT_TRUE(authentication.admits("/mixed/x", raw).allowed);
-  EXPECT_TRUE(authentication.admits("/mixed/x", "plain-b").allowed);
-  EXPECT_FALSE(authentication.admits("/mixed/x", "neither").allowed);
+  EXPECT_TRUE(authentication.admits(at("/mixed/x"), {.bearer = raw}).allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/mixed/x"), {.bearer = "plain-b"}).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/mixed/x"), {.bearer = "neither"}).allowed);
 }
 
 TEST(supports_the_maximum_number_of_policies) {
@@ -547,10 +635,10 @@ TEST(supports_the_maximum_number_of_policies) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The keyless policies gate their scope with no key that can open it
-  EXPECT_FALSE(authentication.admits("/p0/foo", "").allowed);
-  EXPECT_FALSE(authentication.admits("/p63/foo", "").allowed);
+  EXPECT_FALSE(authentication.admits(at("/p0/foo"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.admits(at("/p63/foo"), {.bearer = ""}).allowed);
   // An uncovered path is public
-  EXPECT_TRUE(authentication.admits("/missing", "").allowed);
+  EXPECT_TRUE(authentication.admits(at("/missing"), {.bearer = ""}).allowed);
 }
 
 TEST(governing_returns_policy_indices_in_declaration_order) {
@@ -565,11 +653,12 @@ TEST(governing_returns_policy_indices_in_declaration_order) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_EQ(authentication.governing("/"), (std::vector<std::size_t>{0}));
-  EXPECT_EQ(authentication.governing("/vendor"), (std::vector<std::size_t>{0}));
-  EXPECT_EQ(authentication.governing("/internal"),
+  EXPECT_EQ(authentication.governing(at("/")), (std::vector<std::size_t>{0}));
+  EXPECT_EQ(authentication.governing(at("/vendor")),
+            (std::vector<std::size_t>{0}));
+  EXPECT_EQ(authentication.governing(at("/internal")),
             (std::vector<std::size_t>{0, 1}));
-  EXPECT_EQ(authentication.governing("/internal/foo"),
+  EXPECT_EQ(authentication.governing(at("/internal/foo")),
             (std::vector<std::size_t>{0, 1}));
 }
 
@@ -583,8 +672,9 @@ TEST(governing_of_an_ungoverned_path_is_empty) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_EQ(authentication.governing("/vendor"), (std::vector<std::size_t>{}));
-  EXPECT_EQ(authentication.governing("/internal"),
+  EXPECT_EQ(authentication.governing(at("/vendor")),
+            (std::vector<std::size_t>{}));
+  EXPECT_EQ(authentication.governing(at("/internal")),
             (std::vector<std::size_t>{0}));
 }
 
@@ -592,10 +682,12 @@ TEST(reference_through_a_broken_artifact_is_rejected) {
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"},
       stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.reference_permitted("/open/one", "/open/two"));
-  EXPECT_FALSE(authentication.reference_permitted("/open/one", "/secret/two"));
   EXPECT_FALSE(
-      authentication.reference_permitted("/secret/one", "/secret/two"));
+      authentication.reference_permitted(at("/open/one"), at("/open/two")));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/open/one"), at("/secret/two")));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/secret/one"), at("/secret/two")));
 }
 
 TEST(reference_to_a_public_schema_is_permitted) {
@@ -608,8 +700,10 @@ TEST(reference_to_a_public_schema_is_permitted) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(authentication.reference_permitted("/secret/one", "/open/two"));
-  EXPECT_TRUE(authentication.reference_permitted("/open/one", "/open/two"));
+  EXPECT_TRUE(
+      authentication.reference_permitted(at("/secret/one"), at("/open/two")));
+  EXPECT_TRUE(
+      authentication.reference_permitted(at("/open/one"), at("/open/two")));
 }
 
 TEST(public_schema_referencing_an_apikey_schema_is_rejected) {
@@ -622,7 +716,8 @@ TEST(public_schema_referencing_an_apikey_schema_is_rejected) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.reference_permitted("/open/one", "/secret/two"));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/open/one"), at("/secret/two")));
 }
 
 TEST(reference_within_the_same_policy_is_permitted) {
@@ -635,10 +730,10 @@ TEST(reference_within_the_same_policy_is_permitted) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(
-      authentication.reference_permitted("/internal/one", "/internal/two"));
-  EXPECT_TRUE(
-      authentication.reference_permitted("/internal/one", "/internal/one"));
+  EXPECT_TRUE(authentication.reference_permitted(at("/internal/one"),
+                                                 at("/internal/two")));
+  EXPECT_TRUE(authentication.reference_permitted(at("/internal/one"),
+                                                 at("/internal/one")));
 }
 
 TEST(reference_across_disjoint_policies_is_rejected) {
@@ -653,8 +748,10 @@ TEST(reference_across_disjoint_policies_is_rejected) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.reference_permitted("/alpha/one", "/beta/two"));
-  EXPECT_FALSE(authentication.reference_permitted("/beta/two", "/alpha/one"));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_from_a_narrower_to_a_wider_audience_is_permitted) {
@@ -669,8 +766,10 @@ TEST(reference_from_a_narrower_to_a_wider_audience_is_permitted) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(authentication.reference_permitted("/p/one", "/p/inner/two"));
-  EXPECT_FALSE(authentication.reference_permitted("/p/inner/two", "/p/one"));
+  EXPECT_TRUE(
+      authentication.reference_permitted(at("/p/one"), at("/p/inner/two")));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/p/inner/two"), at("/p/one")));
 }
 
 TEST(jwt_admits_a_valid_token_and_caches_the_key_set) {
@@ -691,11 +790,14 @@ TEST(jwt_admits_a_valid_token_and_caches_the_key_set) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          calls)};
-  EXPECT_TRUE(authentication.admits("/secure/x", SIGNED_TOKEN).allowed);
-  EXPECT_FALSE(authentication.admits("/secure/x", "not-a-token").allowed);
-  EXPECT_FALSE(authentication.admits("/secure/x", "").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_FALSE(authentication.admits(at("/secure/x"), {.bearer = "not-a-token"})
+                   .allowed);
+  EXPECT_FALSE(authentication.admits(at("/secure/x"), {.bearer = ""}).allowed);
   // A second valid request reuses the cached key set rather than refetching
-  EXPECT_TRUE(authentication.admits("/secure/x", SIGNED_TOKEN).allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
   EXPECT_EQ(*calls, 1);
 }
 
@@ -716,7 +818,8 @@ TEST(jwt_denies_a_token_for_the_wrong_audience) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
-  EXPECT_FALSE(authentication.admits("/secure/x", SIGNED_TOKEN).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
 }
 
 TEST(jwt_denies_a_token_from_the_wrong_issuer) {
@@ -736,7 +839,8 @@ TEST(jwt_denies_a_token_from_the_wrong_issuer) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
-  EXPECT_FALSE(authentication.admits("/secure/x", SIGNED_TOKEN).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
 }
 
 TEST(jwt_denies_a_disallowed_algorithm) {
@@ -756,7 +860,8 @@ TEST(jwt_denies_a_disallowed_algorithm) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
-  EXPECT_FALSE(authentication.admits("/secure/x", SIGNED_TOKEN).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
 }
 
 TEST(jwt_denies_when_the_signing_key_is_absent) {
@@ -777,7 +882,8 @@ TEST(jwt_denies_when_the_signing_key_is_absent) {
       path,
       stub_fetcher({{"https://idp.test/jwks", std::string{UNRELATED_KEYS}}},
                    nullptr)};
-  EXPECT_FALSE(authentication.admits("/secure/x", SIGNED_TOKEN).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
 }
 
 TEST(jwt_denies_when_the_key_set_cannot_be_fetched) {
@@ -796,7 +902,8 @@ TEST(jwt_denies_when_the_key_set_cannot_be_fetched) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits("/secure/x", SIGNED_TOKEN).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
 }
 
 TEST(an_apikey_credential_never_triggers_a_jwt_fetch) {
@@ -817,8 +924,10 @@ TEST(an_apikey_credential_never_triggers_a_jwt_fetch) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          calls)};
-  EXPECT_FALSE(authentication.admits("/secure/x", "static-api-key").allowed);
-  EXPECT_FALSE(authentication.admits("/secure/x", "").allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secure/x"), {.bearer = "static-api-key"})
+          .allowed);
+  EXPECT_FALSE(authentication.admits(at("/secure/x"), {.bearer = ""}).allowed);
   EXPECT_EQ(*calls, 0);
 }
 
@@ -847,7 +956,8 @@ TEST(jwt_resolves_the_key_set_through_discovery) {
   // Both the provider metadata and the key set it names are retrieved, and
   // the token then fails only on its issuer claim, which names a different
   // issuer than the policy trusts
-  EXPECT_FALSE(authentication.admits("/secure/x", SIGNED_TOKEN).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
   EXPECT_EQ(*calls, 2);
 }
 
@@ -873,7 +983,8 @@ TEST(jwt_without_a_discoverable_issuer_fails_closed) {
             R"JSON({ "issuer": "acme", "jwks_uri": "https://acme.test/keys" })JSON"},
            {"https://acme.test/keys", std::string{SIGNED_KEYS}}},
           calls)};
-  EXPECT_FALSE(authentication.admits("/secure/x", SIGNED_TOKEN).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
   EXPECT_EQ(*calls, 0);
 }
 
@@ -898,11 +1009,14 @@ TEST(mixed_apikey_and_jwt_policies_admit_either_credential) {
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
   // The static key opens the path
-  EXPECT_TRUE(authentication.admits("/both/x", "static-secret").allowed);
+  EXPECT_TRUE(authentication.admits(at("/both/x"), {.bearer = "static-secret"})
+                  .allowed);
   // The token opens the path
-  EXPECT_TRUE(authentication.admits("/both/x", SIGNED_TOKEN).allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/both/x"), {.bearer = SIGNED_TOKEN}).allowed);
   // Neither a wrong key nor a wrong token opens it
-  EXPECT_FALSE(authentication.admits("/both/x", "wrong").allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/both/x"), {.bearer = "wrong"}).allowed);
 }
 
 TEST(oidc_policy_admits_no_presented_credential) {
@@ -930,15 +1044,18 @@ TEST(oidc_policy_admits_no_presented_credential) {
                     {"https://acme.test/keys", std::string{SIGNED_KEYS}}},
                    calls)};
 
-  const auto empty_verdict{authentication.admits("/portal/x", "")};
+  const auto empty_verdict{
+      authentication.admits(at("/portal/x"), {.bearer = ""})};
   EXPECT_FALSE(empty_verdict.allowed);
   EXPECT_FALSE(empty_verdict.principal.has_value());
 
-  const auto secret_verdict{authentication.admits("/portal/x", "confidential")};
+  const auto secret_verdict{
+      authentication.admits(at("/portal/x"), {.bearer = "confidential"})};
   EXPECT_FALSE(secret_verdict.allowed);
   EXPECT_FALSE(secret_verdict.principal.has_value());
 
-  const auto token_verdict{authentication.admits("/portal/x", SIGNED_TOKEN)};
+  const auto token_verdict{
+      authentication.admits(at("/portal/x"), {.bearer = SIGNED_TOKEN})};
   EXPECT_FALSE(token_verdict.allowed);
   EXPECT_FALSE(token_verdict.principal.has_value());
 
@@ -964,14 +1081,16 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_only_the_key) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
 
-  const auto key_verdict{authentication.admits("/both/x", "union-secret")};
+  const auto key_verdict{
+      authentication.admits(at("/both/x"), {.bearer = "union-secret"})};
   EXPECT_TRUE(key_verdict.allowed);
   EXPECT_TRUE(key_verdict.principal.has_value());
   EXPECT_EQ(key_verdict.principal.value().type,
             sourcemeta::one::Authentication::Type::ApiKey);
   EXPECT_EQ(key_verdict.principal.value().policy, std::size_t{0});
 
-  const auto token_verdict{authentication.admits("/both/x", SIGNED_TOKEN)};
+  const auto token_verdict{
+      authentication.admits(at("/both/x"), {.bearer = SIGNED_TOKEN})};
   EXPECT_FALSE(token_verdict.allowed);
   EXPECT_FALSE(token_verdict.principal.has_value());
 }
@@ -1000,7 +1119,8 @@ TEST(oidc_policy_admits_its_session_cookie) {
   const std::string cookies{"theme=dark; sourcemeta_one_session_okta=" +
                             sealed};
 
-  const auto verdict{authentication.admits("/portal/x", "", cookies)};
+  const auto verdict{authentication.admits(at("/portal/x"),
+                                           {.bearer = "", .cookies = cookies})};
   EXPECT_TRUE(verdict.allowed);
   EXPECT_TRUE(verdict.principal.has_value());
   EXPECT_EQ(verdict.principal.value().type,
@@ -1008,7 +1128,8 @@ TEST(oidc_policy_admits_its_session_cookie) {
   EXPECT_EQ(verdict.principal.value().policy, std::size_t{0});
   EXPECT_EQ(*calls, 0);
 
-  const auto anonymous_verdict{authentication.admits("/portal/x", "")};
+  const auto anonymous_verdict{
+      authentication.admits(at("/portal/x"), {.bearer = ""})};
   EXPECT_FALSE(anonymous_verdict.allowed);
   EXPECT_FALSE(anonymous_verdict.principal.has_value());
 }
@@ -1043,14 +1164,23 @@ TEST(session_cookie_is_bound_to_the_policy_it_was_minted_for) {
 
   // The session opens the path its policy governs
   const std::string okta_cookies{"sourcemeta_one_session_okta=" + sealed};
-  EXPECT_TRUE(authentication.admits("/alpha/x", "", okta_cookies).allowed);
+  EXPECT_TRUE(
+      authentication
+          .admits(at("/alpha/x"), {.bearer = "", .cookies = okta_cookies})
+          .allowed);
 
   // The same session does not open a path governed by another policy
-  EXPECT_FALSE(authentication.admits("/beta/x", "", okta_cookies).allowed);
+  EXPECT_FALSE(
+      authentication
+          .admits(at("/beta/x"), {.bearer = "", .cookies = okta_cookies})
+          .allowed);
 
   // Nor does re-presenting the value under the other policy's cookie name
   const std::string renamed_cookies{"sourcemeta_one_session_google=" + sealed};
-  EXPECT_FALSE(authentication.admits("/beta/x", "", renamed_cookies).allowed);
+  EXPECT_FALSE(
+      authentication
+          .admits(at("/beta/x"), {.bearer = "", .cookies = renamed_cookies})
+          .allowed);
 }
 
 TEST(expired_session_cookie_is_denied) {
@@ -1074,7 +1204,9 @@ TEST(expired_session_cookie_is_denied) {
   const auto sealed{sourcemeta::one::session_seal(
       R"JSON({ "policy": "okta" })JSON", SESSION_SECRET, past)};
   const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
-  EXPECT_FALSE(authentication.admits("/portal/x", "", cookies).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/portal/x"), {.bearer = "", .cookies = cookies})
+          .allowed);
 }
 
 TEST(forged_session_cookie_is_denied) {
@@ -1098,7 +1230,10 @@ TEST(forged_session_cookie_is_denied) {
   const auto foreign{sourcemeta::one::session_seal(
       R"JSON({ "policy": "okta" })JSON", "other-secret", SESSION_EXPIRY)};
   const std::string foreign_cookies{"sourcemeta_one_session_okta=" + foreign};
-  EXPECT_FALSE(authentication.admits("/portal/x", "", foreign_cookies).allowed);
+  EXPECT_FALSE(
+      authentication
+          .admits(at("/portal/x"), {.bearer = "", .cookies = foreign_cookies})
+          .allowed);
 
   // A value whose signature no longer matches its contents
   auto tampered{sourcemeta::one::session_seal(R"JSON({ "policy": "okta" })JSON",
@@ -1106,13 +1241,16 @@ TEST(forged_session_cookie_is_denied) {
   tampered.back() = tampered.back() == 'A' ? 'B' : 'A';
   const std::string tampered_cookies{"sourcemeta_one_session_okta=" + tampered};
   EXPECT_FALSE(
-      authentication.admits("/portal/x", "", tampered_cookies).allowed);
+      authentication
+          .admits(at("/portal/x"), {.bearer = "", .cookies = tampered_cookies})
+          .allowed);
 
   // A value that is not a sealed session at all
-  EXPECT_FALSE(
-      authentication
-          .admits("/portal/x", "", "sourcemeta_one_session_okta=garbage")
-          .allowed);
+  EXPECT_FALSE(authentication
+                   .admits(at("/portal/x"),
+                           {.bearer = "",
+                            .cookies = "sourcemeta_one_session_okta=garbage"})
+                   .allowed);
 }
 
 TEST(session_payload_must_declare_its_policy) {
@@ -1139,7 +1277,10 @@ TEST(session_payload_must_declare_its_policy) {
     const auto sealed{
         sourcemeta::one::session_seal(payload, SESSION_SECRET, SESSION_EXPIRY)};
     const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
-    EXPECT_FALSE(authentication.admits("/portal/x", "", cookies).allowed);
+    EXPECT_FALSE(
+        authentication
+            .admits(at("/portal/x"), {.bearer = "", .cookies = cookies})
+            .allowed);
   }
 }
 
@@ -1163,7 +1304,9 @@ TEST(session_cookie_without_a_configured_secret_is_denied) {
   const auto sealed{sourcemeta::one::session_seal(
       R"JSON({ "policy": "okta" })JSON", SESSION_SECRET, SESSION_EXPIRY)};
   const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
-  EXPECT_FALSE(authentication.admits("/portal/x", "", cookies).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/portal/x"), {.bearer = "", .cookies = cookies})
+          .allowed);
 }
 
 TEST(session_admitted_under_a_rotated_secret) {
@@ -1190,7 +1333,9 @@ TEST(session_admitted_under_a_rotated_secret) {
       R"JSON({ "policy": "okta" })JSON", "old-secret", SESSION_EXPIRY)};
   EXPECT_TRUE(
       authentication
-          .admits("/portal/x", "", "sourcemeta_one_session_okta=" + old_sealed)
+          .admits(at("/portal/x"),
+                  {.bearer = "",
+                   .cookies = "sourcemeta_one_session_okta=" + old_sealed})
           .allowed);
 
   // A fresh login mints under the newest secret alone, so the minted value
@@ -1211,7 +1356,9 @@ TEST(session_admitted_under_a_rotated_secret) {
       R"JSON({ "policy": "okta" })JSON", "retired-secret", SESSION_EXPIRY)};
   EXPECT_FALSE(
       authentication
-          .admits("/portal/x", "", "sourcemeta_one_session_okta=" + retired)
+          .admits(at("/portal/x"),
+                  {.bearer = "",
+                   .cookies = "sourcemeta_one_session_okta=" + retired})
           .allowed);
 }
 
@@ -1236,7 +1383,9 @@ TEST(session_with_a_blank_configured_secret_is_denied) {
   const auto forged{sourcemeta::one::session_seal(
       R"JSON({ "policy": "okta" })JSON", "", SESSION_EXPIRY)};
   const std::string cookies{"sourcemeta_one_session_okta=" + forged};
-  EXPECT_FALSE(authentication.admits("/portal/x", "", cookies).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/portal/x"), {.bearer = "", .cookies = cookies})
+          .allowed);
 }
 
 TEST(save_rejects_a_nameless_interactive_policy) {
@@ -1277,7 +1426,8 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_key_or_session) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
 
-  const auto key_verdict{authentication.admits("/both/x", "union-key")};
+  const auto key_verdict{
+      authentication.admits(at("/both/x"), {.bearer = "union-key"})};
   EXPECT_TRUE(key_verdict.allowed);
   EXPECT_TRUE(key_verdict.principal.has_value());
   EXPECT_EQ(key_verdict.principal.value().type,
@@ -1287,14 +1437,15 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_key_or_session) {
   const auto sealed{sourcemeta::one::session_seal(
       R"JSON({ "policy": "okta" })JSON", SESSION_SECRET, SESSION_EXPIRY)};
   const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
-  const auto session_verdict{authentication.admits("/both/x", "", cookies)};
+  const auto session_verdict{
+      authentication.admits(at("/both/x"), {.bearer = "", .cookies = cookies})};
   EXPECT_TRUE(session_verdict.allowed);
   EXPECT_TRUE(session_verdict.principal.has_value());
   EXPECT_EQ(session_verdict.principal.value().type,
             sourcemeta::one::Authentication::Type::OIDC);
   EXPECT_EQ(session_verdict.principal.value().policy, std::size_t{1});
 
-  EXPECT_FALSE(authentication.admits("/both/x", "").allowed);
+  EXPECT_FALSE(authentication.admits(at("/both/x"), {.bearer = ""}).allowed);
 }
 
 TEST(session_cookie_does_not_open_an_apikey_path) {
@@ -1313,7 +1464,10 @@ TEST(session_cookie_does_not_open_an_apikey_path) {
   const auto sealed{sourcemeta::one::session_seal(
       R"JSON({ "policy": "okta" })JSON", SESSION_SECRET, SESSION_EXPIRY)};
   const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
-  EXPECT_FALSE(authentication.admits("/internal/x", "", cookies).allowed);
+  EXPECT_FALSE(
+      authentication
+          .admits(at("/internal/x"), {.bearer = "", .cookies = cookies})
+          .allowed);
 }
 
 TEST(interactive_returns_the_policy_by_name) {
@@ -1503,8 +1657,10 @@ TEST(reference_within_the_same_oidc_scope_is_permitted) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(authentication.reference_permitted("/alpha/one", "/beta/two"));
-  EXPECT_TRUE(authentication.reference_permitted("/beta/two", "/alpha/one"));
+  EXPECT_TRUE(
+      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_TRUE(
+      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_across_distinct_oidc_clients_is_rejected) {
@@ -1530,8 +1686,10 @@ TEST(reference_across_distinct_oidc_clients_is_rejected) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.reference_permitted("/alpha/one", "/beta/two"));
-  EXPECT_FALSE(authentication.reference_permitted("/beta/two", "/alpha/one"));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_across_swapped_oidc_identities_is_rejected) {
@@ -1559,8 +1717,10 @@ TEST(reference_across_swapped_oidc_identities_is_rejected) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.reference_permitted("/alpha/one", "/beta/two"));
-  EXPECT_FALSE(authentication.reference_permitted("/beta/two", "/alpha/one"));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_mixing_identities_across_oidc_policies_is_rejected) {
@@ -1597,7 +1757,7 @@ TEST(reference_mixing_identities_across_oidc_policies_is_rejected) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(
-      authentication.reference_permitted("/source/one", "/target/two"));
+      authentication.reference_permitted(at("/source/one"), at("/target/two")));
 }
 
 TEST(admission_by_an_apikey_policy_identifies_the_principal) {
@@ -1611,8 +1771,8 @@ TEST(admission_by_an_apikey_policy_identifies_the_principal) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  const auto verdict{
-      authentication.admits("/internal/foo", "principal-secret")};
+  const auto verdict{authentication.admits(at("/internal/foo"),
+                                           {.bearer = "principal-secret"})};
   EXPECT_TRUE(verdict.allowed);
   EXPECT_TRUE(verdict.principal.has_value());
   EXPECT_EQ(verdict.principal.value().type,
@@ -1637,7 +1797,8 @@ TEST(admission_by_a_jwt_policy_identifies_the_principal) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
-  const auto verdict{authentication.admits("/secure/foo", SIGNED_TOKEN)};
+  const auto verdict{
+      authentication.admits(at("/secure/foo"), {.bearer = SIGNED_TOKEN})};
   EXPECT_TRUE(verdict.allowed);
   EXPECT_TRUE(verdict.principal.has_value());
   EXPECT_EQ(verdict.principal.value().type,
@@ -1667,14 +1828,15 @@ TEST(principal_identifies_the_admitting_policy_among_several) {
                          nullptr)};
 
   const auto apikey_verdict{
-      authentication.admits("/both/x", "principal-mixed")};
+      authentication.admits(at("/both/x"), {.bearer = "principal-mixed"})};
   EXPECT_TRUE(apikey_verdict.allowed);
   EXPECT_TRUE(apikey_verdict.principal.has_value());
   EXPECT_EQ(apikey_verdict.principal.value().type,
             sourcemeta::one::Authentication::Type::ApiKey);
   EXPECT_EQ(apikey_verdict.principal.value().policy, std::size_t{0});
 
-  const auto jwt_verdict{authentication.admits("/both/x", SIGNED_TOKEN)};
+  const auto jwt_verdict{
+      authentication.admits(at("/both/x"), {.bearer = SIGNED_TOKEN})};
   EXPECT_TRUE(jwt_verdict.allowed);
   EXPECT_TRUE(jwt_verdict.principal.has_value());
   EXPECT_EQ(jwt_verdict.principal.value().type,
@@ -1695,12 +1857,14 @@ TEST(anonymous_and_denied_verdicts_carry_no_principal) {
       path, stub_fetcher({}, nullptr)};
 
   // An uncovered path admits an anonymous caller
-  const auto anonymous_verdict{authentication.admits("/open/foo", "")};
+  const auto anonymous_verdict{
+      authentication.admits(at("/open/foo"), {.bearer = ""})};
   EXPECT_TRUE(anonymous_verdict.allowed);
   EXPECT_FALSE(anonymous_verdict.principal.has_value());
 
   // A denial identifies nobody
-  const auto denied_verdict{authentication.admits("/internal/foo", "wrong")};
+  const auto denied_verdict{
+      authentication.admits(at("/internal/foo"), {.bearer = "wrong"})};
   EXPECT_FALSE(denied_verdict.allowed);
   EXPECT_FALSE(denied_verdict.principal.has_value());
 
@@ -1708,7 +1872,8 @@ TEST(anonymous_and_denied_verdicts_carry_no_principal) {
   const sourcemeta::one::Authentication missing{
       std::filesystem::path{"/no/such/authentication.bin"},
       stub_fetcher({}, nullptr)};
-  const auto missing_verdict{missing.admits("/internal/foo", "principal-none")};
+  const auto missing_verdict{
+      missing.admits(at("/internal/foo"), {.bearer = "principal-none"})};
   EXPECT_FALSE(missing_verdict.allowed);
   EXPECT_FALSE(missing_verdict.principal.has_value());
 }
@@ -1731,10 +1896,13 @@ TEST(reference_rules_treat_a_jwt_scope_conservatively) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // A public schema may not reference one behind the token scope
-  EXPECT_FALSE(authentication.reference_permitted("/open/one", "/secure/two"));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/open/one"), at("/secure/two")));
   // The token scope may reference a public schema, and itself
-  EXPECT_TRUE(authentication.reference_permitted("/secure/one", "/open/two"));
-  EXPECT_TRUE(authentication.reference_permitted("/secure/one", "/secure/two"));
+  EXPECT_TRUE(
+      authentication.reference_permitted(at("/secure/one"), at("/open/two")));
+  EXPECT_TRUE(
+      authentication.reference_permitted(at("/secure/one"), at("/secure/two")));
 }
 
 TEST(jwt_without_a_transport_denies_rather_than_crashes) {
@@ -1752,7 +1920,8 @@ TEST(jwt_without_a_transport_denies_rather_than_crashes) {
   sourcemeta::one::Authentication::save(policies, path, path);
 
   const sourcemeta::one::Authentication authentication{path, {}};
-  EXPECT_FALSE(authentication.admits("/secure/x", SIGNED_TOKEN).allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
 }
 
 TEST(jwt_policies_sharing_an_issuer_use_their_own_key_set) {
@@ -1783,8 +1952,11 @@ TEST(jwt_policies_sharing_an_issuer_use_their_own_key_set) {
                 nullptr)};
   // The primary path is populated first, which under a per-issuer cache would
   // have leaked its key set to the secondary path
-  EXPECT_TRUE(authentication.admits("/primary/x", SIGNED_TOKEN).allowed);
-  EXPECT_FALSE(authentication.admits("/secondary/x", SIGNED_TOKEN).allowed);
+  EXPECT_TRUE(authentication.admits(at("/primary/x"), {.bearer = SIGNED_TOKEN})
+                  .allowed);
+  EXPECT_FALSE(
+      authentication.admits(at("/secondary/x"), {.bearer = SIGNED_TOKEN})
+          .allowed);
 }
 
 TEST(reference_between_jwt_scopes_distinguishes_algorithms) {
@@ -1821,7 +1993,9 @@ TEST(reference_between_jwt_scopes_distinguishes_algorithms) {
       path, stub_fetcher({}, nullptr)};
   // Same issuer, audience, and key set but a different algorithm is a different
   // scope, so no token could satisfy the reference
-  EXPECT_FALSE(authentication.reference_permitted("/alpha/one", "/beta/two"));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
   // An identical policy is the same scope
-  EXPECT_TRUE(authentication.reference_permitted("/alpha/one", "/gamma/two"));
+  EXPECT_TRUE(
+      authentication.reference_permitted(at("/alpha/one"), at("/gamma/two")));
 }

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -1999,3 +1999,91 @@ TEST(reference_between_jwt_scopes_distinguishes_algorithms) {
   EXPECT_TRUE(
       authentication.reference_permitted(at("/alpha/one"), at("/gamma/two")));
 }
+
+// A configured policy path that only differs cosmetically still has to gate the
+// location it names. A spelling the matcher could not traverse would leave the
+// target public while the configuration reads as though it were gated
+
+TEST(a_policy_path_declared_canonically_gates_its_location) {
+  setenv("ONE_TEST_KEY_CANONICAL", "spelling-secret", 1);
+  const std::array<std::string_view, 1> paths{{"/private"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_CANONICAL"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{paths, keys}}};
+  const auto path{test_path("policy_declared_canonically.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  EXPECT_FALSE(
+      authentication.admits(at("/private/secret"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication
+                  .admits(at("/private/secret"), {.bearer = "spelling-secret"})
+                  .allowed);
+  // A location the policy does not name stays public
+  EXPECT_TRUE(
+      authentication.admits(at("/public/string"), {.bearer = ""}).allowed);
+}
+
+TEST(a_policy_path_carrying_a_dot_segment_gates_its_location) {
+  setenv("ONE_TEST_KEY_DOT", "spelling-secret", 1);
+  const std::array<std::string_view, 1> paths{{"/./private"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_DOT"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{paths, keys}}};
+  const auto path{test_path("policy_carrying_a_dot_segment.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  EXPECT_FALSE(
+      authentication.admits(at("/private/secret"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication
+                  .admits(at("/private/secret"), {.bearer = "spelling-secret"})
+                  .allowed);
+  // A location the policy does not name stays public
+  EXPECT_TRUE(
+      authentication.admits(at("/public/string"), {.bearer = ""}).allowed);
+}
+
+TEST(a_policy_path_that_climbs_back_into_itself_gates_its_location) {
+  setenv("ONE_TEST_KEY_CLIMB", "spelling-secret", 1);
+  const std::array<std::string_view, 1> paths{{"/private/../private"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_CLIMB"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{paths, keys}}};
+  const auto path{test_path("policy_that_climbs_back_into_itself.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  EXPECT_FALSE(
+      authentication.admits(at("/private/secret"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication
+                  .admits(at("/private/secret"), {.bearer = "spelling-secret"})
+                  .allowed);
+  // A location the policy does not name stays public
+  EXPECT_TRUE(
+      authentication.admits(at("/public/string"), {.bearer = ""}).allowed);
+}
+
+TEST(a_policy_path_carrying_a_repeated_separator_gates_its_location) {
+  setenv("ONE_TEST_KEY_SEPARATOR", "spelling-secret", 1);
+  const std::array<std::string_view, 1> paths{{"//private"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_SEPARATOR"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{paths, keys}}};
+  const auto path{test_path("policy_carrying_a_repeated_separator.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  EXPECT_FALSE(
+      authentication.admits(at("/private/secret"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication
+                  .admits(at("/private/secret"), {.bearer = "spelling-secret"})
+                  .allowed);
+  // A location the policy does not name stays public
+  EXPECT_TRUE(
+      authentication.admits(at("/public/string"), {.bearer = ""}).allowed);
+}

--- a/src/actions/action_schema_search_v1.h
+++ b/src/actions/action_schema_search_v1.h
@@ -182,7 +182,12 @@ public:
         query, limit, scope,
         [this, &credential, cookies](const std::string_view path) -> bool {
           const auto &authentication{this->dispatcher().authentication()};
-          return authentication.admits(path, credential, cookies).allowed;
+          const auto location{this->canonical_path(path)};
+          return location.has_value() &&
+                 authentication
+                     .admits(location.value(),
+                             {.bearer = credential, .cookies = cookies})
+                     .allowed;
         })};
     response.write_status(sourcemeta::core::HTTP_STATUS_OK);
     response.write_header("Access-Control-Allow-Origin", "*");
@@ -286,7 +291,10 @@ public:
         arguments.at("q").to_string(), limit, scope,
         [this, &credential](const std::string_view path) -> bool {
           const auto &authentication{this->dispatcher().authentication()};
-          return authentication.admits(path, credential).allowed;
+          const auto location{this->canonical_path(path)};
+          return location.has_value() &&
+                 authentication.admits(location.value(), {.bearer = credential})
+                     .allowed;
         })};
     auto envelope{sourcemeta::core::JSON::make_object()};
     envelope.assign_assume_new("results", std::move(results));

--- a/src/authentication/CMakeLists.txt
+++ b/src/authentication/CMakeLists.txt
@@ -2,6 +2,7 @@ if(ONE_ENTERPRISE)
   sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME authentication
     PRIVATE_HEADERS error.h session.h
     SOURCES
+      path.cc
       "${PROJECT_SOURCE_DIR}/enterprise/authentication/authentication.cc"
       "${PROJECT_SOURCE_DIR}/enterprise/authentication/authentication_save.cc"
       "${PROJECT_SOURCE_DIR}/enterprise/authentication/session.cc")
@@ -9,12 +10,16 @@ if(ONE_ENTERPRISE)
   target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::crypto)
   target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::http)
   target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::oidc)
-  target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::uri)
 else()
   sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME authentication
     PRIVATE_HEADERS error.h session.h
-    SOURCES authentication.cc session.cc)
+    SOURCES authentication.cc path.cc session.cc)
 endif()
+
+# Paths are the key the policy trie is built from and looked up by, so
+# canonicalising them belongs to this module in both editions
+target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::text)
+target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::uri)
 
 target_link_libraries(sourcemeta_one_authentication PUBLIC sourcemeta::core::io)
 target_link_libraries(sourcemeta_one_authentication PUBLIC sourcemeta::core::jose)

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -46,15 +46,20 @@ Authentication::Authentication(const std::filesystem::path &,
 
 Authentication::~Authentication() = default;
 
-auto Authentication::admits(const std::string_view, const std::string_view,
-                            const std::string_view,
-                            const std::string_view) const
+auto Authentication::admits(const Authentication::Path &,
+                            const Credentials &) const
     -> Authentication::Verdict {
   return {.allowed = true, .principal = std::nullopt};
 }
 
-auto Authentication::governing(const std::string_view,
-                               const std::string_view) const
+auto Authentication::admits_route(const std::string_view,
+                                  const std::string_view,
+                                  const Credentials &) const
+    -> Authentication::Verdict {
+  return {.allowed = true, .principal = std::nullopt};
+}
+
+auto Authentication::governing(const Authentication::Path &) const
     -> std::vector<std::size_t> {
   return {};
 }
@@ -75,8 +80,9 @@ auto Authentication::open(const std::string_view, const std::string_view) const
   return std::nullopt;
 }
 
-auto Authentication::reference_permitted(const std::string_view,
-                                         const std::string_view) const -> bool {
+auto Authentication::reference_permitted(const Authentication::Path &,
+                                         const Authentication::Path &) const
+    -> bool {
   return true;
 }
 

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -19,8 +19,9 @@
 #include <memory>      // std::unique_ptr
 #include <optional>    // std::optional
 #include <span>        // std::span
-#include <string>      // std::string, std::move
+#include <string>      // std::string
 #include <string_view> // std::string_view
+#include <utility>     // std::move
 #include <vector>      // std::vector
 
 namespace sourcemeta::one {

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -19,7 +19,7 @@
 #include <memory>      // std::unique_ptr
 #include <optional>    // std::optional
 #include <span>        // std::span
-#include <string>      // std::string
+#include <string>      // std::string, std::move
 #include <string_view> // std::string_view
 #include <vector>      // std::vector
 
@@ -36,6 +36,54 @@ struct Credentials {
 class SOURCEMETA_ONE_AUTHENTICATION_EXPORT Authentication {
 public:
   static constexpr std::size_t MAXIMUM_POLICIES{64};
+
+  /// Where a resource lives within an instance, in the single spelling every
+  /// part of the system agrees on: no base path, no leading or trailing
+  /// separator, no empty or relative segments, and lowercase throughout. The
+  /// instance root is the empty value.
+  ///
+  /// An extension is kept, because it names a representation of a resource
+  /// rather than a different resource, and a policy may gate one
+  /// representation on its own. The artifact tree stores a resource once, so
+  /// locating an artifact drops the extension while the gate keeps it.
+  ///
+  /// Policies, artifact locations, and directory listings are all keyed by
+  /// this, so the spelling has to be decided in exactly one place. That is
+  /// what this type is for: a value can only come from `parse`, which means a
+  /// caller cannot hand a path to one part of the system that another part
+  /// would read differently.
+  class SOURCEMETA_ONE_AUTHENTICATION_EXPORT Path {
+  public:
+    /// Canonicalise a request path or a URL against an instance, returning
+    /// nothing when the input names somewhere outside it
+    [[nodiscard]] static auto parse(const std::string_view input,
+                                    const std::string_view instance_url,
+                                    const std::string_view base_path)
+        -> std::optional<Path>;
+
+    /// Canonicalise input that is already relative to the instance root, such
+    /// as a configured policy path or a path the indexer composed. It carries
+    /// no base path to remove and names nowhere outside the instance, so
+    /// unlike `parse` it always yields a value
+    [[nodiscard]] static auto relative(const std::string_view input) -> Path;
+
+    [[nodiscard]] auto value() const noexcept -> std::string_view {
+      return this->value_;
+    }
+
+    [[nodiscard]] auto empty() const noexcept -> bool {
+      return this->value_.empty();
+    }
+
+    [[nodiscard]] auto operator==(const Path &other) const noexcept -> bool {
+      return this->value_ == other.value_;
+    }
+
+  private:
+    Path() = default;
+    explicit Path(std::string value) : value_{std::move(value)} {}
+    std::string value_;
+  };
 
   // How a presented credential is compared against a policy's stored keys.
   // Identity stores the key verbatim, every other algorithm stores it hashed
@@ -98,19 +146,25 @@ public:
   auto operator=(const Authentication &) -> Authentication & = delete;
   auto operator=(Authentication &&) -> Authentication & = delete;
 
-  // A non-empty base path is stripped off the input before matching, turning a
-  // request URL path into a registry path. The credential is a presented
-  // bearer value and the cookies are the raw request cookie header, either of
-  // which may admit the caller under a covering policy
-  [[nodiscard]] auto admits(std::string_view registry_path,
-                            std::string_view credential,
-                            std::string_view cookies = {},
-                            std::string_view base_path = {}) const -> Verdict;
+  // Whether what a request presented admits it to a path. The path arrives
+  // canonical, so every caller asks about the same location rather than about
+  // whichever spelling it happened to receive
+  [[nodiscard]] auto admits(const Path &path,
+                            const Credentials &credentials) const -> Verdict;
+
+  // Whether what a request presented admits it to an explicit route, which the
+  // router matched on the request target literally rather than on the location
+  // that target resolves to. The spelling is taken as matched, so a target
+  // reaching past a governed prefix is still governed by it, and a non-empty
+  // base path is removed first
+  [[nodiscard]] auto admits_route(std::string_view target,
+                                  std::string_view base_path,
+                                  const Credentials &credentials) const
+      -> Verdict;
 
   // The configuration declaration indices of the policies that govern a path,
   // sorted ascending
-  [[nodiscard]] auto governing(std::string_view registry_path,
-                               std::string_view base_path = {}) const
+  [[nodiscard]] auto governing(const Path &path) const
       -> std::vector<std::size_t>;
 
   // What an interactive policy declares about its provider client. The views
@@ -143,9 +197,8 @@ public:
   [[nodiscard]] auto open(std::string_view policy, std::string_view value) const
       -> std::optional<std::string>;
 
-  [[nodiscard]] auto reference_permitted(std::string_view referrer_path,
-                                         std::string_view referent_path) const
-      -> bool;
+  [[nodiscard]] auto reference_permitted(const Path &referrer,
+                                         const Path &referent) const -> bool;
 
 private:
   // The implementation differs by edition and owns the memory-mapped artifact,

--- a/src/authentication/path.cc
+++ b/src/authentication/path.cc
@@ -1,0 +1,163 @@
+#include <sourcemeta/one/authentication.h>
+
+#include <sourcemeta/core/text.h>
+#include <sourcemeta/core/uri.h>
+
+#include <cstddef>     // std::size_t
+#include <exception>   // std::exception
+#include <optional>    // std::optional, std::nullopt
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::move
+#include <vector>      // std::vector
+
+namespace {
+
+constexpr std::string_view HEX_DIGITS{"0123456789abcdefABCDEF"};
+
+// The table lists the lowercase digits before the uppercase ones, so an index
+// past the first sixteen names the same digit six positions along
+auto hex_nibble(const std::size_t index) -> std::size_t {
+  return index >= 16 ? index - 6 : index;
+}
+
+// RFC 3986 Section 6.2.2.2: only an escape that stands for an unreserved
+// character is equivalent to that character, so only those are decoded. A
+// reserved character keeps its escape, which is what the artifact tree stores
+// and what stops an escaped separator or dot segment from taking effect
+auto decode_unreserved(const std::string_view segment) -> std::string {
+  std::string result;
+  result.reserve(segment.size());
+  std::size_t cursor{0};
+  while (cursor < segment.size()) {
+    if (segment[cursor] != '%' || cursor + 2 >= segment.size() ||
+        HEX_DIGITS.find(segment[cursor + 1]) == std::string_view::npos ||
+        HEX_DIGITS.find(segment[cursor + 2]) == std::string_view::npos) {
+      result += segment[cursor];
+      cursor += 1;
+      continue;
+    }
+
+    const auto high{hex_nibble(HEX_DIGITS.find(segment[cursor + 1]))};
+    const auto low{hex_nibble(HEX_DIGITS.find(segment[cursor + 2]))};
+    const auto value{static_cast<char>((high * 16) + low)};
+    const auto unreserved{(value >= 'A' && value <= 'Z') ||
+                          (value >= 'a' && value <= 'z') ||
+                          (value >= '0' && value <= '9') || value == '-' ||
+                          value == '.' || value == '_' || value == '~'};
+    if (unreserved) {
+      result += value;
+    } else {
+      result.append(segment, cursor, 3);
+    }
+
+    cursor += 3;
+  }
+
+  return result;
+}
+
+// Reduce a path that is already relative to the instance to the one spelling
+// the rest of the system reads. The input is a request target rather than a
+// URL reference, so its separators are literal and a leading double separator
+// introduces an empty segment rather than an authority
+auto canonicalize(const std::string_view input) -> std::string {
+  std::vector<std::string> segments;
+  std::size_t cursor{0};
+  while (cursor <= input.size()) {
+    const auto next{input.find('/', cursor)};
+    const auto raw{next == std::string_view::npos
+                       ? input.substr(cursor)
+                       : input.substr(cursor, next - cursor)};
+    cursor = next == std::string_view::npos ? input.size() + 1 : next + 1;
+
+    auto segment{decode_unreserved(raw)};
+
+    // An empty segment carries no location and a single dot repeats the
+    // current one, while a double dot climbs, which at the root goes nowhere
+    if (segment.empty() || segment == ".") {
+      continue;
+    } else if (segment == "..") {
+      if (!segments.empty()) {
+        segments.pop_back();
+      }
+
+      continue;
+    }
+
+    segments.push_back(std::move(segment));
+  }
+
+  std::string result;
+  for (const auto &segment : segments) {
+    if (!result.empty()) {
+      result += '/';
+    }
+
+    result += segment;
+  }
+
+  sourcemeta::core::to_lowercase(result);
+  return result;
+}
+
+} // namespace
+
+namespace sourcemeta::one {
+
+auto Authentication::Path::relative(const std::string_view input) -> Path {
+  return Path{canonicalize(input)};
+}
+
+auto Authentication::Path::parse(const std::string_view input,
+                                 const std::string_view instance_url,
+                                 const std::string_view base_path)
+    -> std::optional<Authentication::Path> {
+  std::string_view target{input};
+
+  // A caller may name a resource by its URL rather than by a request target,
+  // and only a scheme tells the two apart, since a request target's
+  // separators are always literal
+  std::string reduced;
+  std::optional<sourcemeta::core::URI> parsed;
+  try {
+    parsed.emplace(input);
+  } catch (const std::exception &) {
+    return std::nullopt;
+  }
+
+  if (parsed->scheme().has_value()) {
+    try {
+      parsed->canonicalize();
+      parsed->relative_to(sourcemeta::core::URI{std::string{instance_url}});
+    } catch (const std::exception &) {
+      return std::nullopt;
+    }
+
+    // Still absolute after being made relative means another origin entirely
+    if (parsed->is_absolute()) {
+      return std::nullopt;
+    }
+
+    const auto path{parsed->path()};
+    reduced = path.has_value() ? std::string{path.value()} : std::string{};
+    target = reduced;
+  }
+
+  // A target addressed from the instance root only means something once the
+  // base path comes off, and one that does not carry that base path names
+  // somewhere outside this instance
+  if (target.starts_with('/')) {
+    const auto stripped{
+        sourcemeta::core::URI::strip_path_prefix(target, base_path)};
+    if (!stripped.has_value()) {
+      return std::nullopt;
+    }
+
+    return Path{canonicalize(stripped.value())};
+  }
+
+  return Path{canonicalize(target)};
+}
+
+} // namespace sourcemeta::one

--- a/src/authentication/path.cc
+++ b/src/authentication/path.cc
@@ -127,8 +127,11 @@ auto Authentication::Path::parse(const std::string_view input,
   }
 
   if (parsed->scheme().has_value()) {
+    std::string absolute;
     try {
       parsed->canonicalize();
+      const auto path{parsed->path()};
+      absolute = path.has_value() ? std::string{path.value()} : std::string{};
       parsed->relative_to(sourcemeta::core::URI{std::string{instance_url}});
     } catch (const std::exception &) {
       return std::nullopt;
@@ -139,8 +142,12 @@ auto Authentication::Path::parse(const std::string_view input,
       return std::nullopt;
     }
 
-    const auto path{parsed->path()};
-    reduced = path.has_value() ? std::string{path.value()} : std::string{};
+    // Reducing against the instance answers whether the origin matches, but
+    // not whether the URL sits under the base path, since a sibling of that
+    // base reduces to a relative path just as a child of it does. So the URL
+    // continues as the target it names, which the base path is then removed
+    // from exactly as it is for a request
+    reduced = absolute.empty() ? std::string{"/"} : std::move(absolute);
     target = reduced;
   }
 

--- a/src/index/explorer.h
+++ b/src/index/explorer.h
@@ -132,7 +132,10 @@ static auto make_policies(const sourcemeta::one::Authentication &authentication,
   // The policies that gate the path, in declaration order. An empty array means
   // the path is public
   auto result{sourcemeta::core::JSON::make_array()};
-  for (const auto index : authentication.governing(registry_path)) {
+  // The indexer composes these from the content tree, so they are already
+  // relative to the instance root
+  for (const auto index : authentication.governing(
+           sourcemeta::one::Authentication::Path::relative(registry_path))) {
     assert(index < configuration.authentication.size());
     const auto &entry{configuration.authentication[index]};
     auto policy{sourcemeta::core::JSON::make_object()};

--- a/src/index/generators.h
+++ b/src/index/generators.h
@@ -319,8 +319,10 @@ struct GENERATE_DEPENDENCIES {
       for (const auto &edge : result.as_array()) {
         const auto &referrer_uri{edge.at("from").to_string()};
         const auto &referent_uri{edge.at("to").to_string()};
-        const auto referrer{registry_path(referrer_uri, configuration.url)};
-        const auto referent{registry_path(referent_uri, configuration.url)};
+        const auto referrer{sourcemeta::one::Authentication::Path::parse(
+            referrer_uri, configuration.url, configuration.base_path)};
+        const auto referent{sourcemeta::one::Authentication::Path::parse(
+            referent_uri, configuration.url, configuration.base_path)};
         if (referrer.has_value() && referent.has_value() &&
             !authentication.reference_permitted(referrer.value(),
                                                 referent.value())) {
@@ -347,22 +349,6 @@ private:
     }
 
     return sourcemeta::core::JSON{uri};
-  }
-
-  static auto registry_path(const std::string_view uri,
-                            const std::string_view base)
-      -> std::optional<std::string_view> {
-    if (!uri.starts_with(base)) {
-      return std::nullopt;
-    }
-
-    const auto remainder{uri.substr(base.size())};
-    if (!base.ends_with('/') && !remainder.empty() &&
-        !remainder.starts_with('/')) {
-      return std::nullopt;
-    }
-
-    return remainder;
   }
 };
 

--- a/src/router/artifact.cc
+++ b/src/router/artifact.cc
@@ -28,49 +28,17 @@ struct DialectExtension {
 };
 #pragma pack(pop)
 
-auto uri_to_relative_path(const std::string_view uri,
-                          const std::string_view server_uri)
-    -> std::optional<std::filesystem::path> {
-  std::optional<sourcemeta::core::URI> parsed;
-  try {
-    parsed.emplace(uri);
-    parsed->canonicalize();
-  } catch (const std::exception &) {
-    return std::nullopt;
-  }
-
-  parsed->relative_to(sourcemeta::core::URI{server_uri});
-  if (parsed->is_absolute()) {
-    return std::nullopt;
-  }
-
-  const auto path_option{parsed->path()};
-  if (path_option.has_value() && path_option.value().starts_with("/")) {
-    return std::nullopt;
-  }
-
-  std::string_view normalized{path_option.has_value()
-                                  ? std::string_view{path_option.value()}
-                                  : std::string_view{}};
-  while (normalized.starts_with("../")) {
-    normalized.remove_prefix(3);
-  }
-  if (normalized == "..") {
-    normalized = std::string_view{};
-  }
-
-  const auto stripped{
-      sourcemeta::core::remove_suffix_ignore_case(normalized, ".json")};
-  std::filesystem::path result{stripped};
-  sourcemeta::core::to_lowercase(result);
-  return result;
-}
-
 } // namespace
 
 namespace sourcemeta::one {
 
-auto RouterAction::artifact_locate(const std::string_view input,
+auto RouterAction::canonical_path(const std::string_view input) const
+    -> std::optional<Authentication::Path> {
+  return Authentication::Path::parse(input, this->server_uri_,
+                                     this->server_uri_base_path_);
+}
+
+auto RouterAction::artifact_locate(const Authentication::Path &path,
                                    const Tree tree,
                                    const std::string_view artifact_name) const
     -> std::optional<std::filesystem::path> {
@@ -78,19 +46,11 @@ auto RouterAction::artifact_locate(const std::string_view input,
                                                             : "explorer"};
   const auto tree_root{this->index_directory_ / tree_segment};
   auto directory{tree_root};
-  if (!input.empty()) {
-    auto resolved{uri_to_relative_path(input, this->server_uri_)};
-    if (!resolved.has_value()) {
-      auto stripped{sourcemeta::core::URI::strip_path_prefix(
-          input, this->server_uri_base_path_)};
-      if (!stripped.has_value()) {
-        return std::nullopt;
-      }
-      resolved = std::filesystem::path{std::move(stripped).value()};
-    }
-    if (!resolved.value().empty()) {
-      directory /= std::move(resolved).value();
-    }
+  // The tree stores a resource once, whatever representation was asked for
+  const auto location{
+      sourcemeta::core::remove_suffix_ignore_case(path.value(), ".json")};
+  if (!location.empty()) {
+    directory /= std::filesystem::path{location};
   }
   directory /= "%";
   directory /= std::string{artifact_name} + ".metapack";
@@ -108,30 +68,22 @@ auto RouterAction::artifact_resolve_path(
     const Credentials credentials, const std::string_view input,
     const Tree tree, const std::string_view artifact_name) const
     -> ArtifactResolution {
-  // The gate consults the registry path, not the filesystem, and runs
-  // before the existence check so a denial reveals nothing about
-  // whether the artifact exists. The relative-path computation here
-  // mirrors the locator below, and the two converge once the gate is
-  // real
-  std::filesystem::path relative;
-  if (!input.empty()) {
-    auto resolved{uri_to_relative_path(input, this->server_uri_)};
-    if (!resolved.has_value()) {
-      auto stripped{sourcemeta::core::URI::strip_path_prefix(
-          input, this->server_uri_base_path_)};
-      if (stripped.has_value()) {
-        resolved = std::filesystem::path{std::move(stripped).value()};
-      }
-    }
-    if (resolved.has_value()) {
-      relative = std::move(resolved).value();
-    }
+  // The gate and the locator have to agree on where a request points, so both
+  // read the one canonical path rather than each deriving its own. A path that
+  // names nowhere in this instance is refused without consulting the gate,
+  // since there is nothing to be admitted to
+  const auto path{this->canonical_path(input)};
+  if (!path.has_value()) {
+    return {.outcome = ArtifactResolution::Outcome::NotFound,
+            .path = std::nullopt,
+            .is_public = false};
   }
 
+  // The gate consults the registry path, not the filesystem, and runs before
+  // the existence check so a denial reveals nothing about whether the artifact
+  // exists
   const auto &authentication{this->dispatcher_.authentication()};
-  const auto registry_path{relative.generic_string()};
-  const auto verdict{authentication.admits(registry_path, credentials.bearer,
-                                           credentials.cookies)};
+  const auto verdict{authentication.admits(path.value(), credentials)};
   // Nothing is served on a denial or a miss, so report the path as not public
   // and let any caller that skips the outcome check fall back to a private
   // caching directive rather than a public one
@@ -141,7 +93,7 @@ auto RouterAction::artifact_resolve_path(
             .is_public = false};
   }
 
-  auto located{this->artifact_locate(input, tree, artifact_name)};
+  auto located{this->artifact_locate(path.value(), tree, artifact_name)};
   if (!located.has_value()) {
     return {.outcome = ArtifactResolution::Outcome::NotFound,
             .path = std::nullopt,
@@ -154,7 +106,7 @@ auto RouterAction::artifact_resolve_path(
   // public for shared caches
   const auto is_public{
       (credentials.bearer.empty() && credentials.cookies.empty()) ||
-      authentication.admits(registry_path, {}).allowed};
+      authentication.admits(path.value(), {}).allowed};
   return {.outcome = ArtifactResolution::Outcome::Found,
           .path = ResolvedArtifact{std::move(located).value()},
           .is_public = is_public};
@@ -164,7 +116,12 @@ auto RouterAction::artifact_resolve_path_unauthenticated(
     const std::string_view input, const Tree tree,
     const std::string_view artifact_name) const
     -> std::optional<ResolvedArtifact> {
-  auto located{this->artifact_locate(input, tree, artifact_name)};
+  const auto path{this->canonical_path(input)};
+  if (!path.has_value()) {
+    return std::nullopt;
+  }
+
+  auto located{this->artifact_locate(path.value(), tree, artifact_name)};
   if (!located.has_value()) {
     return std::nullopt;
   }

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -169,6 +169,11 @@ public:
       const sourcemeta::core::JSON &instance,
       const sourcemeta::blaze::Callback &callback) const -> bool;
 
+  // Where a request points within this instance, in the one spelling the gate
+  // and the artifact tree both read, or nothing when it points outside
+  [[nodiscard]] auto canonical_path(std::string_view input) const
+      -> std::optional<Authentication::Path>;
+
 protected:
   // Resolution for trees that are not registry content, such as the
   // compile-time static asset bundle. Same containment discipline as
@@ -189,7 +194,8 @@ protected:
       -> std::optional<ResolvedArtifact>;
 
 private:
-  [[nodiscard]] auto artifact_locate(std::string_view input, Tree tree,
+  [[nodiscard]] auto artifact_locate(const Authentication::Path &path,
+                                     Tree tree,
                                      std::string_view artifact_name) const
       -> std::optional<std::filesystem::path>;
 

--- a/src/router/router.cc
+++ b/src/router/router.cc
@@ -122,11 +122,16 @@ auto Router::dispatch(
   // path. A CORS preflight is never gated, and neither is a route that must
   // stay reachable to establish authentication in the first place, which
   // vouches for itself instead
+  // An explicit route is matched on the request target literally, so the gate
+  // authorises that same spelling rather than the location it resolves to. A
+  // target reaching past a governed prefix is therefore still governed by it,
+  // while one that merely addresses content relative to its own route is not
   if (identifier != 0 && request.method() != "options" &&
       !instance->is_authentication_exempt() &&
       !this->authentication_
-           .admits(request.path(), credential, request.header("cookie"),
-                   instance->server_uri_base_path())
+           .admits_route(
+               request.path(), instance->server_uri_base_path(),
+               {.bearer = credential, .cookies = request.header("cookie")})
            .allowed) {
     if (instance->serve_login(request, response)) {
       return;

--- a/test/unit/authentication/CMakeLists.txt
+++ b/test/unit/authentication/CMakeLists.txt
@@ -1,5 +1,5 @@
 sourcemeta_test(NAMESPACE sourcemeta PROJECT one NAME authentication
-  SOURCES authentication_test.cc)
+  SOURCES authentication_test.cc authentication_path_test.cc)
 
 target_link_libraries(sourcemeta_one_authentication_unit
   PRIVATE sourcemeta::one::authentication)

--- a/test/unit/authentication/CMakeLists.txt
+++ b/test/unit/authentication/CMakeLists.txt
@@ -1,5 +1,5 @@
 sourcemeta_test(NAMESPACE sourcemeta PROJECT one NAME authentication
-  SOURCES authentication_test.cc authentication_path_test.cc)
+  SOURCES authentication_test.cc)
 
 target_link_libraries(sourcemeta_one_authentication_unit
   PRIVATE sourcemeta::one::authentication)

--- a/test/unit/authentication/authentication_path_test.cc
+++ b/test/unit/authentication/authentication_path_test.cc
@@ -1,0 +1,198 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/one/authentication.h>
+
+#include <optional>    // std::optional
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+static constexpr std::string_view INSTANCE{"http://localhost:8000"};
+static constexpr std::string_view BASED{"http://localhost:8000/registry"};
+
+static auto parse(const std::string_view input,
+                  const std::string_view instance = INSTANCE,
+                  const std::string_view base_path = "")
+    -> std::optional<sourcemeta::one::Authentication::Path> {
+  return sourcemeta::one::Authentication::Path::parse(input, instance,
+                                                      base_path);
+}
+
+// Returned by value: a view would dangle into the parsed path, which lives
+// only for this call
+static auto value(const std::string_view input,
+                  const std::string_view instance = INSTANCE,
+                  const std::string_view base_path = "") -> std::string {
+  const auto result{parse(input, instance, base_path)};
+  return result.has_value() ? std::string{result.value().value()}
+                            : std::string{"<none>"};
+}
+
+TEST(the_instance_root_is_the_empty_path) {
+  EXPECT_TRUE(parse("").has_value());
+  EXPECT_TRUE(parse("").value().empty());
+  EXPECT_EQ(value(""), "");
+  EXPECT_EQ(value("/"), "");
+}
+
+TEST(an_ordinary_path_keeps_its_segments) {
+  EXPECT_EQ(value("/private/secret"), "private/secret");
+  EXPECT_EQ(value("private/secret"), "private/secret");
+  EXPECT_EQ(value("/a/b/c/d"), "a/b/c/d");
+}
+
+TEST(an_extension_is_kept_because_it_names_a_representation) {
+  // A policy may gate one representation on its own, so the extension has to
+  // survive canonicalisation even though the artifact tree ignores it
+  EXPECT_EQ(value("/private/secret.json"), "private/secret.json");
+  EXPECT_EQ(value("/private/secret.JSON"), "private/secret.json");
+  EXPECT_EQ(value("/private/secret.yaml"), "private/secret.yaml");
+  EXPECT_EQ(value("/private/secret"), "private/secret");
+}
+
+TEST(spelling_is_lowercased) {
+  EXPECT_EQ(value("/PRIVATE/SECRET"), "private/secret");
+  EXPECT_EQ(value("/Private/Secret.json"), "private/secret.json");
+}
+
+TEST(empty_segments_collapse) {
+  EXPECT_EQ(value("//private/secret"), "private/secret");
+  EXPECT_EQ(value("/private//secret"), "private/secret");
+  EXPECT_EQ(value("///private///secret///"), "private/secret");
+  EXPECT_EQ(value("/private/secret/"), "private/secret");
+}
+
+TEST(relative_segments_are_resolved) {
+  EXPECT_EQ(value("/private/./secret"), "private/secret");
+  EXPECT_EQ(value("/./private/secret"), "private/secret");
+  EXPECT_EQ(value("/private/../private/secret"), "private/secret");
+  EXPECT_EQ(value("/public/../private/secret"), "private/secret");
+}
+
+TEST(climbing_above_the_instance_root_stays_at_the_root) {
+  EXPECT_EQ(value("/../private/secret"), "private/secret");
+  EXPECT_EQ(value("/../../private/secret"), "private/secret");
+  EXPECT_EQ(value(".."), "");
+}
+
+TEST(an_escaped_unreserved_character_is_decoded) {
+  EXPECT_EQ(value("/%70rivate/secret"), "private/secret");
+  EXPECT_EQ(value("/PRIVATE/%53ECRET"), "private/secret");
+  EXPECT_EQ(value("/public/%2e%2e/private/secret"), "private/secret");
+}
+
+TEST(an_escaped_reserved_character_keeps_its_escape) {
+  // Decoding these would either invent a separator or rename the location,
+  // and the artifact tree stores the escaped spelling
+  EXPECT_EQ(value("/test/schemas/%25/test.json"), "test/schemas/%25/test.json");
+  EXPECT_EQ(value("/private%2Fsecret"), "private%2fsecret");
+  EXPECT_EQ(value("/a/b%3Fc"), "a/b%3fc");
+}
+
+TEST(an_escaped_separator_never_becomes_a_separator) {
+  // Otherwise one location could be spelled as another
+  EXPECT_FALSE(parse("/private%2Fsecret").value() ==
+               parse("/private/secret").value());
+}
+
+TEST(every_spelling_of_one_location_agrees) {
+  const auto canonical{value("/private/secret")};
+  EXPECT_EQ(value("/public/../private/secret/"), canonical);
+  EXPECT_EQ(value("///private/./secret"), canonical);
+  EXPECT_EQ(value("//PRIVATE/secret"), canonical);
+  EXPECT_EQ(value("http://localhost:8000/private/secret"), canonical);
+
+  const auto representation{value("/private/secret.json")};
+  EXPECT_EQ(value("//PRIVATE/secret.json"), representation);
+  EXPECT_EQ(value("/./PRIVATE//secret.JSON"), representation);
+  EXPECT_EQ(value("http://localhost:8000/private/secret.json"), representation);
+}
+
+TEST(canonicalisation_is_idempotent) {
+  for (const std::string_view input :
+       {"/private/secret.json", "//PRIVATE//secret", "/./a/../b/c.JSON", "/",
+        "/a/b/"}) {
+    const auto once{parse(input)};
+    EXPECT_TRUE(once.has_value());
+    const auto twice{parse(once.value().value())};
+    EXPECT_TRUE(twice.has_value());
+    EXPECT_EQ(once.value().value(), twice.value().value());
+  }
+}
+
+TEST(a_url_on_this_instance_reduces_to_its_path) {
+  EXPECT_EQ(value("http://localhost:8000/private/secret"), "private/secret");
+  EXPECT_EQ(value("http://localhost:8000/"), "");
+  EXPECT_EQ(value("http://localhost:8000"), "");
+}
+
+TEST(a_url_on_another_origin_names_nowhere_here) {
+  EXPECT_FALSE(parse("http://evil.example.com/private/secret").has_value());
+  EXPECT_FALSE(parse("https://localhost:8000/private/secret").has_value());
+  EXPECT_FALSE(parse("http://localhost:9999/private/secret").has_value());
+}
+
+TEST(a_base_path_is_removed) {
+  EXPECT_EQ(value("/registry/private/secret", BASED, "/registry"),
+            "private/secret");
+  EXPECT_EQ(value("/registry/private/secret.json", BASED, "/registry"),
+            "private/secret.json");
+  EXPECT_EQ(value("/registry", BASED, "/registry"), "");
+  EXPECT_EQ(value("/registry/", BASED, "/registry"), "");
+}
+
+TEST(a_url_under_a_base_path_reduces_the_same_way) {
+  EXPECT_EQ(value("http://localhost:8000/registry/private/secret", BASED,
+                  "/registry"),
+            "private/secret");
+}
+
+TEST(a_path_outside_the_base_path_names_nowhere_here) {
+  EXPECT_FALSE(parse("/private/secret", BASED, "/registry").has_value());
+  EXPECT_FALSE(parse("/elsewhere/private", BASED, "/registry").has_value());
+}
+
+TEST(a_base_path_is_matched_on_whole_segments) {
+  EXPECT_FALSE(parse("/registrynot/private", BASED, "/registry").has_value());
+}
+
+TEST(hostile_spellings_never_escape_their_location) {
+  // Each of these was a gate bypass attempt, and every one has to reduce to
+  // the same governed location rather than to something a policy would miss
+  for (const std::string_view input :
+       {"//PRIVATE/secret", "/PRIVATE/secret", "//private/secret",
+        "///PRIVATE///SECRET", "/./PRIVATE/secret",
+        "/private/../PRIVATE/secret", "/%50RIVATE/secret",
+        "/public/../PRIVATE/secret"}) {
+    const auto result{parse(input)};
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().value(), "private/secret");
+  }
+}
+
+TEST(two_paths_compare_by_their_canonical_spelling) {
+  EXPECT_TRUE(parse("/private/secret").value() ==
+              parse("//PRIVATE/secret").value());
+  EXPECT_FALSE(parse("/private/secret").value() ==
+               parse("/private/other").value());
+}
+
+TEST(input_already_relative_to_the_root_is_canonicalised_as_is) {
+  // What the indexer composes carries no base path and names nowhere outside
+  // the instance, so it always yields a value
+  EXPECT_EQ(sourcemeta::one::Authentication::Path::relative("/private/secret")
+                .value(),
+            "private/secret");
+  EXPECT_EQ(
+      sourcemeta::one::Authentication::Path::relative("private/secret").value(),
+      "private/secret");
+  EXPECT_EQ(sourcemeta::one::Authentication::Path::relative("/").value(), "");
+  EXPECT_EQ(sourcemeta::one::Authentication::Path::relative("").value(), "");
+}
+
+TEST(a_relative_path_is_canonicalised_the_same_way_a_request_is) {
+  for (const std::string_view input :
+       {"/PRIVATE/secret", "//private//secret", "/private/./secret",
+        "/public/../private/secret"}) {
+    EXPECT_EQ(sourcemeta::one::Authentication::Path::relative(input).value(),
+              parse("/private/secret").value().value());
+  }
+}

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -7,6 +7,15 @@
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
+// Every gate question is asked about a canonical location, so the tests name
+// one the same way a request would
+static auto at(const std::string_view input)
+    -> sourcemeta::one::Authentication::Path {
+  return sourcemeta::one::Authentication::Path::parse(
+             input, "http://localhost:8000", "")
+      .value();
+}
+
 static auto test_path(const std::string &name) -> std::filesystem::path {
   return std::filesystem::path{AUTHENTICATION_TEST_DIRECTORY} / name;
 }
@@ -14,16 +23,19 @@ static auto test_path(const std::string &name) -> std::filesystem::path {
 TEST(admits_every_path_without_a_credential) {
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_TRUE(authentication.admits("/", "").allowed);
-  EXPECT_TRUE(authentication.admits("", "").allowed);
-  EXPECT_TRUE(authentication.admits("/acme/foo/bar", "").allowed);
+  EXPECT_TRUE(authentication.admits(at("/"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.admits(at(""), {.bearer = ""}).allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/acme/foo/bar"), {.bearer = ""}).allowed);
 }
 
 TEST(admits_every_path_with_any_credential) {
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_TRUE(authentication.admits("/internal", "anything").allowed);
-  EXPECT_TRUE(authentication.admits("/internal/foo", "another").allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/internal"), {.bearer = "anything"}).allowed);
+  EXPECT_TRUE(authentication.admits(at("/internal/foo"), {.bearer = "another"})
+                  .allowed);
 }
 
 TEST(save_emits_an_empty_artifact_that_admits_everything) {
@@ -37,15 +49,17 @@ TEST(save_emits_an_empty_artifact_that_admits_everything) {
   EXPECT_EQ(std::filesystem::file_size(path), 0);
 
   const sourcemeta::one::Authentication authentication{path, {}};
-  EXPECT_TRUE(authentication.admits("/", "").allowed);
-  EXPECT_TRUE(authentication.admits("/internal/foo", "").allowed);
+  EXPECT_TRUE(authentication.admits(at("/"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(
+      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
 }
 
 TEST(permits_every_reference) {
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_TRUE(authentication.reference_permitted("/one", "/two"));
+  EXPECT_TRUE(authentication.reference_permitted(at("/one"), at("/two")));
+  EXPECT_TRUE(authentication.reference_permitted(at("/public/one"),
+                                                 at("/private/two")));
   EXPECT_TRUE(
-      authentication.reference_permitted("/public/one", "/private/two"));
-  EXPECT_TRUE(authentication.reference_permitted("/internal/a", "/internal/a"));
+      authentication.reference_permitted(at("/internal/a"), at("/internal/a")));
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

