### PR TITLE
Bind sealed values to when they were minted and fetch discovery once

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -5,6 +5,7 @@
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth.h>
 #include <sourcemeta/core/oidc.h>
 
 #include "authentication_format.h"
@@ -757,7 +758,9 @@ struct Authentication::Impl {
       return std::nullopt;
     }
 
-    return Authentication::seal_value(payload, purpose, secrets.front(),
+    const auto issued{std::chrono::time_point_cast<std::chrono::seconds>(
+        std::chrono::system_clock::now())};
+    return Authentication::seal_value(payload, purpose, secrets.front(), issued,
                                       expiry);
   }
 
@@ -806,6 +809,87 @@ struct Authentication::Impl {
     }
 
     return this->session_open(decoded.session_secret_variable, purpose, value);
+  }
+
+  // The provider's description of itself is fetched once and refreshed on the
+  // freshness its own response advertises, rather than on every login. The
+  // caching resolver hands back a snapshot of what it last read, so the OpenID
+  // Connect layer is applied again only when that snapshot changes rather than
+  // once per request
+  [[nodiscard]] auto endpoints(const std::string_view policy) const
+      -> std::optional<Authentication::ProviderEndpoints> {
+    OIDCPolicyMetadata decoded;
+    if (!this->find_interactive(policy, decoded) || !this->fetcher_) {
+      return std::nullopt;
+    }
+
+    std::string issuer{decoded.issuer};
+    sourcemeta::core::OAuthMetadataProvider *provider{nullptr};
+    {
+      const std::scoped_lock lock{this->metadata_mutex_};
+      const auto existing{this->metadata_providers_.find(issuer)};
+      if (existing == this->metadata_providers_.cend()) {
+        // The two resolvers describe a retrieval with their own result type,
+        // so the one transport this instance was given is adapted rather than
+        // a second one being introduced
+        auto transport{
+            [fetcher = this->fetcher_](const std::string_view url)
+                -> std::optional<
+                    sourcemeta::core::OAuthMetadataProvider::FetchResult> {
+              auto result{fetcher(url)};
+              if (!result.has_value()) {
+                return std::nullopt;
+              }
+
+              const auto max_age{result.value().max_age};
+              return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+                  .body = std::move(result).value().body, .max_age = max_age};
+            }};
+        auto fresh{std::make_unique<sourcemeta::core::OAuthMetadataProvider>(
+            issuer,
+            sourcemeta::core::OAuthWellKnownKind::OpenIDConfigurationAppended,
+            std::move(transport))};
+        provider = fresh.get();
+        this->metadata_providers_.emplace(issuer, std::move(fresh));
+      } else {
+        provider = existing->second.get();
+      }
+    }
+
+    const auto server{provider->metadata()};
+    if (!server) {
+      return std::nullopt;
+    }
+
+    const std::scoped_lock lock{this->metadata_mutex_};
+    auto &cached{this->endpoints_[issuer]};
+    if (cached.source != server) {
+      auto document{sourcemeta::core::OIDCProviderMetadata::from(
+          sourcemeta::core::OAuthServerMetadata{*server})};
+      if (!document.has_value()) {
+        return std::nullopt;
+      }
+
+      Authentication::ProviderEndpoints resolved;
+      if (document.value().authorization_endpoint().has_value()) {
+        resolved.authorization =
+            document.value().authorization_endpoint().value();
+      }
+
+      if (document.value().token_endpoint().has_value()) {
+        resolved.token = document.value().token_endpoint().value();
+      }
+
+      resolved.jwks_uri = document.value().jwks_uri();
+      if (document.value().end_session_endpoint().has_value()) {
+        resolved.end_session = document.value().end_session_endpoint().value();
+      }
+
+      cached.source = server;
+      cached.resolved = std::move(resolved);
+    }
+
+    return cached.resolved;
   }
 
   [[nodiscard]] auto provider_for(const std::string_view issuer,
@@ -965,6 +1049,17 @@ struct Authentication::Impl {
   mutable std::map<std::pair<std::string, std::string>,
                    std::unique_ptr<sourcemeta::core::JWKSProvider>>
       jwks_providers_;
+
+  struct ResolvedEndpoints {
+    std::shared_ptr<const sourcemeta::core::OAuthServerMetadata> source;
+    Authentication::ProviderEndpoints resolved;
+  };
+
+  mutable std::mutex metadata_mutex_;
+  mutable std::map<std::string,
+                   std::unique_ptr<sourcemeta::core::OAuthMetadataProvider>>
+      metadata_providers_;
+  mutable std::map<std::string, ResolvedEndpoints> endpoints_;
 };
 
 Authentication::Authentication(const std::filesystem::path &path,
@@ -988,6 +1083,11 @@ auto Authentication::interactive(const std::string_view name) const
 auto Authentication::client_secret(const std::string_view policy) const
     -> std::optional<std::string> {
   return this->impl_->client_secret(policy);
+}
+
+auto Authentication::endpoints(const std::string_view policy) const
+    -> std::optional<Authentication::ProviderEndpoints> {
+  return this->impl_->endpoints(policy);
 }
 
 auto Authentication::seal(const std::string_view policy, const Purpose purpose,

--- a/enterprise/authentication/session.cc
+++ b/enterprise/authentication/session.cc
@@ -23,6 +23,17 @@ constexpr std::string_view SESSION_VERSION{"1"};
 
 constexpr std::size_t SESSION_SIGNATURE_LENGTH{32};
 
+// A sealed value carries the instant it was minted alongside the instant it
+// stops being honoured, so a lifetime is a fact about the value rather than
+// whatever its expiry happens to claim. Nothing this system mints lives
+// anywhere near this long, and refusing more bounds what a leaked secret is
+// worth: a forged value cannot outlive this no matter what expiry it names
+constexpr std::chrono::seconds MAXIMUM_LIFETIME{std::chrono::hours{24}};
+
+// Replicas seal and open each other's values, so a clock that reads slightly
+// ahead of the one opening must not produce values nobody accepts yet
+constexpr std::chrono::seconds CLOCK_SKEW{60};
+
 // The canonical unpadded encoding of a signature has exactly one length, so
 // anything else is rejected before it is even decoded
 constexpr std::size_t SESSION_SIGNATURE_ENCODED_LENGTH{
@@ -84,10 +95,14 @@ namespace sourcemeta::one {
 auto Authentication::seal_value(const std::string_view payload,
                                 const Purpose purpose,
                                 const std::string_view secret,
+                                const std::chrono::sys_seconds issued,
                                 const std::chrono::sys_seconds expiry)
     -> std::string {
   const auto key{derive_key(secret, purpose)};
   std::string result{SESSION_VERSION};
+  result += '.';
+  result += std::to_string(std::max(std::chrono::seconds::rep{0},
+                                    issued.time_since_epoch().count()));
   result += '.';
   // A pre-epoch expiry is clamped so that every sealed value is well-formed,
   // remaining expired from the moment it is produced
@@ -118,7 +133,12 @@ auto Authentication::open_value(const std::string_view value,
     return std::nullopt;
   }
 
-  const auto expiry_end{value.find('.', version_end + 1)};
+  const auto issued_end{value.find('.', version_end + 1)};
+  if (issued_end == std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  const auto expiry_end{value.find('.', issued_end + 1)};
   if (expiry_end == std::string_view::npos) {
     return std::nullopt;
   }
@@ -137,9 +157,27 @@ auto Authentication::open_value(const std::string_view value,
     return std::nullopt;
   }
 
-  const auto expiry{parse_expiry(
-      value.substr(version_end + 1, expiry_end - version_end - 1))};
+  const auto issued{parse_expiry(
+      value.substr(version_end + 1, issued_end - version_end - 1))};
+  if (!issued.has_value()) {
+    return std::nullopt;
+  }
+
+  const auto expiry{
+      parse_expiry(value.substr(issued_end + 1, expiry_end - issued_end - 1))};
   if (!expiry.has_value()) {
+    return std::nullopt;
+  }
+
+  // A value that claims to outlive anything this system mints was not minted
+  // by it, whatever signature it carries, and one that expires before it was
+  // issued names no interval at all. Bounding the interval is only worth
+  // anything alongside refusing one issued in the future, since a lifetime
+  // measured from an instant that has not arrived would otherwise start
+  // whenever its holder chose
+  if (expiry.value() < issued.value() ||
+      expiry.value() - issued.value() > MAXIMUM_LIFETIME ||
+      issued.value() > now + CLOCK_SKEW) {
     return std::nullopt;
   }
 

--- a/enterprise/e2e/auth-sso/playwright/callback.spec.js
+++ b/enterprise/e2e/auth-sso/playwright/callback.spec.js
@@ -17,9 +17,12 @@ const NONCE = 'e2e-forged-nonce-value-for-callback-tests-1';
 const VERIFIER = 'e2e-forged-verifier-value-for-callback-12';
 
 function sealTransaction(payload) {
-  const expiry = Math.floor(Date.now() / 1000) + 600;
+  // A sealed value carries the instant it was minted alongside its expiry, so
+  // that the interval it claims is one the instance would have produced
+  const issued = Math.floor(Date.now() / 1000);
+  const expiry = issued + 600;
   const encoded = Buffer.from(JSON.stringify(payload)).toString('base64url');
-  const prefix = `1.${expiry}.${encoded}`;
+  const prefix = `1.${issued}.${expiry}.${encoded}`;
   const key = createHmac('sha256', SESSION_SECRET)
     .update(TRANSACTION_LABEL)
     .digest();

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -146,9 +146,8 @@ public:
       return;
     }
 
-    const auto metadata{this->discover(policy->issuer)};
-    if (!metadata.has_value() ||
-        !metadata.value().token_endpoint().has_value()) {
+    const auto endpoints{authentication.endpoints(policy_name)};
+    if (!endpoints.has_value() || endpoints.value().token.empty()) {
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
                  "urn:sourcemeta:one:auth-provider-unreachable",
                  "The identity provider could not be reached", policy_name);
@@ -160,8 +159,8 @@ public:
     redirect_uri += policy_name;
 
     const auto id_token{this->exchange(
-        metadata.value().token_endpoint().value(), policy->client_id,
-        client_secret.value(), redirect_uri, code, verifier->to_string())};
+        endpoints.value().token, policy->client_id, client_secret.value(),
+        redirect_uri, code, verifier->to_string())};
     if (!id_token.has_value()) {
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
                  "urn:sourcemeta:one:auth-exchange-failed",
@@ -177,8 +176,7 @@ public:
       return;
     }
 
-    auto provider{
-        this->jwks_provider(std::string{metadata.value().jwks_uri()})};
+    auto provider{this->jwks_provider(endpoints.value().jwks_uri)};
     sourcemeta::core::OIDCValidationOptions options;
     options.nonce = nonce->to_string();
     const auto identity{sourcemeta::core::oidc_validate_id_token(
@@ -354,36 +352,6 @@ private:
          .same_site = sourcemeta::core::HTTPCookieSameSite::Lax})};
     if (cookie.has_value()) {
       response.write_header("Set-Cookie", cookie.value());
-    }
-  }
-
-  [[nodiscard]] auto discover(const std::string_view issuer) const
-      -> std::optional<sourcemeta::core::OIDCProviderMetadata> {
-    try {
-      const auto url{sourcemeta::core::oidc_discovery_url(issuer)};
-      if (!url.has_value()) {
-        return std::nullopt;
-      }
-
-      sourcemeta::core::HTTPSystemRequest fetch{url.value()};
-      fetch.connect_timeout(std::chrono::seconds{2});
-      fetch.timeout(std::chrono::seconds{5});
-      fetch.maximum_response_size(1024UL * 1024UL);
-      fetch.follow_redirects(false);
-      const auto result{fetch.send()};
-      if (result.status.code < 200 || result.status.code >= 300) {
-        return std::nullopt;
-      }
-
-      auto parsed{sourcemeta::core::try_parse_json(result.body)};
-      if (!parsed.has_value()) {
-        return std::nullopt;
-      }
-
-      return sourcemeta::core::OIDCProviderMetadata::from(
-          std::move(parsed).value(), issuer);
-    } catch (...) {
-      return std::nullopt;
     }
   }
 

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
@@ -111,9 +111,8 @@ public:
       return;
     }
 
-    const auto authorization_endpoint{
-        this->discover_authorization_endpoint(policy->issuer)};
-    if (!authorization_endpoint.has_value()) {
+    const auto endpoints{authentication.endpoints(policy_name)};
+    if (!endpoints.has_value() || endpoints.value().authorization.empty()) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
           "urn:sourcemeta:one:auth-provider-unreachable",
@@ -191,7 +190,7 @@ public:
 
     const auto challenge{sourcemeta::core::oauth_pkce_challenge(verifier)};
     const auto url{sourcemeta::core::oidc_authorization_url(
-        authorization_endpoint.value(), policy->client_id, redirect_uri, state,
+        endpoints.value().authorization, policy->client_id, redirect_uri, state,
         std::string_view{challenge.data(), challenge.size()}, nonce)};
     if (!url.has_value()) {
       sourcemeta::one::json_error(
@@ -246,43 +245,6 @@ public:
   }
 
 private:
-  [[nodiscard]] auto
-  discover_authorization_endpoint(const std::string_view issuer) const
-      -> std::optional<std::string> {
-    try {
-      const auto url{sourcemeta::core::oidc_discovery_url(issuer)};
-      if (!url.has_value()) {
-        return std::nullopt;
-      }
-
-      sourcemeta::core::HTTPSystemRequest fetch{url.value()};
-      fetch.connect_timeout(std::chrono::seconds{2});
-      fetch.timeout(std::chrono::seconds{5});
-      fetch.maximum_response_size(1024UL * 1024UL);
-      fetch.follow_redirects(false);
-      const auto result{fetch.send()};
-      if (result.status.code < 200 || result.status.code >= 300) {
-        return std::nullopt;
-      }
-
-      auto parsed{sourcemeta::core::try_parse_json(result.body)};
-      if (!parsed.has_value()) {
-        return std::nullopt;
-      }
-
-      const auto document{sourcemeta::core::OIDCProviderMetadata::from(
-          std::move(parsed).value(), issuer)};
-      if (!document.has_value() ||
-          !document.value().authorization_endpoint().has_value()) {
-        return std::nullopt;
-      }
-
-      return std::string{document.value().authorization_endpoint().value()};
-    } catch (...) {
-      return std::nullopt;
-    }
-  }
-
   std::string_view error_schema_;
 };
 

--- a/enterprise/unit/authentication/authentication_session_test.cc
+++ b/enterprise/unit/authentication/authentication_session_test.cc
@@ -19,7 +19,7 @@ static constexpr auto PURPOSE{
 
 TEST(session_round_trips_a_payload) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", LATER)};
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
   const auto payload{sourcemeta::one::Authentication::open_value(value, PURPOSE,
                                                                  SECRETS, NOW)};
   EXPECT_TRUE(payload.has_value());
@@ -28,7 +28,7 @@ TEST(session_round_trips_a_payload) {
 
 TEST(session_round_trips_an_empty_payload) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "", PURPOSE, "session-secret", LATER)};
+      "", PURPOSE, "session-secret", NOW, LATER)};
   const auto payload{sourcemeta::one::Authentication::open_value(value, PURPOSE,
                                                                  SECRETS, NOW)};
   EXPECT_TRUE(payload.has_value());
@@ -37,7 +37,8 @@ TEST(session_round_trips_an_empty_payload) {
 
 TEST(session_round_trips_a_payload_containing_separators) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "left.right.{\"claims\":[1,2]}\n", PURPOSE, "session-secret", LATER)};
+      "left.right.{\"claims\":[1,2]}\n", PURPOSE, "session-secret", NOW,
+      LATER)};
   const auto payload{sourcemeta::one::Authentication::open_value(value, PURPOSE,
                                                                  SECRETS, NOW)};
   EXPECT_TRUE(payload.has_value());
