### PR TITLE
Match a policy identity whole, and check which provider answered

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -552,6 +552,12 @@ follows is signed with a secret of the instance's own, unrelated to the provider
 
 !!! note
 
+    A login that names no page to return to lands on the **first** path the
+    policy declares. The order of `paths` therefore decides where signing in
+    leaves somebody, though it never changes what the policy gates.
+
+!!! note
+
     A browser holds one session per instance, whichever interactive policy
     established it, so signing in with a second one ends the first. Separate
     browser profiles are the way to hold both at once.

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -351,9 +351,18 @@ auto decode_jwt_metadata(const std::span<const std::byte> metadata,
   return true;
 }
 
-// The reference check treats two JWT policies as the same scope only when every
-// parameter that decides admission matches, so the identity spans the issuer,
-// audience, key set location, and the exact allowed algorithm bytes
+// The reference check treats two JWT policies as the same scope only when
+// every parameter that decides admission matches, so the issuer, audience, key
+// set location, required token type and allowed algorithms count as one
+// indivisible identity, never as separate keys that several policies could
+// satisfy piecewise or in swapped roles.
+//
+// A policy requiring a token type admits a narrower set than one that does
+// not, so two policies alike but for it are not the same audience either. That
+// refuses a reference from the stricter of the two to the looser one, which
+// every holder of the stricter credential could have followed anyway, and the
+// cost of refusing is a build that has to say so against disclosing a referent
+// to somebody the referrer never admitted
 auto collect_jwt_identifiers(const std::span<const std::byte> metadata,
                              std::unordered_set<std::string_view> &keys)
     -> void {
@@ -369,25 +378,15 @@ auto collect_jwt_identifiers(const std::span<const std::byte> metadata,
     return;
   }
 
-  keys.emplace(issuer);
-  keys.emplace(audience);
-  keys.emplace(jwks_uri);
-  // A policy that requires a token type admits a narrower set than one that
-  // does not, so two policies alike but for it are not the same audience.
-  // This refuses a reference from the stricter of the two to the looser one,
-  // which every holder of the stricter credential could have followed anyway.
-  // That is deliberate: the comparison is by equality, and the cost of
-  // refusing is a build that has to say so, against disclosing a referent to
-  // somebody the referrer never admitted
-  keys.emplace(token_type);
-
   std::uint32_t count{0};
   if (!read_u32(metadata, cursor, count) || count > metadata.size() - cursor) {
     return;
   }
 
+  // The serialized run itself is the key. Its length prefixes keep the fields
+  // delimited, so exactly the equal identities compare equal
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-  keys.emplace(reinterpret_cast<const char *>(metadata.data() + cursor), count);
+  keys.emplace(reinterpret_cast<const char *>(metadata.data()), cursor + count);
 }
 
 struct OIDCPolicyMetadata {

--- a/enterprise/e2e/auth-sso/hurl/decline.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/decline.all.hurl
@@ -90,6 +90,74 @@ Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
 [Asserts]
 jsonpath "$.valid" == true
 
+# An answer may name the provider it came from, and RFC 9207 Section 2.4 has a
+# client compare that against the one it addressed. Naming another provider
+# makes this an answer relayed from somewhere else, so it is refused before the
+# code is spent
+GET {{base}}/self/v1/auth/callback/keycloak?code=a-code-nobody-issued&state={{state}}&iss=https%3A%2F%2Fkeycloak%3A8443%2Frealms%2Fcleartext
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 400
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+foreign_issuer_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+body == {{refused_body}}
+{
+  "type": "urn:sourcemeta:one:auth-invalid-callback",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The login could not be completed"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{foreign_issuer_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# Naming the provider this login did address reaches the exchange, so the
+# comparison is what decided the answer above rather than the parameter merely
+# being present
+GET {{base}}/self/v1/auth/callback/keycloak?code=a-code-nobody-issued&state={{state}}&iss=https%3A%2F%2Fkeycloak%3A8443%2Frealms%2Fmain
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 502
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+own_issuer_body: body
+[Asserts]
+header "Set-Cookie" not exists
+body == {{exchange_body}}
+{
+  "type": "urn:sourcemeta:one:auth-exchange-failed",
+  "title": "Bad Gateway",
+  "status": 502,
+  "detail": "The authorization code could not be redeemed"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{own_issuer_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
 # A refusal carried by a proven callback is honoured, and answered as the
 # provider's decision rather than as a denial of a resource, so somebody who
 # declined at the provider is told what happened
@@ -185,6 +253,38 @@ body == {{declined_body}}
 POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
 ```
 {{contradictory_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# A refusal is placed before it is honoured too, so one arriving from another
+# provider is refused rather than reported as this login's outcome
+GET {{base}}/self/v1/auth/callback/keycloak?error=access_denied&state={{state}}&iss=https%3A%2F%2Fkeycloak%3A8443%2Frealms%2Fcleartext
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 400
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+foreign_refusal_body: body
+[Asserts]
+header "Set-Cookie" not exists
+body == {{refused_body}}
+{
+  "type": "urn:sourcemeta:one:auth-invalid-callback",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "The login could not be completed"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{foreign_refusal_body}}
 ```
 HTTP 200
 Cache-Control: no-store

--- a/enterprise/e2e/auth-sso/hurl/decline.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/decline.all.hurl
@@ -140,6 +140,7 @@ Link: </self/v1/schemas/api/error>; rel="describedby"
 own_issuer_body: body
 [Asserts]
 header "Set-Cookie" not exists
+header "Location" not exists
 body == {{exchange_body}}
 {
   "type": "urn:sourcemeta:one:auth-exchange-failed",
@@ -274,6 +275,7 @@ Link: </self/v1/schemas/api/error>; rel="describedby"
 foreign_refusal_body: body
 [Asserts]
 header "Set-Cookie" not exists
+header "Location" not exists
 body == {{refused_body}}
 {
   "type": "urn:sourcemeta:one:auth-invalid-callback",

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -119,6 +119,30 @@ public:
     const auto *nonce{transaction.value().try_at("nonce")};
     const auto *verifier{transaction.value().try_at("verifier")};
 
+    // Which policy a callback belongs to is settled by opening its
+    // transaction, so nothing reaching here names one this instance does not
+    // serve. Answering as though the callback were unproven keeps that the
+    // only thing this URL ever says about a name
+    const auto policy{authentication.interactive(policy_name)};
+    if (!policy.has_value()) {
+      this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
+                 "urn:sourcemeta:one:auth-invalid-callback",
+                 "The login could not be completed");
+      return;
+    }
+
+    // RFC 9207 Section 2.4 has a client compare the issuer an answer names
+    // against the one it addressed the request to, which is what catches an
+    // answer relayed from somewhere else. A provider naming none cannot be
+    // checked that way, so this runs only when one arrives, and it runs ahead
+    // of the outcome so that no answer is acted on before it is placed
+    if (request.has_query("iss") && request.query("iss") != policy->issuer) {
+      this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
+                 "urn:sourcemeta:one:auth-invalid-callback",
+                 "The login could not be completed");
+      return;
+    }
+
     // Only once the callback is proven to belong to a real login is the
     // provider's outcome honoured: a decline returns an error instead of a
     // code, and a success without a code is malformed. RFC 6749 Section
@@ -141,18 +165,6 @@ public:
 
     const auto code{request.query("code")};
     if (code.empty()) {
-      this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
-                 "urn:sourcemeta:one:auth-invalid-callback",
-                 "The login could not be completed");
-      return;
-    }
-
-    // Which policy a callback belongs to is settled by opening its
-    // transaction, so nothing reaching here names one this instance does not
-    // serve. Answering as though the callback were unproven keeps that the
-    // only thing this URL ever says about a name
-    const auto policy{authentication.interactive(policy_name)};
-    if (!policy.has_value()) {
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
                  "urn:sourcemeta:one:auth-invalid-callback",
                  "The login could not be completed");

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -306,6 +306,12 @@ private:
       ID_TOKEN_ALGORITHMS{{sourcemeta::core::JWSAlgorithm::RS256,
                            sourcemeta::core::JWSAlgorithm::ES256}};
 
+  // The tolerance allowed on an identity token's time-based claims, matching
+  // what a presented access token is already given. A provider whose clock
+  // runs a little fast otherwise mints a token this refuses the instant it
+  // arrives, which ends a login that did everything right
+  static constexpr std::chrono::seconds ID_TOKEN_CLOCK_SKEW{60};
+
   // The transaction a callback belongs to, if the request carries one. A
   // request can present several cookies under one name, since a parent
   // domain and the host itself can each set one and neither the header nor
@@ -473,7 +479,7 @@ private:
             return std::nullopt;
           }
         },
-        {}};
+        {.clock_skew = ID_TOKEN_CLOCK_SKEW}};
   }
 
   // A failed login leaves its transaction cookie in place, sealed and bound

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -2699,6 +2699,105 @@ TEST(reference_between_jwt_scopes_distinguishes_algorithms) {
       authentication.reference_permitted(at("/alpha/one"), at("/gamma/two")));
 }
 
