### PR TITLE
Cover the login callback's refusals and report only a named one

### DIFF
--- a/enterprise/e2e/auth-sso/hurl/decline.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/decline.all.hurl
@@ -1,0 +1,395 @@
+# The provider answers a login by sending the browser back here, either with an
+# authorization code or with a refusal. That makes this the one URL a stranger
+# can aim somebody else's browser at, so nothing the provider is said to have
+# answered is acted on until the callback has proven it belongs to a login this
+# instance started. The sealed transaction names the state the provider will
+# echo, and only a request echoing it gets past, which is what RFC 6749 Section
+# 4.1.2.1 asks of a client. A refusal is held to the same proof as a code,
+# because otherwise a page belonging to somebody else could make a person's
+# login fail on their behalf.
+
+# A login mints the transaction and names the state, which is everything the
+# callback is checked against
+GET {{base}}/self/v1/auth/login/keycloak
+HTTP 303
+Cache-Control: no-store
+[Captures]
+transaction: cookie "sourcemeta_one_transaction"
+state: header "Location" regex "[?&]state=([A-Za-z0-9_-]+)"
+[Asserts]
+cookie "sourcemeta_one_transaction" exists
+cookie "sourcemeta_one_transaction[HttpOnly]" exists
+cookie "sourcemeta_one_transaction[SameSite]" == "Lax"
+cookie "sourcemeta_one_transaction[Max-Age]" == 600
+
+# A code presented against a state the transaction does not name gets no
+# further than the gate, and the refusal describes nothing about what was wrong
+GET {{base}}/self/v1/auth/callback/keycloak?code=a-code-nobody-issued&state=a-state-nobody-minted
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 400
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+refused_body: body
+error_schema: header "Link" regex "<([^>]+)>"
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+header "ETag" not exists
+{
+  "type": "urn:sourcemeta:one:auth-invalid-callback",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The login could not be completed"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{refused_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# The very same request against the state the transaction does name reaches the
+# provider, which refuses the invented code. Nothing but the state differs
+# between this and the one before it, so the state is the whole of what stands
+# between a stranger's callback and a token exchange
+GET {{base}}/self/v1/auth/callback/keycloak?code=a-code-nobody-issued&state={{state}}
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 502
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+exchange_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+{
+  "type": "urn:sourcemeta:one:auth-exchange-failed",
+  "title": "Bad Gateway",
+  "status": 502,
+  "detail": "The authorization code could not be redeemed"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{exchange_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# A refusal carried by a proven callback is honoured, and answered as the
+# provider's decision rather than as a denial of a resource, so somebody who
+# declined at the provider is told what happened
+GET {{base}}/self/v1/auth/callback/keycloak?error=access_denied&state={{state}}
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 403
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+declined_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+header "ETag" not exists
+{
+  "type": "urn:sourcemeta:one:auth-login-declined",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "The identity provider declined the login"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{declined_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# The same refusal against a state the transaction does not name is not
+# honoured, and is refused exactly as an unproven code is, so a page belonging
+# to somebody else cannot end a login in progress
+GET {{base}}/self/v1/auth/callback/keycloak?error=access_denied&state=a-state-nobody-minted
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 400
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+unproven_decline_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+body == {{refused_body}}
+{
+  "type": "urn:sourcemeta:one:auth-invalid-callback",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The login could not be completed"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{unproven_decline_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# An answer claiming a code and a refusal at once contradicts itself, and the
+# refusal decides, so nothing is exchanged on the strength of a code the same
+# answer says was not granted
+GET {{base}}/self/v1/auth/callback/keycloak?code=a-code-nobody-issued&error=access_denied&state={{state}}
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 403
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+contradictory_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+body == {{declined_body}}
+{
+  "type": "urn:sourcemeta:one:auth-login-declined",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "The identity provider declined the login"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{contradictory_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# A refusal names itself with an error code, so one naming nothing is not a
+# decision to report as the provider's. It is no grant either, and a code
+# arriving beside it is left unredeemed rather than read as the answer
+GET {{base}}/self/v1/auth/callback/keycloak?code=a-code-nobody-issued&error=&state={{state}}
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 400
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+nameless_refusal_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+body == {{refused_body}}
+{
+  "type": "urn:sourcemeta:one:auth-invalid-callback",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The login could not be completed"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{nameless_refusal_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# A proven callback carrying neither a code nor a refusal is malformed, and is
+# answered in the terms an unproven one is, so a stranger learns the same
+# either way
+GET {{base}}/self/v1/auth/callback/keycloak?state={{state}}
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 400
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+neither_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+body == {{refused_body}}
+{
+  "type": "urn:sourcemeta:one:auth-invalid-callback",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The login could not be completed"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{neither_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# An empty state names nothing, including the transaction the browser is
+# carrying, rather than reading as the absence of a requirement
+GET {{base}}/self/v1/auth/callback/keycloak?error=access_denied&state=
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 400
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+empty_state_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+body == {{refused_body}}
+{
+  "type": "urn:sourcemeta:one:auth-invalid-callback",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The login could not be completed"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{empty_state_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# The state is compared as the provider would echo it rather than loosely, so a
+# value that merely starts with the one the transaction names is not it
+GET {{base}}/self/v1/auth/callback/keycloak?error=access_denied&state={{state}}%20
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 400
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+extended_state_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+body == {{refused_body}}
+{
+  "type": "urn:sourcemeta:one:auth-invalid-callback",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The login could not be completed"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{extended_state_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# A transaction is sealed under the policy that minted it, so another policy's
+# callback opens nothing from it, even carrying the state it does name. Which
+# policy a callback belongs to is therefore not something the caller chooses by
+# aiming at a different URL
+GET {{base}}/self/v1/auth/callback/cleartext?error=access_denied&state={{state}}
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 400
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+foreign_policy_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+body == {{refused_body}}
+{
+  "type": "urn:sourcemeta:one:auth-invalid-callback",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The login could not be completed"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{foreign_policy_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# Every refusal above left the transaction where it was, which is what lets it
+# still be honoured here after all of them. Clearing it on a refusal would hand
+# anybody who can aim a browser at this URL a way to cancel a login in progress
+GET {{base}}/self/v1/auth/callback/keycloak?error=access_denied&state={{state}}
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 403
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+surviving_body: body
+[Asserts]
+header "Set-Cookie" not exists
+body == {{declined_body}}
+{
+  "type": "urn:sourcemeta:one:auth-login-declined",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "The identity provider declined the login"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{surviving_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true

--- a/enterprise/e2e/auth-sso/playwright/callback.spec.js
+++ b/enterprise/e2e/auth-sso/playwright/callback.spec.js
@@ -16,6 +16,8 @@ const STATE = 'e2e-forged-state-value-for-callback-tests-1';
 const NONCE = 'e2e-forged-nonce-value-for-callback-tests-1';
 const VERIFIER = 'e2e-forged-verifier-value-for-callback-12';
 
+const CALLBACK = /\/self\/v1\/auth\/callback\//;
+
 function sealTransaction(payload) {
   // A sealed value carries the instant it was minted alongside its expiry, so
   // that the interval it claims is one the instance would have produced
@@ -30,6 +32,29 @@ function sealTransaction(payload) {
   return `${prefix}.${signature}`;
 }
 
+// A sealed value is signed rather than encrypted, so whoever holds one can
+// read what it carries. That is what lets these tests reproduce a real login's
+// transaction and alter one field of it.
+function openSealed(value) {
+  return JSON.parse(Buffer.from(value.split('.')[3], 'base64url').toString());
+}
+
+// The whole of a `Set-Cookie` a response carries under a given name,
+// attributes and all, so that what a browser would store can be measured
+// rather than only what it would send back.
+async function setCookieFrom(response, name) {
+  const header = (await response.headersArray())
+    .filter((entry) => entry.name.toLowerCase() === 'set-cookie')
+    .map((entry) => entry.value)
+    .find((value) => value.startsWith(`${name}=`));
+  expect(header).toBeDefined();
+  return header;
+}
+
+function valueOf(setCookie) {
+  return setCookie.slice(setCookie.indexOf('=') + 1).split(';')[0];
+}
+
 async function callback(request, transaction) {
   return request.get(
     `/self/v1/auth/callback/keycloak?code=a-code-nobody-issued&state=${STATE}`,
@@ -39,6 +64,38 @@ async function callback(request, transaction) {
       }
     }
   );
+}
+
+// Signs in for real, having first replaced the transaction the login minted
+// with one differing from it in whatever the caller alters. The authorization
+// request has already gone to the provider by then, so the provider answers
+// the login that was actually started while this instance reads the altered
+// account of it. That is what puts a genuine, unspent code in front of a
+// transaction that does not match it.
+async function signInAlteringTheTransaction(page, context, alteration) {
+  await page.goto('/self/v1/auth/login/keycloak');
+  const carried = (await context.cookies()).find(
+    (cookie) => cookie.name === 'sourcemeta_one_transaction'
+  );
+  expect(carried).toBeDefined();
+
+  const sealed = sealTransaction({
+    ...openSealed(carried.value),
+    ...alteration
+  });
+  await context.addCookies([
+    {
+      name: 'sourcemeta_one_transaction',
+      value: sealed,
+      url: process.env.PLAYWRIGHT_BASE_URL
+    }
+  ]);
+
+  await page.locator('#username').fill('jane');
+  await page.locator('#password').fill('jane-password');
+  const answer = page.waitForResponse(CALLBACK);
+  await page.locator('#kc-login').click();
+  return { response: await answer, sealed };
 }
 
 test.describe('Callback transaction validation', () => {
@@ -91,6 +148,257 @@ test.describe('Callback transaction validation', () => {
     });
     expect(response.status()).toBe(400);
     expect(await response.json()).toEqual({
+      type: 'urn:sourcemeta:one:auth-invalid-callback',
+      title: 'Bad Request',
+      status: 400,
+      detail: 'The login could not be completed'
+    });
+  });
+
+  test('a signed transaction naming no state at all matches nothing', async ({
+    request
+  }) => {
+    // An empty state is not a state a provider could echo, so it is refused
+    // rather than read as there being nothing to compare
+    const response = await request.get(
+      '/self/v1/auth/callback/keycloak?code=a-code-nobody-issued&state=',
+      {
+        headers: {
+          Cookie: `sourcemeta_one_transaction=${sealTransaction({
+            policy: 'keycloak',
+            state: '',
+            nonce: NONCE,
+            verifier: VERIFIER
+          })}`
+        }
+      }
+    );
+    expect(response.status()).toBe(400);
+    expect(await response.json()).toEqual({
+      type: 'urn:sourcemeta:one:auth-invalid-callback',
+      title: 'Bad Request',
+      status: 400,
+      detail: 'The login could not be completed'
+    });
+  });
+
+  test('a transaction is found among several the browser carries', async ({
+    request
+  }) => {
+    // A browser can carry several cookies under one name, because a parent
+    // domain and the host itself can each set one and neither the header nor
+    // the order says which is which. Letting whoever set the other one decide
+    // which login this is turns the cookie from a defence against a forged
+    // callback into the way to mount one, so every value is tried.
+    const other = sealTransaction({
+      policy: 'keycloak',
+      state: 'a-state-belonging-to-some-other-login-1',
+      nonce: NONCE,
+      verifier: VERIFIER
+    });
+    const mine = sealTransaction({
+      policy: 'keycloak',
+      state: STATE,
+      nonce: NONCE,
+      verifier: VERIFIER
+    });
+    const declined = {
+      type: 'urn:sourcemeta:one:auth-login-declined',
+      title: 'Forbidden',
+      status: 403,
+      detail: 'The identity provider declined the login'
+    };
+
+    const behind = await request.get(
+      `/self/v1/auth/callback/keycloak?error=access_denied&state=${STATE}`,
+      {
+        headers: {
+          Cookie: `sourcemeta_one_transaction=${other}; sourcemeta_one_transaction=${mine}`
+        }
+      }
+    );
+    expect(behind.status()).toBe(403);
+    expect(await behind.json()).toEqual(declined);
+
+    // Mirrored, so neither position is the one that decides
+    const ahead = await request.get(
+      `/self/v1/auth/callback/keycloak?error=access_denied&state=${STATE}`,
+      {
+        headers: {
+          Cookie: `sourcemeta_one_transaction=${mine}; sourcemeta_one_transaction=${other}`
+        }
+      }
+    );
+    expect(ahead.status()).toBe(403);
+    expect(await ahead.json()).toEqual(declined);
+  });
+});
+
+// Everything above forges a transaction against a code no provider issued, so
+// nothing there reaches an identity token. These sign in for real, altering
+// one field of the transaction after the authorization request has gone out,
+// so the provider answers the login that was started while this instance reads
+// an account of it that differs in exactly that field.
+test.describe('Callback identity validation against a real login', () => {
+  test('a faithfully reproduced transaction completes the login', async ({
+    page,
+    context
+  }) => {
+    const { response, sealed } = await signInAlteringTheTransaction(
+      page,
+      context,
+      {}
+    );
+
+    // The control the two below are read against: re-sealing the transaction
+    // unchanged still signs the person in, so when an altered one fails, it
+    // fails on what was altered rather than on having been re-sealed
+    expect(response.status()).toBe(303);
+    expect(response.headers()['location']).toBe('/private');
+
+    const session = await setCookieFrom(response, 'sourcemeta_one_session');
+
+    // RFC 6265 Section 6.1 asks a user agent to support at least 4096 bytes
+    // per cookie, counting its name, value and attributes. A browser that
+    // drops a larger one says nothing about having done so, which would look
+    // like signing in and then not being signed in, so the whole of it is kept
+    // inside what every browser will store
+    expect(session.length).toBeLessThan(4000);
+
+    // And it carries the identity token, which is what lets signing out prove
+    // whose session the provider is being asked to end
+    const payload = openSealed(valueOf(session));
+    expect(payload.policy).toBe('keycloak');
+    expect(payload.subject).toBeTruthy();
+    expect(payload.id_token).toBeTruthy();
+
+    // The code that session was built from is spent, so the very same answer
+    // buys nothing a second time. The transaction is put back first, since the
+    // callback expired it, so what is being refused here is the code alone
+    await context.addCookies([
+      {
+        name: 'sourcemeta_one_transaction',
+        value: sealed,
+        url: process.env.PLAYWRIGHT_BASE_URL
+      }
+    ]);
+    const again = await page.request.get(response.url(), { maxRedirects: 0 });
+    expect(again.status()).toBe(502);
+    expect(await again.json()).toEqual({
+      type: 'urn:sourcemeta:one:auth-exchange-failed',
+      title: 'Bad Gateway',
+      status: 502,
+      detail: 'The authorization code could not be redeemed'
+    });
+  });
+
+  test('an identity token echoing a nonce other than the one asked for is refused', async ({
+    page,
+    context
+  }) => {
+    // The provider echoes the nonce the authorization request named, so
+    // expecting a different one back is what a token minted for some other
+    // login looks like. Nothing else here is altered: the code is genuine and
+    // unspent, and the exchange for it succeeds before the token is read
+    const { response } = await signInAlteringTheTransaction(page, context, {
+      nonce: 'a-nonce-the-provider-was-never-asked-to-echo'
+    });
+
+    expect(response.status()).toBe(502);
+    expect(await response.json()).toEqual({
+      type: 'urn:sourcemeta:one:auth-invalid-identity',
+      title: 'Bad Gateway',
+      status: 502,
+      detail: 'The identity token could not be validated'
+    });
+    expect(response.headers()['set-cookie']).toBeUndefined();
+  });
+
+  test('a code redeemed with a verifier other than the one that earned it is refused', async ({
+    page,
+    context
+  }) => {
+    // The authorization request committed to the real verifier by its digest,
+    // so the code is worth nothing without it. That is what keeps a code that
+    // leaks through a log or a referrer from being spent by whoever reads it
+    const { response } = await signInAlteringTheTransaction(page, context, {
+      verifier: 'a-verifier-no-authorization-request-committed'
+    });
+
+    expect(response.status()).toBe(502);
+    expect(await response.json()).toEqual({
+      type: 'urn:sourcemeta:one:auth-exchange-failed',
+      title: 'Bad Gateway',
+      status: 502,
+      detail: 'The authorization code could not be redeemed'
+    });
+    expect(response.headers()['set-cookie']).toBeUndefined();
+  });
+});
+
+// A transaction and a session are both values this instance seals for one
+// policy, and the cookie name that tells them apart travels outside the
+// signature where whoever presents it chooses the name. Anybody can obtain a
+// transaction, since starting a login asks for nothing, which is what once
+// made presenting one as a session an unauthenticated way into every gated
+// path. These carry a real value of each kind across to the other's name, in a
+// request holding nothing else, so what is refused is the value rather than
+// the absence of one.
+test.describe('Neither sealed value passes for the other', () => {
+  test('a transaction under the session name opens nothing a session opens', async ({
+    page,
+    context,
+    request
+  }) => {
+    const login = await context.request.get('/self/v1/auth/login/keycloak', {
+      maxRedirects: 0
+    });
+    expect(login.status()).toBe(303);
+    const transaction = valueOf(
+      await setCookieFrom(login, 'sourcemeta_one_transaction')
+    );
+
+    const { response } = await signInAlteringTheTransaction(page, context, {});
+    const session = valueOf(
+      await setCookieFrom(response, 'sourcemeta_one_session')
+    );
+
+    // A real session opens the gated schema, which is what makes the refusal
+    // below mean the transaction was read and rejected rather than that
+    // nothing was read at all
+    const opened = await request.get('/private/secret.json', {
+      headers: { Cookie: `sourcemeta_one_session=${session}` }
+    });
+    expect(opened.status()).toBe(200);
+
+    const denied = await request.get('/private/secret.json', {
+      headers: { Cookie: `sourcemeta_one_session=${transaction}` }
+    });
+    expect(denied.status()).toBe(401);
+    expect(await denied.json()).toEqual({
+      type: 'urn:sourcemeta:one:authentication-required',
+      title: 'Unauthorized',
+      status: 401,
+      detail: 'This resource requires authentication'
+    });
+  });
+
+  test('a session under the transaction name proves no login was started', async ({
+    page,
+    context,
+    request
+  }) => {
+    const { response } = await signInAlteringTheTransaction(page, context, {});
+    const session = valueOf(
+      await setCookieFrom(response, 'sourcemeta_one_session')
+    );
+
+    const refused = await request.get(
+      `/self/v1/auth/callback/keycloak?code=a-code-nobody-issued&state=${STATE}`,
+      { headers: { Cookie: `sourcemeta_one_transaction=${session}` } }
+    );
+    expect(refused.status()).toBe(400);
+    expect(await refused.json()).toEqual({
       type: 'urn:sourcemeta:one:auth-invalid-callback',
       title: 'Bad Request',
       status: 400,

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -112,7 +112,7 @@ public:
     if (!transaction.has_value()) {
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
                  "urn:sourcemeta:one:auth-invalid-callback",
-                 "The login could not be completed", policy_name);
+                 "The login could not be completed");
       return;
     }
 
@@ -121,11 +121,21 @@ public:
 
     // Only once the callback is proven to belong to a real login is the
     // provider's outcome honoured: a decline returns an error instead of a
-    // code, and a success without a code is malformed
+    // code, and a success without a code is malformed. RFC 6749 Section
+    // 4.1.2.1 has a decline name itself with an error code, so one that names
+    // nothing is not a decision this can report as the provider's. It is no
+    // grant either, and a code arriving beside it is left unredeemed
     if (request.has_query("error")) {
-      this->fail(request, response, sourcemeta::core::HTTP_STATUS_FORBIDDEN,
-                 "urn:sourcemeta:one:auth-login-declined",
-                 "The identity provider declined the login", policy_name);
+      if (request.query("error").empty()) {
+        this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
+                   "urn:sourcemeta:one:auth-invalid-callback",
+                   "The login could not be completed");
+      } else {
+        this->fail(request, response, sourcemeta::core::HTTP_STATUS_FORBIDDEN,
+                   "urn:sourcemeta:one:auth-login-declined",
+                   "The identity provider declined the login");
+      }
+
       return;
     }
 
@@ -133,15 +143,19 @@ public:
     if (code.empty()) {
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
                  "urn:sourcemeta:one:auth-invalid-callback",
-                 "The login could not be completed", policy_name);
+                 "The login could not be completed");
       return;
     }
 
+    // Which policy a callback belongs to is settled by opening its
+    // transaction, so nothing reaching here names one this instance does not
+    // serve. Answering as though the callback were unproven keeps that the
+    // only thing this URL ever says about a name
     const auto policy{authentication.interactive(policy_name)};
     if (!policy.has_value()) {
-      this->fail(request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
-                 "urn:sourcemeta:one:not-found", "There is nothing at this URL",
-                 policy_name);
+      this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
+                 "urn:sourcemeta:one:auth-invalid-callback",
+                 "The login could not be completed");
       return;
     }
 
@@ -150,7 +164,7 @@ public:
       this->fail(request, response,
                  sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
                  "urn:sourcemeta:one:auth-misconfigured",
-                 "The authentication configuration is incomplete", policy_name);
+                 "The authentication configuration is incomplete");
       return;
     }
 
@@ -158,7 +172,7 @@ public:
     if (!endpoints.has_value() || endpoints.value().token.empty()) {
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
                  "urn:sourcemeta:one:auth-provider-unreachable",
-                 "The identity provider could not be reached", policy_name);
+                 "The identity provider could not be reached");
       return;
     }
 
@@ -172,7 +186,7 @@ public:
     if (!id_token.has_value()) {
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
                  "urn:sourcemeta:one:auth-exchange-failed",
-                 "The authorization code could not be redeemed", policy_name);
+                 "The authorization code could not be redeemed");
       return;
     }
 
@@ -180,7 +194,7 @@ public:
     if (!token.has_value()) {
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
                  "urn:sourcemeta:one:auth-invalid-identity",
-                 "The identity token could not be validated", policy_name);
+                 "The identity token could not be validated");
       return;
     }
 
@@ -193,7 +207,7 @@ public:
     if (!identity.has_value()) {
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
                  "urn:sourcemeta:one:auth-invalid-identity",
-                 "The identity token could not be validated", policy_name);
+                 "The identity token could not be validated");
       return;
     }
 
@@ -230,8 +244,7 @@ public:
         session_cookie.value().size() > MAXIMUM_COOKIE_LENGTH) {
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
                  "urn:sourcemeta:one:auth-identity-too-large",
-                 "The identity provider returned more than a session can hold",
-                 policy_name);
+                 "The identity provider returned more than a session can hold");
       return;
     }
 