@@ -46,7 +47,8 @@ TEST(session_round_trips_a_payload_containing_separators) {
 
 TEST(session_value_is_cookie_safe) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "payload with spaces; and = signs", PURPOSE, "session-secret", LATER)};
+      "payload with spaces; and = signs", PURPOSE, "session-secret", NOW,
+      LATER)};
   for (const auto character : value) {
     const auto safe{(character >= 'a' && character <= 'z') ||
                     (character >= 'A' && character <= 'Z') ||
@@ -58,7 +60,7 @@ TEST(session_value_is_cookie_safe) {
 
 TEST(session_denies_at_and_after_the_expiry_instant) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", LATER)};
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
   EXPECT_TRUE(
       sourcemeta::one::Authentication::open_value(value, PURPOSE, SECRETS, NOW)
           .has_value());
@@ -73,7 +75,7 @@ TEST(session_denies_at_and_after_the_expiry_instant) {
 
 TEST(session_denies_a_wrong_secret) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "other-secret", LATER)};
+      "the-payload", PURPOSE, "other-secret", NOW, LATER)};
   EXPECT_FALSE(
       sourcemeta::one::Authentication::open_value(value, PURPOSE, SECRETS, NOW)
           .has_value());
@@ -81,7 +83,7 @@ TEST(session_denies_a_wrong_secret) {
 
 TEST(session_denies_with_no_secrets) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", LATER)};
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
   const std::array<std::string_view, 0> no_secrets{};
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(value, PURPOSE,
                                                            no_secrets, NOW)
@@ -90,7 +92,7 @@ TEST(session_denies_with_no_secrets) {
 
 TEST(session_admits_a_value_sealed_under_an_older_secret) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "old-secret", LATER)};