+TEST(reference_across_swapped_jwt_identities_is_rejected) {
+  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
+  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
+  const std::array<sourcemeta::core::JWSAlgorithm, 1> rsa{
+      {sourcemeta::core::JWSAlgorithm::RS256}};
+  // One policy's issuer is the other's audience and vice versa, so the scopes
+  // share both strings yet no token satisfies them both
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = alpha_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://login.test",
+        .audience = "registry",
+        .jwks_uri = "https://idp.test/jwks",
+        .algorithms = rsa},
+       {.paths = beta_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "registry",
+        .audience = "https://login.test",
+        .jwks_uri = "https://idp.test/jwks",
+        .algorithms = rsa}}};
+  const auto path{test_path("jwt_reference_swapped.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+}
+
+TEST(reference_mixing_identities_across_jwt_policies_is_rejected) {
+  const std::array<std::string_view, 1> source_paths{{"/source"}};
+  const std::array<std::string_view, 1> target_paths{{"/target"}};
+  const std::array<sourcemeta::core::JWSAlgorithm, 1> rsa{
+      {sourcemeta::core::JWSAlgorithm::RS256}};
+  // The referrer pairs an issuer and an audience that the referent only
+  // carries through two different policies, so no single referent scope
+  // matches and the reference must not slip through their union
+  const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
+      {{.paths = source_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://alpha.test",
+        .audience = "dashboard",
+        .jwks_uri = "https://idp.test/jwks",
+        .algorithms = rsa},
+       {.paths = target_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://alpha.test",
+        .audience = "registry",
+        .jwks_uri = "https://idp.test/jwks",
+        .algorithms = rsa},
+       {.paths = target_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://beta.test",
+        .audience = "dashboard",
+        .jwks_uri = "https://idp.test/jwks",
+        .algorithms = rsa}}};
+  const auto path{test_path("jwt_reference_mixed.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/source/one"), at("/target/two")));
+}
+
+TEST(reference_across_swapped_jwt_key_set_locations_is_rejected) {
+  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
+  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
+  const std::array<sourcemeta::core::JWSAlgorithm, 1> rsa{
+      {sourcemeta::core::JWSAlgorithm::RS256}};
+  // The key set location decides which keys sign an admitted token, so
+  // trading it with the audience denotes a different scope as surely as
+  // trading the issuer does
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = alpha_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "acme",
+        .audience = "https://idp.test/jwks",
+        .jwks_uri = "registry",
+        .algorithms = rsa},
+       {.paths = beta_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "acme",
+        .audience = "registry",
+        .jwks_uri = "https://idp.test/jwks",
+        .algorithms = rsa}}};
+  const auto path{test_path("jwt_reference_swapped_keys.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(
+      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+}
+
 // A configured policy path that only differs cosmetically still has to gate the
 // location it names. A spelling the matcher could not traverse would leave the
 // target public while the configuration reads as though it were gated

--- a/src/configuration/parse.cc
+++ b/src/configuration/parse.cc
@@ -178,7 +178,16 @@ auto Configuration::parse(const sourcemeta::core::JSON &data,
         }
 
         if (entry.defines("tokenType")) {
+          // A media type is compared case-insensitively and with the
+          // `application/` prefix optional, so the spelling is reduced here to
+          // the single form the artifact carries. Otherwise two policies that
+          // admit exactly the same tokens would read as different scopes
           parsed.token_type = entry.at("tokenType").to_string();
+          sourcemeta::core::to_lowercase(parsed.token_type);
+          constexpr std::string_view MEDIA_TYPE_PREFIX{"application/"};
+          if (parsed.token_type.starts_with(MEDIA_TYPE_PREFIX)) {
+            parsed.token_type.erase(0, MEDIA_TYPE_PREFIX.size());
+          }
         }
 
         for (const auto &algorithm : entry.at("algorithms").as_array()) {

--- a/test/unit/configuration/configuration_test.cc
+++ b/test/unit/configuration/configuration_test.cc
@@ -896,6 +896,39 @@ TEST(authentication_jwt_token_type_is_reduced_to_one_spelling) {
   EXPECT_EQ(configuration.authentication.at(0).token_type, "at+jwt");
 }
 
+TEST(authentication_jwt_algorithms_are_reduced_to_one_order) {
+  const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
+    "url": "https://example.com",
+    "authentication": [
+      {
+        "type": "jwt",
+        "name": "one",
+        "paths": [ "/one" ],
+        "issuer": "https://acme.example.com",
+        "audience": "https://schemas.example.com",
+        "algorithms": [ "ES256", "RS256" ]
+      },
+      {
+        "type": "jwt",
+        "name": "two",
+        "paths": [ "/two" ],
+        "issuer": "https://acme.example.com",
+        "audience": "https://schemas.example.com",
+        "algorithms": [ "RS256", "ES256" ]
+      }
+    ]
+  })JSON")};
+  const auto configuration{sourcemeta::one::Configuration::parse(
+      raw_configuration, "/tmp/one.json", ".")};
+
+  // The allow-list is a set as far as admission is concerned, so two policies
+  // naming the same algorithms admit the same tokens whatever order they were
+  // written in, and must not read as different policies anywhere downstream
+  EXPECT_EQ(configuration.authentication.size(), 2);
+  EXPECT_EQ(configuration.authentication.at(0).algorithms,
+            configuration.authentication.at(1).algorithms);
+}
+
 TEST(authentication_jwt_issuer_with_a_key_set_is_left_alone) {
   const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
     "url": "https://example.com",

--- a/test/unit/configuration/configuration_test.cc
+++ b/test/unit/configuration/configuration_test.cc
@@ -871,6 +871,31 @@ TEST(authentication_jwt_issuer_trailing_slash_is_dropped) {
             "https://acme.example.com");
 }
 
+TEST(authentication_jwt_token_type_is_reduced_to_one_spelling) {
+  const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
+    "url": "https://example.com",
+    "authentication": [
+      {
+        "type": "jwt",
+        "name": "ci",
+        "paths": [ "/internal" ],
+        "issuer": "https://acme.example.com",
+        "audience": "https://schemas.example.com",
+        "tokenType": "Application/AT+JWT",
+        "algorithms": [ "RS256" ]
+      }
+    ]
+  })JSON")};
+  const auto configuration{sourcemeta::one::Configuration::parse(
+      raw_configuration, "/tmp/one.json", ".")};
+
+  // A media type is compared case-insensitively and with the leading
+  // `application/` optional, so spellings that admit exactly the same tokens
+  // must not read as different policies anywhere downstream
+  EXPECT_EQ(configuration.authentication.size(), 1);
+  EXPECT_EQ(configuration.authentication.at(0).token_type, "at+jwt");
+}
+
 TEST(authentication_jwt_issuer_with_a_key_set_is_left_alone) {
   const auto raw_configuration{sourcemeta::core::parse_json(R"JSON({
     "url": "https://example.com",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