@@ -239,7 +252,7 @@ public:
       this->fail(request, response,
                  sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
                  "urn:sourcemeta:one:auth-misconfigured",
-                 "The authentication configuration is incomplete", policy_name);
+                 "The authentication configuration is incomplete");
       return;
     }
 
@@ -458,8 +471,8 @@ private:
   auto fail(sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response,
             const sourcemeta::core::HTTPStatus &status,
-            const std::string_view type, const std::string_view detail,
-            const std::string_view) const -> void {
+            const std::string_view type, const std::string_view detail) const
+      -> void {
     sourcemeta::one::json_error(request, response, status, type, detail,
                                 this->error_schema_, "*");
   }

--- a/src/http/include/sourcemeta/one/http_request.h
+++ b/src/http/include/sourcemeta/one/http_request.h
@@ -67,6 +67,13 @@ public:
     return this->request_ ? this->request_->getFullUrl() : this->path_;
   }
 
+  // TODO: This answers with the first field of a given name, which is the
+  // wrong answer for cookies. RFC 9113 Section 8.2.3 lets a client split those
+  // across several fields and asks whoever reads them to rejoin them first, so
+  // a browser behind a proxy that forwards the split unchanged has every
+  // cookie past the first ignored here. A cookie only ever admits, so missing
+  // one denies rather than lets anybody in, though somebody would experience
+  // it as signing in and then not being signed in
   [[nodiscard]] auto header(const std::string_view name) const noexcept
       -> std::string_view {
     return this->request_->getHeader(name);


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