+      "the-payload", PURPOSE, "old-secret", NOW, LATER)};
   const std::array<std::string_view, 2> rotated{{"new-secret", "old-secret"}};
   const auto payload{sourcemeta::one::Authentication::open_value(value, PURPOSE,
                                                                  rotated, NOW)};
@@ -104,7 +106,7 @@ TEST(session_admits_a_value_sealed_under_an_older_secret) {
 
 TEST(session_denies_a_tampered_payload) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", LATER)};
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
   auto tampered{value};
   const auto payload_start{tampered.find('.', tampered.find('.') + 1) + 1};
   tampered[payload_start] = tampered[payload_start] == 'A' ? 'B' : 'A';
@@ -115,7 +117,7 @@ TEST(session_denies_a_tampered_payload) {
 
 TEST(session_denies_a_tampered_expiry) {
   const auto expired{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW)};
+      "the-payload", PURPOSE, "session-secret", NOW, NOW)};
   // Extending the lifetime of an expired value must break its signature
   const auto expiry_start{expired.find('.') + 1};
   auto tampered{expired};
@@ -127,7 +129,7 @@ TEST(session_denies_a_tampered_expiry) {
 
 TEST(session_denies_a_tampered_version) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", LATER)};
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
   auto tampered{value};
   tampered[0] = '2';
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(tampered, PURPOSE,
@@ -137,9 +139,9 @@ TEST(session_denies_a_tampered_version) {
 
 TEST(session_denies_a_transplanted_signature) {
   const auto first{sourcemeta::one::Authentication::seal_value(
-      "first-payload", PURPOSE, "session-secret", LATER)};
+      "first-payload", PURPOSE, "session-secret", NOW, LATER)};
   const auto second{sourcemeta::one::Authentication::seal_value(
-      "second-payload", PURPOSE, "session-secret", LATER)};
+      "second-payload", PURPOSE, "session-secret", NOW, LATER)};
   const auto first_body{first.substr(0, first.rfind('.'))};
   const auto second_signature{second.substr(second.rfind('.') + 1)};
   const auto spliced{first_body + "." + second_signature};
@@ -150,7 +152,7 @@ TEST(session_denies_a_transplanted_signature) {
 
 TEST(session_denies_a_truncated_signature) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", LATER)};
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
   const auto truncated{value.substr(0, value.size() - 2)};
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(truncated, PURPOSE,
                                                            SECRETS, NOW)
@@ -159,7 +161,7 @@ TEST(session_denies_a_truncated_signature) {
 
 TEST(session_denies_a_lengthened_signature) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", LATER)};
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
   const auto lengthened{value + "AA"};
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(lengthened, PURPOSE,
                                                            SECRETS, NOW)
@@ -169,7 +171,7 @@ TEST(session_denies_a_lengthened_signature) {
 TEST(session_denies_a_value_sealed_with_a_pre_epoch_expiry) {
   const std::chrono::sys_seconds before_epoch{std::chrono::seconds{-1}};
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", before_epoch)};
+      "the-payload", PURPOSE, "session-secret", NOW, before_epoch)};
   EXPECT_FALSE(
       sourcemeta::one::Authentication::open_value(value, PURPOSE, SECRETS, NOW)
           .has_value());
@@ -180,7 +182,7 @@ TEST(session_denies_a_value_sealed_with_a_pre_epoch_expiry) {
 
 TEST(session_denies_everything_under_a_pre_epoch_clock) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", LATER)};
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
   const std::chrono::sys_seconds before_epoch{std::chrono::seconds{-1}};
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
                    value, PURPOSE, SECRETS, before_epoch)
@@ -210,7 +212,7 @@ TEST(session_denies_malformed_values) {
 
 TEST(session_denies_a_malformed_expiry) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", LATER)};
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
   const auto expiry_start{value.find('.') + 1};
   const auto expiry_end{value.find('.', expiry_start)};
 
@@ -242,12 +244,69 @@ TEST(session_denies_a_malformed_expiry) {
 
 TEST(session_denies_a_signature_that_is_not_base64url) {
   const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", LATER)};
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
   const auto body{value.substr(0, value.rfind('.'))};
   const auto invalid{body + ".!!!not-base64url!!!"};
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(invalid, PURPOSE,
                                                            SECRETS, NOW)
                    .has_value());
+}
+
+TEST(session_denies_a_lifetime_longer_than_any_this_system_mints) {
+  // Only the expiry used to be sealed, so a value could name any expiry it
+  // liked and be honoured until it. Sealing the instant of minting alongside
+  // it makes the lifetime a fact about the value, and one this long was not
+  // minted here whatever signature it carries
+  const auto sealed{sourcemeta::one::Authentication::seal_value(
+      "the-payload", PURPOSE, "session-secret", NOW,
+      NOW + std::chrono::hours{25})};
+  EXPECT_FALSE(
+      sourcemeta::one::Authentication::open_value(sealed, PURPOSE, SECRETS, NOW)
+          .has_value());
+}
+
+TEST(session_admits_a_lifetime_at_the_bound) {
+  const auto sealed{sourcemeta::one::Authentication::seal_value(
+      "the-payload", PURPOSE, "session-secret", NOW,
+      NOW + std::chrono::hours{24})};
+  const auto opened{sourcemeta::one::Authentication::open_value(sealed, PURPOSE,
+                                                                SECRETS, NOW)};
+  EXPECT_TRUE(opened.has_value());
+  EXPECT_EQ(opened.value(), "the-payload");
+}
+
+TEST(session_denies_a_value_issued_in_the_future) {
+  // A bounded lifetime measured from an instant that has not arrived would
+  // start whenever its holder chose, so the bound only means anything
+  // alongside this
+  const auto ahead{NOW + std::chrono::hours{12}};
+  const auto sealed{sourcemeta::one::Authentication::seal_value(
+      "the-payload", PURPOSE, "session-secret", ahead,
+      ahead + std::chrono::hours{1})};
+  EXPECT_FALSE(
+      sourcemeta::one::Authentication::open_value(sealed, PURPOSE, SECRETS, NOW)
+          .has_value());
+}
+
+TEST(session_admits_a_value_issued_within_the_clock_skew) {
+  // Replicas seal for one another, so one reading slightly ahead must not mint
+  // values the rest refuse
+  const auto ahead{NOW + std::chrono::seconds{30}};
+  const auto sealed{sourcemeta::one::Authentication::seal_value(
+      "the-payload", PURPOSE, "session-secret", ahead,
+      ahead + std::chrono::hours{1})};
+  EXPECT_TRUE(
+      sourcemeta::one::Authentication::open_value(sealed, PURPOSE, SECRETS, NOW)
+          .has_value());
+}
+
+TEST(session_denies_an_expiry_before_the_instant_it_was_issued) {
+  const auto sealed{sourcemeta::one::Authentication::seal_value(
+      "the-payload", PURPOSE, "session-secret", NOW,
+      NOW - std::chrono::seconds{1})};
+  EXPECT_FALSE(
+      sourcemeta::one::Authentication::open_value(sealed, PURPOSE, SECRETS, NOW)
+          .has_value());
 }
 
 TEST(session_denies_a_value_sealed_for_another_purpose) {
@@ -257,7 +316,7 @@ TEST(session_denies_a_value_sealed_for_another_purpose) {
   // inspects what the payload claims to be
   const auto transaction{sourcemeta::one::Authentication::seal_value(
       "the-payload", sourcemeta::one::Authentication::Purpose::Transaction,
-      "session-secret", LATER)};
+      "session-secret", NOW, LATER)};
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
                    transaction,
                    sourcemeta::one::Authentication::Purpose::Session, SECRETS,
@@ -268,7 +327,7 @@ TEST(session_denies_a_value_sealed_for_another_purpose) {
 TEST(transaction_denies_a_value_sealed_as_a_session) {
   const auto session{sourcemeta::one::Authentication::seal_value(
       "the-payload", sourcemeta::one::Authentication::Purpose::Session,
-      "session-secret", LATER)};
+      "session-secret", NOW, LATER)};
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
                    session,
                    sourcemeta::one::Authentication::Purpose::Transaction,
@@ -280,7 +339,7 @@ TEST(each_purpose_opens_the_value_it_sealed) {
   const auto transaction{sourcemeta::one::Authentication::seal_value(
       "transaction-payload",
       sourcemeta::one::Authentication::Purpose::Transaction, "session-secret",
-      LATER)};
+      NOW, LATER)};
   const auto opened{sourcemeta::one::Authentication::open_value(
       transaction, sourcemeta::one::Authentication::Purpose::Transaction,
       SECRETS, NOW)};
@@ -291,9 +350,9 @@ TEST(each_purpose_opens_the_value_it_sealed) {
 TEST(the_two_purposes_seal_one_payload_differently) {
   const auto session{sourcemeta::one::Authentication::seal_value(
       "the-payload", sourcemeta::one::Authentication::Purpose::Session,
-      "session-secret", LATER)};
+      "session-secret", NOW, LATER)};
   const auto transaction{sourcemeta::one::Authentication::seal_value(
       "the-payload", sourcemeta::one::Authentication::Purpose::Transaction,
-      "session-secret", LATER)};
+      "session-secret", NOW, LATER)};
   EXPECT_FALSE(session == transaction);
 }

--- a/enterprise/unit/authentication/authentication_session_test.cc
+++ b/enterprise/unit/authentication/authentication_session_test.cc
@@ -2,8 +2,9 @@
 
 #include <sourcemeta/core/test.h>
 
-#include <array>       // std::array
-#include <chrono>      // std::chrono::sys_seconds, std::chrono::seconds
+#include <array> // std::array
+#include <chrono>
+#include <cstddef>     // std::chrono::sys_seconds, std::chrono::seconds
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -16,6 +17,28 @@ static const std::array<std::string_view, 1> SECRETS{{"session-secret"}};
 // value is for, so they name one purpose throughout
 static constexpr auto PURPOSE{
     sourcemeta::one::Authentication::Purpose::Session};
+
+// A sealed value is version.issued.expiry.payload.signature. Every field is
+// covered by the signature, so a test that disturbs the wrong one still passes
+// and quietly stops testing what it names. These say which field they mean
+enum class Field : std::size_t {
+  Version = 0,
+  Issued = 1,
+  Expiry = 2,
+  Payload = 3,
+  Signature = 4
+};
+
+static auto field_start(const std::string_view value, const Field field)
+    -> std::size_t {
+  std::size_t position{0};
+  for (std::size_t index{0}; index < static_cast<std::size_t>(field);
+       index += 1) {
+    position = value.find('.', position) + 1;
+  }
+
+  return position;
+}
 
 TEST(session_round_trips_a_payload) {
   const auto value{sourcemeta::one::Authentication::seal_value(
@@ -104,11 +127,24 @@ TEST(session_admits_a_value_sealed_under_an_older_secret) {
           .has_value());
 }
 
+TEST(session_value_has_the_shape_the_tests_below_assume) {
+  // Several tests locate a field by index, so a change to the grammar would
+  // silently move what they disturb while leaving them green. This pins the
+  // whole shape against known inputs, so such a change fails here first and
+  // names what moved
+  const auto value{sourcemeta::one::Authentication::seal_value(
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
+  constexpr std::string_view prefix{"1.1000000.1000060.dGhlLXBheWxvYWQ."};
+  EXPECT_TRUE(value.starts_with(prefix));
+  // The signature is the unpadded encoding of a fixed-width digest
+  EXPECT_EQ(value.size(), prefix.size() + 43);
+}
+
 TEST(session_denies_a_tampered_payload) {
   const auto value{sourcemeta::one::Authentication::seal_value(
       "the-payload", PURPOSE, "session-secret", NOW, LATER)};
   auto tampered{value};
-  const auto payload_start{tampered.find('.', tampered.find('.') + 1) + 1};
+  const auto payload_start{field_start(tampered, Field::Payload)};
   tampered[payload_start] = tampered[payload_start] == 'A' ? 'B' : 'A';
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(tampered, PURPOSE,
                                                            SECRETS, NOW)
@@ -119,7 +155,7 @@ TEST(session_denies_a_tampered_expiry) {
   const auto expired{sourcemeta::one::Authentication::seal_value(
       "the-payload", PURPOSE, "session-secret", NOW, NOW)};
   // Extending the lifetime of an expired value must break its signature
-  const auto expiry_start{expired.find('.') + 1};
+  const auto expiry_start{field_start(expired, Field::Expiry)};
   auto tampered{expired};
   tampered.insert(expiry_start, "9");
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(tampered, PURPOSE,
@@ -202,18 +238,53 @@ TEST(session_denies_malformed_values) {
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
                    "no-dots-at-all", PURPOSE, SECRETS, NOW)
                    .has_value());
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value("1.123.AA", PURPOSE,
+  // Too few fields to be a sealed value
+  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
+                   "1.123.456.AA", PURPOSE, SECRETS, NOW)
+                   .has_value());
+  // One field too many, which lands in the signature, where a separator says
+  // the value was not produced by sealing anything
+  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
+                   "1.123.456.AA.BB.CC", PURPOSE, SECRETS, NOW)
+                   .has_value());
+}
+
+TEST(session_denies_a_tampered_issuance) {
+  const auto value{sourcemeta::one::Authentication::seal_value(
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
+  // Moving the instant of minting backwards would stretch the lifetime a value
+  // is allowed to claim, so the signature has to cover it like everything else
+  const auto issued_start{field_start(value, Field::Issued)};
+  auto tampered{value};
+  tampered.insert(issued_start, "9");
+  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(tampered, PURPOSE,
                                                            SECRETS, NOW)
                    .has_value());
+}
+
+TEST(session_denies_a_malformed_issuance) {
+  const auto value{sourcemeta::one::Authentication::seal_value(
+      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
+  const auto issued_start{field_start(value, Field::Issued)};
+  const auto issued_end{value.find('.', issued_start)};
+
+  auto empty_issued{value};
+  empty_issued.erase(issued_start, issued_end - issued_start);
   EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   "1.123.AA.BB.CC", PURPOSE, SECRETS, NOW)
+                   empty_issued, PURPOSE, SECRETS, NOW)
+                   .has_value());
+
+  auto negative_issued{value};
+  negative_issued.replace(issued_start, issued_end - issued_start, "-1");
+  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
+                   negative_issued, PURPOSE, SECRETS, NOW)
                    .has_value());
 }
 
 TEST(session_denies_a_malformed_expiry) {
   const auto value{sourcemeta::one::Authentication::seal_value(
       "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  const auto expiry_start{value.find('.') + 1};
+  const auto expiry_start{field_start(value, Field::Expiry)};
   const auto expiry_end{value.find('.', expiry_start)};
 
   auto empty_expiry{value};

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -65,9 +65,19 @@ static constexpr std::string_view SIGNED_KEYS{
 static constexpr std::string_view UNRELATED_KEYS{
     R"JSON({ "keys": [ { "kty": "RSA", "n": "ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddxHmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMsD1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSHSXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdVMTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ", "e": "AQAB" } ] })JSON"};
 
-// A session expiry far enough in the future to outlive any test run
-static constexpr std::chrono::sys_seconds SESSION_EXPIRY{
-    std::chrono::seconds{2000000000}};
+// A sealed value carries the instant it was minted, and is only honoured for
+// a bounded interval after it, so these are read from the clock rather than
+// named as constants
+static auto minted_now() -> std::chrono::sys_seconds {
+  return std::chrono::time_point_cast<std::chrono::seconds>(
+      std::chrono::system_clock::now());
+}
+
+// An expiry far enough ahead to outlive any test run, and near enough to the
+// instant of minting for the value to be one this system would produce
+static auto session_expiry() -> std::chrono::sys_seconds {
+  return minted_now() + std::chrono::hours{1};
+}
 
 // An interactive policy names the environment variable holding the secret
 // that signs its session and transaction cookies, so the tests set that
@@ -1193,7 +1203,7 @@ TEST(oidc_policy_admits_its_session_cookie) {
   const auto sealed{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta", "subject": "jane@acme.test" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
   const std::string cookies{"theme=dark; sourcemeta_one_session_okta=" +
                             sealed};
 
@@ -1240,7 +1250,7 @@ TEST(session_cookie_is_bound_to_the_policy_it_was_minted_for) {
   const auto sealed{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
 
   // The session opens the path its policy governs
   const std::string okta_cookies{"sourcemeta_one_session_okta=" + sealed};
@@ -1280,10 +1290,11 @@ TEST(expired_session_cookie_is_denied) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
 
-  const std::chrono::sys_seconds past{std::chrono::seconds{1000}};
+  const auto past{minted_now() - std::chrono::hours{2}};
   const auto sealed{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET, past)};
+      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET, past,
+      past + std::chrono::hours{1})};
   const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
   EXPECT_FALSE(
       authentication.admits(at("/portal/x"), {.bearer = "", .cookies = cookies})
@@ -1311,7 +1322,7 @@ TEST(forged_session_cookie_is_denied) {
   const auto foreign{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, "other-secret",
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
   const std::string foreign_cookies{"sourcemeta_one_session_okta=" + foreign};
   EXPECT_FALSE(
       authentication
@@ -1322,7 +1333,7 @@ TEST(forged_session_cookie_is_denied) {
   auto tampered{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
   tampered.back() = tampered.back() == 'A' ? 'B' : 'A';
   const std::string tampered_cookies{"sourcemeta_one_session_okta=" + tampered};
   EXPECT_FALSE(
@@ -1361,7 +1372,7 @@ TEST(session_payload_must_declare_its_policy) {
   for (const auto payload : payloads) {
     const auto sealed{sourcemeta::one::Authentication::seal_value(
         payload, sourcemeta::one::Authentication::Purpose::Session,
-        SESSION_SECRET, SESSION_EXPIRY)};
+        SESSION_SECRET, minted_now(), session_expiry())};
     const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
     EXPECT_FALSE(
         authentication
@@ -1389,7 +1400,7 @@ TEST(session_is_admitted_when_a_shadowing_cookie_precedes_it) {
   const auto sealed{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
 
   // A parent domain can set a cookie the host also sets, and the header says
   // nothing about which is which, so the genuine one is honoured wherever it
@@ -1421,7 +1432,7 @@ TEST(session_is_admitted_when_a_shadowing_cookie_follows_it) {
   const auto sealed{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
 
   // Taking the last match would deny here, which is the shape that lets a
   // neighbouring host lock somebody out of an instance it does not control
@@ -1461,11 +1472,11 @@ TEST(a_session_for_another_policy_does_not_end_the_search) {
   const auto other{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "google" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
   const auto mine{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
 
   // The first value opens but was minted elsewhere, so stopping there would
   // deny a caller who did present a session for this policy
@@ -1527,7 +1538,7 @@ TEST(session_cookie_without_a_configured_secret_is_denied) {
   const auto sealed{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
   const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
   EXPECT_FALSE(
       authentication.admits(at("/portal/x"), {.bearer = "", .cookies = cookies})
@@ -1557,7 +1568,7 @@ TEST(session_admitted_under_a_rotated_secret) {
   const auto old_sealed{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, "old-secret",
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
   EXPECT_TRUE(
       authentication
           .admits(at("/portal/x"),
@@ -1569,9 +1580,10 @@ TEST(session_admitted_under_a_rotated_secret) {
   // verifies under a new-only secret set and not under an old-only one
   const auto minted{authentication.seal(
       "okta", sourcemeta::one::Authentication::Purpose::Session,
-      R"JSON({ "policy": "okta" })JSON", SESSION_EXPIRY)};
+      R"JSON({ "policy": "okta" })JSON", session_expiry())};
   EXPECT_TRUE(minted.has_value());
-  const std::chrono::sys_seconds now{std::chrono::seconds{1000000}};
+  // The value was minted from the clock, so it is read against the same one
+  const auto now{minted_now()};
   const std::array<std::string_view, 1> new_only{{"new-secret"}};
   EXPECT_TRUE(sourcemeta::one::Authentication::open_value(
                   minted.value(),
@@ -1589,7 +1601,7 @@ TEST(session_admitted_under_a_rotated_secret) {
   const auto retired{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, "retired-secret",
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
   EXPECT_FALSE(
       authentication
           .admits(at("/portal/x"),
@@ -1618,7 +1630,8 @@ TEST(session_with_a_blank_configured_secret_is_denied) {
   // A blank secret would let anyone forge sessions, so it never verifies one
   const auto forged{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, "", SESSION_EXPIRY)};
+      sourcemeta::one::Authentication::Purpose::Session, "", minted_now(),
+      session_expiry())};
   const std::string cookies{"sourcemeta_one_session_okta=" + forged};
   EXPECT_FALSE(
       authentication.admits(at("/portal/x"), {.bearer = "", .cookies = cookies})
@@ -1692,7 +1705,7 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_key_or_session) {
   const auto sealed{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
   const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
   const auto session_verdict{
       authentication.admits(at("/both/x"), {.bearer = "", .cookies = cookies})};
@@ -1721,7 +1734,7 @@ TEST(session_cookie_does_not_open_an_apikey_path) {
   const auto sealed{sourcemeta::one::Authentication::seal_value(
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      SESSION_EXPIRY)};
+      minted_now(), session_expiry())};
   const std::string cookies{"sourcemeta_one_session_okta=" + sealed};
   EXPECT_FALSE(
       authentication
@@ -1914,7 +1927,7 @@ TEST(seal_and_open_round_trip_under_the_policy_secret) {
       path, stub_fetcher({}, nullptr)};
   const auto sealed{authentication.seal(
       "okta", sourcemeta::one::Authentication::Purpose::Session, "the-payload",
-      SESSION_EXPIRY)};
+      session_expiry())};
   EXPECT_TRUE(sealed.has_value());
   const auto payload{authentication.open(
       "okta", sourcemeta::one::Authentication::Purpose::Session,
@@ -1934,7 +1947,7 @@ TEST(seal_and_open_round_trip_under_the_policy_secret) {
   EXPECT_FALSE(authentication
                    .seal("github",
                          sourcemeta::one::Authentication::Purpose::Session,
-                         "the-payload", SESSION_EXPIRY)
+                         "the-payload", session_expiry())
                    .has_value());
   EXPECT_FALSE(authentication
                    .open("github",
@@ -1962,7 +1975,7 @@ TEST(seal_without_a_configured_secret_produces_nothing) {
   EXPECT_FALSE(authentication
                    .seal("okta",
                          sourcemeta::one::Authentication::Purpose::Session,
-                         "the-payload", SESSION_EXPIRY)
+                         "the-payload", session_expiry())
                    .has_value());
   EXPECT_FALSE(authentication
                    .open("okta",

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -1792,6 +1792,72 @@ TEST(interactive_returns_the_policy_by_name) {
   EXPECT_FALSE(authentication.client_secret("").has_value());
 }
 
+TEST(provider_endpoints_are_retrieved_once_and_reused) {
+  const auto calls{std::make_shared<int>(0)};
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://login.test",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_CACHE",
+        .name = "okta",
+        .session_secret_variable = SESSION_SECRET_VARIABLE}}};
+  const auto path{test_path("oidc_endpoints_cached.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const std::map<std::string, std::string> responses{
+      {"https://login.test/.well-known/openid-configuration",
+       R"JSON({
+         "issuer": "https://login.test",
+         "authorization_endpoint": "https://login.test/authorize",
+         "token_endpoint": "https://login.test/token",
+         "jwks_uri": "https://login.test/jwks",
+         "end_session_endpoint": "https://login.test/logout",
+         "response_types_supported": [ "code" ],
+         "subject_types_supported": [ "public" ],
+         "id_token_signing_alg_values_supported": [ "RS256" ]
+       })JSON"}};
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher(responses, calls)};
+
+  const auto first{authentication.endpoints("okta")};
+  EXPECT_TRUE(first.has_value());
+  EXPECT_EQ(first.value().authorization, "https://login.test/authorize");
+  EXPECT_EQ(first.value().token, "https://login.test/token");
+  EXPECT_EQ(first.value().jwks_uri, "https://login.test/jwks");
+  EXPECT_EQ(first.value().end_session, "https://login.test/logout");
+  EXPECT_EQ(*calls, 1);
+
+  // Asking again does not ask the provider again. A login is an
+  // unauthenticated endpoint, so fetching per request would let anybody drive
+  // outbound traffic one for one
+  const auto second{authentication.endpoints("okta")};
+  EXPECT_TRUE(second.has_value());
+  EXPECT_EQ(second.value().token, "https://login.test/token");
+  EXPECT_EQ(*calls, 1);
+}
+
+TEST(provider_endpoints_of_an_unreachable_provider_are_absent) {
+  const auto calls{std::make_shared<int>(0)};
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://login.test",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_UNREACHABLE",
+        .name = "okta",
+        .session_secret_variable = SESSION_SECRET_VARIABLE}}};
+  const auto path{test_path("oidc_endpoints_unreachable.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const sourcemeta::one::Authentication authentication{path,
+                                                       stub_fetcher({}, calls)};
+  EXPECT_FALSE(authentication.endpoints("okta").has_value());
+  EXPECT_FALSE(authentication.endpoints("github").has_value());
+}
+
 TEST(client_secret_of_an_unset_variable_is_absent) {
   unsetenv("ONE_TEST_OIDC_SECRET_UNSET");
   const std::array<std::string_view, 1> paths{{"/alpha"}};

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -68,6 +68,11 @@ auto Authentication::client_secret(const std::string_view) const
   return std::nullopt;
 }
 
+auto Authentication::endpoints(const std::string_view) const
+    -> std::optional<Authentication::ProviderEndpoints> {
+  return std::nullopt;
+}
+
 auto Authentication::seal(const std::string_view, const Purpose,
                           const std::string_view,
                           const std::chrono::sys_seconds) const
@@ -91,6 +96,7 @@ auto Authentication::reference_permitted(const Authentication::Path &,
 // feature, so this edition never produces a sealed value and never accepts one
 auto Authentication::seal_value(const std::string_view, const Purpose,
                                 const std::string_view,
+                                const std::chrono::sys_seconds,
                                 const std::chrono::sys_seconds) -> std::string {
   return {};
 }

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -200,6 +200,24 @@ public:
   [[nodiscard]] auto interactive(std::string_view name) const
       -> std::optional<InteractivePolicy>;
 
+  // Where a provider says its endpoints are. The values are copies, so they
+  // stay usable across a refresh of what the provider last said
+  struct ProviderEndpoints {
+    std::string authorization{};
+    std::string token{};
+    std::string jwks_uri{};
+    // Absent from a provider that does not offer to end its own session
+    std::string end_session{};
+  };
+
+  // What the named interactive policy's provider says about itself, retrieved
+  // once and refreshed on the freshness its own response advertises rather
+  // than on every request. Nothing is returned when the policy is unknown,
+  // the provider cannot be reached, or what it returned is not a description
+  // this instance can act on
+  [[nodiscard]] auto endpoints(std::string_view policy) const
+      -> std::optional<ProviderEndpoints>;
+
   // The client secret the named interactive policy authenticates to its
   // provider with, if the policy is known and its secret is configured in the
   // environment. Every secret this system holds is read here rather than by
@@ -232,9 +250,9 @@ public:
   // purpose, producing a value that is safe to transport as a cookie. Only a
   // holder of the secret can produce or alter such a value, though anyone can
   // read its contents
-  [[nodiscard]] static auto seal_value(std::string_view payload,
-                                       Purpose purpose, std::string_view secret,
-                                       std::chrono::sys_seconds expiry)
+  [[nodiscard]] static auto
+  seal_value(std::string_view payload, Purpose purpose, std::string_view secret,
+             std::chrono::sys_seconds issued, std::chrono::sys_seconds expiry)
       -> std::string;
 
   // Recover the payload of a sealed value, returning nothing for a value that


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

