### PR TITLE
Read every cookie field a request presents, not only the first

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -538,9 +538,10 @@ struct Authentication::Impl {
     return result;
   }
 
-  [[nodiscard]] auto admits(const std::string_view registry_path,
-                            const std::string_view credential,
-                            const std::string_view cookies) const
+  [[nodiscard]] auto
+  admits(const std::string_view registry_path,
+         const std::string_view credential,
+         const std::span<const std::string_view> cookies) const
       -> Authentication::Verdict {
     // A missing or structurally broken artifact leaves the section pointers
     // null and denies everything. Only a valid policy fails open below
@@ -625,8 +626,9 @@ struct Authentication::Impl {
     return !error.has_value();
   }
 
-  [[nodiscard]] auto admits_session(const std::span<const std::byte> metadata,
-                                    const std::string_view cookies) const
+  [[nodiscard]] auto
+  admits_session(const std::span<const std::byte> metadata,
+                 const std::span<const std::string_view> cookies) const
       -> bool {
     if (cookies.empty()) {
       return false;
@@ -645,8 +647,10 @@ struct Authentication::Impl {
     // so each is carried through the whole check and the caller is admitted
     // when any of them is a session for this policy
     std::vector<std::string_view> candidates;
-    sourcemeta::core::http_cookie_values(
-        cookies, Authentication::SESSION_COOKIE, candidates);
+    for (const auto field : cookies) {
+      sourcemeta::core::http_cookie_values(
+          field, Authentication::SESSION_COOKIE, candidates);
+    }
     for (const auto sealed : candidates) {
       const auto payload{this->session_open(decoded.session_secret_variable,
                                             Authentication::Purpose::Session,

--- a/enterprise/e2e/auth-sso/hurl/decline.all.hurl
+++ b/enterprise/e2e/auth-sso/hurl/decline.all.hurl
@@ -495,3 +495,82 @@ Cache-Control: no-store
 Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
 [Asserts]
 jsonpath "$.valid" == true
+
+# A browser may present its cookies across several fields rather than one,
+# which HTTP/2 permits so that a proxy can compress them, and whoever reads
+# them has to put them back together. Starting a second login leaves this
+# browser carrying one transaction in each field
+GET {{base}}/self/v1/auth/login/keycloak
+HTTP 303
+Cache-Control: no-store
+[Captures]
+second_state: header "Location" regex "[?&]state=([A-Za-z0-9_-]+)"
+[Asserts]
+cookie "sourcemeta_one_transaction" exists
+
+# The state the first login named is honoured, though that transaction now
+# arrives in the later of the two fields. Reading only the first would refuse
+# a login that is entirely in order, and the person would be told nothing
+GET {{base}}/self/v1/auth/callback/keycloak?error=access_denied&state={{state}}
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 403
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+later_field_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+body == {{declined_body}}
+{
+  "type": "urn:sourcemeta:one:auth-login-declined",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "The identity provider declined the login"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{later_field_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true
+
+# And the state the second login named is honoured just the same, so neither
+# field is the one that decides
+GET {{base}}/self/v1/auth/callback/keycloak?error=access_denied&state={{second_state}}
+Cookie: sourcemeta_one_transaction={{transaction}}
+HTTP 403
+Cache-Control: no-store
+Content-Type: application/problem+json
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: Link, ETag
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+earlier_field_body: body
+[Asserts]
+header "Set-Cookie" not exists
+header "Location" not exists
+body == {{declined_body}}
+{
+  "type": "urn:sourcemeta:one:auth-login-declined",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "The identity provider declined the login"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+```
+{{earlier_field_body}}
+```
+HTTP 200
+Cache-Control: no-store
+Link: </self/v1/schemas/api/schemas/evaluate/response>; rel="describedby"
+[Asserts]
+jsonpath "$.valid" == true

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -330,9 +330,12 @@ private:
     }
 
     std::vector<std::string_view> candidates;
-    sourcemeta::core::http_cookie_values(
-        request.header("cookie"),
-        sourcemeta::one::Authentication::TRANSACTION_COOKIE, candidates);
+    request.header_values(
+        "cookie", [&candidates](const std::string_view field) -> void {
+          sourcemeta::core::http_cookie_values(
+              field, sourcemeta::one::Authentication::TRANSACTION_COOKIE,
+              candidates);
+        });
     for (const auto sealed : candidates) {
       auto opened{authentication.open(
           policy_name, sourcemeta::one::Authentication::Purpose::Transaction,

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_logout_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_logout_v1.h
@@ -138,9 +138,12 @@ private:
                   const sourcemeta::one::Authentication &authentication) const
       -> std::optional<std::string> {
     std::vector<std::string_view> candidates;
-    sourcemeta::core::http_cookie_values(
-        request.header("cookie"),
-        sourcemeta::one::Authentication::SESSION_COOKIE, candidates);
+    request.header_values(
+        "cookie", [&candidates](const std::string_view field) -> void {
+          sourcemeta::core::http_cookie_values(
+              field, sourcemeta::one::Authentication::SESSION_COOKIE,
+              candidates);
+        });
     for (const auto sealed : candidates) {
       const auto payload{authentication.open_session(sealed)};
       if (!payload.has_value()) {

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_jsonschema_rdf_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_jsonschema_rdf_v1.h
@@ -105,12 +105,13 @@ public:
     std::string schema_uri{this->server_uri()};
     schema_uri.push_back('/');
     schema_uri.append(path);
-    const auto schema_present{this->artifact_resolve_path(
-        {.bearer = credential, .cookies = request.header("cookie")}, schema_uri,
-        Tree::Schemas, "schema")};
+    const sourcemeta::one::RequestCookies cookies{request};
+    const auto schema_present{
+        this->artifact_resolve_path({.bearer = credential, .cookies = cookies},
+                                    schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
-        {.bearer = credential, .cookies = request.header("cookie")}, schema_uri,
-        Tree::Schemas, "blaze-exhaustive")};
+        {.bearer = credential, .cookies = cookies}, schema_uri, Tree::Schemas,
+        "blaze-exhaustive")};
     if (schema_present.outcome ==
             sourcemeta::one::ArtifactResolution::Outcome::Denied ||
         evaluation_enabled.outcome ==
@@ -173,7 +174,7 @@ public:
         // NOLINTNEXTLINE(bugprone-exception-escape)
         [this, schema_template, schema_uri = std::move(schema_uri),
          bearer = std::string{credential},
-         cookies = std::string{request.header("cookie")}](
+         cookies = sourcemeta::one::owned_cookies(request)](
             sourcemeta::one::HTTPRequest &callback_request,
             sourcemeta::one::HTTPResponse &callback_response,
             std::string &&body, bool too_big) -> void {
@@ -208,9 +209,9 @@ public:
             return;
           }
 
-          if (!this->schema_evaluate_fast(
-                  {.bearer = bearer, .cookies = cookies}, this->request_schema_,
-                  envelope)) {
+          const sourcemeta::one::RequestCookies fields{cookies};
+          if (!this->schema_evaluate_fast({.bearer = bearer, .cookies = fields},
+                                          this->request_schema_, envelope)) {
             sourcemeta::one::json_error(
                 callback_request, callback_response,
                 sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
@@ -240,7 +241,7 @@ public:
                    .detail = "The instance does not conform to the schema"})};
               payload.assign(
                   "errors",
-                  this->schema_evaluate({.bearer = bearer, .cookies = cookies},
+                  this->schema_evaluate({.bearer = bearer, .cookies = fields},
                                         schema_uri, instance,
                                         sourcemeta::blaze::Mode::Exhaustive)
                       .second.at("errors"));

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -42,6 +42,12 @@ static auto at_base(const std::string_view input, const std::string_view base)
 // serves, so every path a policy is scoped to is one to gate
 static auto anywhere(const std::string_view) -> bool { return true; }
 
+// One cookie field, which is what a browser conforming to RFC 6265 sends
+static auto fields(const std::string_view value)
+    -> std::array<std::string_view, 1> {
+  return {{value}};
+}
+
 static auto test_path(const std::string &name) -> std::filesystem::path {
   return std::filesystem::path{AUTHENTICATION_TEST_DIRECTORY} / name;
 }
@@ -469,10 +475,10 @@ TEST(base_path_is_stripped_before_matching) {
 
   // An empty base path strips nothing
   EXPECT_TRUE(
-      authentication.admits(at("/public/string"), {.bearer = "", .cookies = ""})
+      authentication.admits(at("/public/string"), {.bearer = "", .cookies = {}})
           .allowed);
   EXPECT_FALSE(authentication
-                   .admits(at("/private/secret"), {.bearer = "", .cookies = ""})
+                   .admits(at("/private/secret"), {.bearer = "", .cookies = {}})
                    .allowed);
 
   // A base that is not a whole-segment prefix of the target is left in place,
@@ -1280,8 +1286,8 @@ TEST(oidc_policy_admits_its_session_cookie) {
       minted_now(), session_expiry())};
   const std::string cookies{"theme=dark; sourcemeta_one_session=" + sealed};
 
-  const auto verdict{authentication.admits(at("/portal/x"),
-                                           {.bearer = "", .cookies = cookies})};
+  const auto verdict{authentication.admits(
+      at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})};
   EXPECT_TRUE(verdict.allowed);
   EXPECT_TRUE(verdict.principal.has_value());
   EXPECT_EQ(verdict.principal.value().type,
@@ -1327,19 +1333,19 @@ TEST(session_cookie_is_bound_to_the_policy_it_was_minted_for) {
 
   // The session opens the path its policy governs
   const std::string okta_cookies{"sourcemeta_one_session=" + sealed};
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/alpha/x"), {.bearer = "", .cookies = okta_cookies})
-          .allowed);
+  EXPECT_TRUE(authentication
+                  .admits(at("/alpha/x"),
+                          {.bearer = "", .cookies = fields(okta_cookies)})
+                  .allowed);
 
   // And not a path governed by another policy. Both policies here read the
   // same session secret, so the value verifies under either and the payload is
   // the only thing that tells them apart. There is no cookie name left to
   // separate them, which makes this the control rather than a second opinion
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/beta/x"), {.bearer = "", .cookies = okta_cookies})
-          .allowed);
+  EXPECT_FALSE(authentication
+                   .admits(at("/beta/x"),
+                           {.bearer = "", .cookies = fields(okta_cookies)})
+                   .allowed);
 }
 
 TEST(expired_session_cookie_is_denied) {
@@ -1366,7 +1372,8 @@ TEST(expired_session_cookie_is_denied) {
       past + std::chrono::hours{1})};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
   EXPECT_FALSE(
-      authentication.admits(at("/portal/x"), {.bearer = "", .cookies = cookies})
+      authentication
+          .admits(at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})
           .allowed);
 }
 
@@ -1393,10 +1400,10 @@ TEST(forged_session_cookie_is_denied) {
       sourcemeta::one::Authentication::Purpose::Session, "other-secret",
       minted_now(), session_expiry())};
   const std::string foreign_cookies{"sourcemeta_one_session=" + foreign};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/portal/x"), {.bearer = "", .cookies = foreign_cookies})
-          .allowed);
+  EXPECT_FALSE(authentication
+                   .admits(at("/portal/x"),
+                           {.bearer = "", .cookies = fields(foreign_cookies)})
+                   .allowed);
 
   // A value whose signature no longer matches its contents
   auto tampered{sourcemeta::one::Authentication::seal_value(
@@ -1405,16 +1412,17 @@ TEST(forged_session_cookie_is_denied) {
       minted_now(), session_expiry())};
   tampered.back() = tampered.back() == 'A' ? 'B' : 'A';
   const std::string tampered_cookies{"sourcemeta_one_session=" + tampered};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/portal/x"), {.bearer = "", .cookies = tampered_cookies})
-          .allowed);
+  EXPECT_FALSE(authentication
+                   .admits(at("/portal/x"),
+                           {.bearer = "", .cookies = fields(tampered_cookies)})
+                   .allowed);
 
   // A value that is not a sealed session at all
   EXPECT_FALSE(
       authentication
           .admits(at("/portal/x"),
-                  {.bearer = "", .cookies = "sourcemeta_one_session=garbage"})
+                  {.bearer = "",
+                   .cookies = fields("sourcemeta_one_session=garbage")})
           .allowed);
 }
 
@@ -1445,7 +1453,7 @@ TEST(session_payload_must_declare_its_policy) {
     const std::string cookies{"sourcemeta_one_session=" + sealed};
     EXPECT_FALSE(
         authentication
-            .admits(at("/portal/x"), {.bearer = "", .cookies = cookies})
+            .admits(at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})
             .allowed);
   }
 }
@@ -1478,7 +1486,8 @@ TEST(session_is_admitted_when_a_shadowing_cookie_precedes_it) {
                             "sourcemeta_one_session=" +
                             sealed};
   EXPECT_TRUE(
-      authentication.admits(at("/alpha/x"), {.bearer = "", .cookies = cookies})
+      authentication
+          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(cookies)})
           .allowed);
 }
 
@@ -1508,7 +1517,8 @@ TEST(session_is_admitted_when_a_shadowing_cookie_follows_it) {
   const std::string cookies{"sourcemeta_one_session=" + sealed +
                             "; sourcemeta_one_session=not-a-session"};
   EXPECT_TRUE(
-      authentication.admits(at("/alpha/x"), {.bearer = "", .cookies = cookies})
+      authentication
+          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(cookies)})
           .allowed);
 }
 
@@ -1552,13 +1562,15 @@ TEST(a_session_for_another_policy_does_not_end_the_search) {
   const std::string cookies{"sourcemeta_one_session=" + other +
                             "; sourcemeta_one_session=" + mine};
   EXPECT_TRUE(
-      authentication.admits(at("/alpha/x"), {.bearer = "", .cookies = cookies})
+      authentication
+          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(cookies)})
           .allowed);
 
   // And a value minted elsewhere still opens nothing on its own
   const std::string alone{"sourcemeta_one_session=" + other};
   EXPECT_FALSE(
-      authentication.admits(at("/alpha/x"), {.bearer = "", .cookies = alone})
+      authentication
+          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(alone)})
           .allowed);
 }
 
@@ -1583,7 +1595,8 @@ TEST(a_shadowing_cookie_alone_never_admits) {
   const std::string cookies{"sourcemeta_one_session=not-a-session; "
                             "sourcemeta_one_session=nor-is-this"};
   EXPECT_FALSE(
-      authentication.admits(at("/alpha/x"), {.bearer = "", .cookies = cookies})
+      authentication
+          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(cookies)})
           .allowed);
 }
 
@@ -1621,10 +1634,12 @@ TEST(a_session_never_admits_under_a_policy_sharing_its_secret) {
   const std::string cookies{"sourcemeta_one_session=" + sealed};
 
   EXPECT_TRUE(
-      authentication.admits(at("/alpha/x"), {.bearer = "", .cookies = cookies})
+      authentication
+          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(cookies)})
           .allowed);
   EXPECT_FALSE(
-      authentication.admits(at("/beta/x"), {.bearer = "", .cookies = cookies})
+      authentication
+          .admits(at("/beta/x"), {.bearer = "", .cookies = fields(cookies)})
           .allowed);
 }
 
@@ -1653,7 +1668,8 @@ TEST(a_session_naming_no_policy_never_admits) {
   EXPECT_FALSE(
       authentication
           .admits(at("/alpha/x"),
-                  {.bearer = "", .cookies = "sourcemeta_one_session=" + empty})
+                  {.bearer = "",
+                   .cookies = fields("sourcemeta_one_session=" + empty)})
           .allowed);
 
   // Names a policy that does not exist
@@ -1661,11 +1677,12 @@ TEST(a_session_naming_no_policy_never_admits) {
       R"JSON({ "policy": "nowhere" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
       minted_now(), session_expiry())};
-  EXPECT_FALSE(authentication
-                   .admits(at("/alpha/x"),
-                           {.bearer = "",
-                            .cookies = "sourcemeta_one_session=" + unknown})
-                   .allowed);
+  EXPECT_FALSE(
+      authentication
+          .admits(at("/alpha/x"),
+                  {.bearer = "",
+                   .cookies = fields("sourcemeta_one_session=" + unknown)})
+          .allowed);
 
   // Names a policy but not as a string
   const auto typed{sourcemeta::one::Authentication::seal_value(
@@ -1675,7 +1692,8 @@ TEST(a_session_naming_no_policy_never_admits) {
   EXPECT_FALSE(
       authentication
           .admits(at("/alpha/x"),
-                  {.bearer = "", .cookies = "sourcemeta_one_session=" + typed})
+                  {.bearer = "",
+                   .cookies = fields("sourcemeta_one_session=" + typed)})
           .allowed);
 }
 
@@ -1795,7 +1813,8 @@ TEST(session_cookie_without_a_configured_secret_is_denied) {
       minted_now(), session_expiry())};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
   EXPECT_FALSE(
-      authentication.admits(at("/portal/x"), {.bearer = "", .cookies = cookies})
+      authentication
+          .admits(at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})
           .allowed);
 }
 
@@ -1823,11 +1842,12 @@ TEST(session_admitted_under_a_rotated_secret) {
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, "old-secret",
       minted_now(), session_expiry())};
-  EXPECT_TRUE(authentication
-                  .admits(at("/portal/x"),
-                          {.bearer = "",
-                           .cookies = "sourcemeta_one_session=" + old_sealed})
-                  .allowed);
+  EXPECT_TRUE(
+      authentication
+          .admits(at("/portal/x"),
+                  {.bearer = "",
+                   .cookies = fields("sourcemeta_one_session=" + old_sealed)})
+          .allowed);
 
   // A fresh login mints under the newest secret alone, so the minted value
   // verifies under a new-only secret set and not under an old-only one
@@ -1855,11 +1875,12 @@ TEST(session_admitted_under_a_rotated_secret) {
       R"JSON({ "policy": "okta" })JSON",
       sourcemeta::one::Authentication::Purpose::Session, "retired-secret",
       minted_now(), session_expiry())};
-  EXPECT_FALSE(authentication
-                   .admits(at("/portal/x"),
-                           {.bearer = "",
-                            .cookies = "sourcemeta_one_session=" + retired})
-                   .allowed);
+  EXPECT_FALSE(
+      authentication
+          .admits(at("/portal/x"),
+                  {.bearer = "",
+                   .cookies = fields("sourcemeta_one_session=" + retired)})
+          .allowed);
 }
 
 TEST(session_with_a_blank_configured_secret_is_denied) {
@@ -1886,7 +1907,8 @@ TEST(session_with_a_blank_configured_secret_is_denied) {
       session_expiry())};
   const std::string cookies{"sourcemeta_one_session=" + forged};
   EXPECT_FALSE(
-      authentication.admits(at("/portal/x"), {.bearer = "", .cookies = cookies})
+      authentication
+          .admits(at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})
           .allowed);
 }
 
@@ -1959,8 +1981,8 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_key_or_session) {
       sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
       minted_now(), session_expiry())};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
-  const auto session_verdict{
-      authentication.admits(at("/both/x"), {.bearer = "", .cookies = cookies})};
+  const auto session_verdict{authentication.admits(
+      at("/both/x"), {.bearer = "", .cookies = fields(cookies)})};
   EXPECT_TRUE(session_verdict.allowed);
   EXPECT_TRUE(session_verdict.principal.has_value());
   EXPECT_EQ(session_verdict.principal.value().type,
@@ -1990,7 +2012,7 @@ TEST(session_cookie_does_not_open_an_apikey_path) {
   const std::string cookies{"sourcemeta_one_session=" + sealed};
   EXPECT_FALSE(
       authentication
-          .admits(at("/internal/x"), {.bearer = "", .cookies = cookies})
+          .admits(at("/internal/x"), {.bearer = "", .cookies = fields(cookies)})
           .allowed);
 }
 

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -1522,6 +1522,68 @@ TEST(session_is_admitted_when_a_shadowing_cookie_follows_it) {
           .allowed);
 }
 
+TEST(session_is_admitted_when_it_arrives_in_a_later_cookie_field) {
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  const std::array<std::string_view, 1> paths{{"/alpha"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_FIELD_LATER",
+        .name = "okta",
+        .session_secret_variable = SESSION_SECRET_VARIABLE}}};
+  const auto path{test_path("oidc_field_later.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  const auto sealed{sourcemeta::one::Authentication::seal_value(
+      R"JSON({ "policy": "okta" })JSON",
+      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
+      minted_now(), session_expiry())};
+
+  // A request may carry its cookies across several fields rather than one, so
+  // reading only the first would deny a session that did arrive
+  const std::string second{"sourcemeta_one_session=" + sealed};
+  const std::array<std::string_view, 2> carried{
+      {"sourcemeta_one_session=not-a-session", second}};
+  EXPECT_TRUE(
+      authentication.admits(at("/alpha/x"), {.bearer = "", .cookies = carried})
+          .allowed);
+}
+
+TEST(session_is_admitted_when_it_arrives_in_an_earlier_cookie_field) {
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  const std::array<std::string_view, 1> paths{{"/alpha"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "acme",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_FIELD_EARLIER",
+        .name = "okta",
+        .session_secret_variable = SESSION_SECRET_VARIABLE}}};
+  const auto path{test_path("oidc_field_earlier.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  const auto sealed{sourcemeta::one::Authentication::seal_value(
+      R"JSON({ "policy": "okta" })JSON",
+      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
+      minted_now(), session_expiry())};
+
+  // And neither field is the one that decides, so a later one carrying nothing
+  // does not undo an earlier one that does
+  const std::string first{"sourcemeta_one_session=" + sealed};
+  const std::array<std::string_view, 2> carried{
+      {first, "sourcemeta_one_session=not-a-session"}};
+  EXPECT_TRUE(
+      authentication.admits(at("/alpha/x"), {.bearer = "", .cookies = carried})
+          .allowed);
+}
+
 TEST(a_session_for_another_policy_does_not_end_the_search) {
   setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
   const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};

--- a/src/actions/action_default_v1.h
+++ b/src/actions/action_default_v1.h
@@ -91,6 +91,7 @@ public:
     }
 
     const auto &path{stripped.value()};
+    const sourcemeta::one::RequestCookies cookies{request};
 
     if (path.empty()) {
       if (request.method() != "get" && request.method() != "head") {
@@ -104,8 +105,8 @@ public:
       const auto serve_html{
           sourcemeta::one::prefers_html(request.header("accept"))};
       const auto root_html{this->artifact_resolve_path(
-          {.bearer = credential, .cookies = request.header("cookie")}, "",
-          Tree::Explorer, "directory-html")};
+          {.bearer = credential, .cookies = cookies}, "", Tree::Explorer,
+          "directory-html")};
       if (root_html.outcome ==
           sourcemeta::one::ArtifactResolution::Outcome::Denied) {
         if (serve_html) {
@@ -145,11 +146,11 @@ public:
     if (request.method() == "get" || request.method() == "head") {
       if (sourcemeta::one::prefers_html(request.header("accept"))) {
         const auto schema_html{this->artifact_resolve_path(
-            {.bearer = credential, .cookies = request.header("cookie")}, path,
-            Tree::Explorer, "schema-html")};
+            {.bearer = credential, .cookies = cookies}, path, Tree::Explorer,
+            "schema-html")};
         const auto directory_html{this->artifact_resolve_path(
-            {.bearer = credential, .cookies = request.header("cookie")}, path,
-            Tree::Explorer, "directory-html")};
+            {.bearer = credential, .cookies = cookies}, path, Tree::Explorer,
+            "directory-html")};
         if (schema_html.outcome ==
                 sourcemeta::one::ArtifactResolution::Outcome::Denied ||
             directory_html.outcome ==
@@ -199,14 +200,14 @@ public:
       // the response must be 405 with Allow listing what is supported.
       // https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.6
       const auto schema_json{this->artifact_resolve_path(
-          {.bearer = credential, .cookies = request.header("cookie")}, path,
-          Tree::Schemas, "schema")};
+          {.bearer = credential, .cookies = cookies}, path, Tree::Schemas,
+          "schema")};
       const auto schema_html{this->artifact_resolve_path(
-          {.bearer = credential, .cookies = request.header("cookie")}, path,
-          Tree::Explorer, "schema-html")};
+          {.bearer = credential, .cookies = cookies}, path, Tree::Explorer,
+          "schema-html")};
       const auto directory_html{this->artifact_resolve_path(
-          {.bearer = credential, .cookies = request.header("cookie")}, path,
-          Tree::Explorer, "directory-html")};
+          {.bearer = credential, .cookies = cookies}, path, Tree::Explorer,
+          "directory-html")};
       if (schema_json.outcome ==
               sourcemeta::one::ArtifactResolution::Outcome::Denied ||
           schema_html.outcome ==

--- a/src/actions/action_dependency_tree_v1.h
+++ b/src/actions/action_dependency_tree_v1.h
@@ -81,9 +81,10 @@ public:
       return;
     }
 
+    const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{this->artifact_resolve_path(
-        {.bearer = credential, .cookies = request.header("cookie")},
-        matches.front(), Tree::Schemas, this->metapack_)};
+        {.bearer = credential, .cookies = cookies}, matches.front(),
+        Tree::Schemas, this->metapack_)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       sourcemeta::one::json_error_unauthorized(request, response,

--- a/src/actions/action_jsonschema_evaluate_v1.h
+++ b/src/actions/action_jsonschema_evaluate_v1.h
@@ -54,19 +54,21 @@ public:
   auto rest(const std::span<std::string_view> matches,
             std::string_view credential, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
+    const sourcemeta::one::RequestCookies cookies{request};
     ActionJSONSchemaEvaluate_v1::serve_post(
-        matches, {.bearer = credential, .cookies = request.header("cookie")},
-        request, response, *this, this->response_schema_, this->error_schema_,
+        matches, {.bearer = credential, .cookies = cookies}, request, response,
+        *this, this->response_schema_, this->error_schema_,
         this->request_schema_,
         // A throw here is intended and caught by the surrounding request
         // handler
         // NOLINTNEXTLINE(bugprone-exception-escape)
         [this, bearer = std::string{credential},
-         cookies = std::string{request.header("cookie")}](
+         cookies = sourcemeta::one::owned_cookies(request)](
             const std::string_view schema_uri,
             const std::string &body) -> sourcemeta::core::JSON {
+          const sourcemeta::one::RequestCookies fields{cookies};
           return this
-              ->schema_evaluate({.bearer = bearer, .cookies = cookies},
+              ->schema_evaluate({.bearer = bearer, .cookies = fields},
                                 schema_uri, sourcemeta::core::parse_json(body),
                                 sourcemeta::blaze::Mode::Exhaustive)
               .second;
@@ -246,7 +248,8 @@ public:
         // NOLINTNEXTLINE(bugprone-exception-escape)
         [response_schema, error_schema, schema_uri = std::move(schema_uri),
          &self, request_schema, bearer = std::string{credentials.bearer},
-         cookies = std::string{credentials.cookies},
+         cookies = std::vector<std::string>{credentials.cookies.begin(),
+                                            credentials.cookies.end()},
          perform = std::move(perform)](
             sourcemeta::one::HTTPRequest &callback_request,
             sourcemeta::one::HTTPResponse &callback_response,
@@ -282,7 +285,8 @@ public:
             return;
           }
 
-          if (!self.schema_evaluate_fast({.bearer = bearer, .cookies = cookies},
+          const sourcemeta::one::RequestCookies fields{cookies};
+          if (!self.schema_evaluate_fast({.bearer = bearer, .cookies = fields},
                                          request_schema, instance)) {
             sourcemeta::one::json_error(
                 callback_request, callback_response,

--- a/src/actions/action_jsonschema_serve_v1.h
+++ b/src/actions/action_jsonschema_serve_v1.h
@@ -59,9 +59,10 @@ public:
                                     : (bundle || is_deno)
                                         ? std::string_view{"bundle"}
                                         : std::string_view{"schema"}};
+    const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{self.artifact_resolve_path(
-        {.bearer = credential, .cookies = request.header("cookie")},
-        schema_path, sourcemeta::one::RouterAction::Tree::Schemas, artifact)};
+        {.bearer = credential, .cookies = cookies}, schema_path,
+        sourcemeta::one::RouterAction::Tree::Schemas, artifact)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       sourcemeta::one::json_error_unauthorized(request, response, error_schema,

--- a/src/actions/action_jsonschema_trace_v1.h
+++ b/src/actions/action_jsonschema_trace_v1.h
@@ -65,21 +65,23 @@ public:
   auto rest(const std::span<std::string_view> matches,
             std::string_view credential, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
+    const sourcemeta::one::RequestCookies cookies{request};
     ActionJSONSchemaEvaluate_v1::serve_post(
-        matches, {.bearer = credential, .cookies = request.header("cookie")},
-        request, response, *this, this->response_schema_, this->error_schema_,
+        matches, {.bearer = credential, .cookies = cookies}, request, response,
+        *this, this->response_schema_, this->error_schema_,
         this->request_schema_,
         // A throw here is intended and caught by the surrounding request
         // handler
         // NOLINTNEXTLINE(bugprone-exception-escape)
         [this, bearer = std::string{credential},
-         cookies = std::string{request.header("cookie")}](
+         cookies = sourcemeta::one::owned_cookies(request)](
             const std::string_view schema_uri,
             const std::string &body) -> sourcemeta::core::JSON {
           sourcemeta::core::PointerPositionTracker tracker;
           sourcemeta::core::JSON instance_json{nullptr};
           sourcemeta::core::parse_json(body, instance_json, std::ref(tracker));
-          return this->trace({.bearer = bearer, .cookies = cookies}, schema_uri,
+          const sourcemeta::one::RequestCookies fields{cookies};
+          return this->trace({.bearer = bearer, .cookies = fields}, schema_uri,
                              instance_json, &tracker,
                              sourcemeta::core::Pointer{});
         });

--- a/src/actions/action_list_directory_v1.h
+++ b/src/actions/action_list_directory_v1.h
@@ -60,9 +60,10 @@ public:
     }
     const std::string_view path_match{matches.empty() ? std::string_view{}
                                                       : matches.front()};
-    const auto resolution{this->artifact_resolve_path(
-        {.bearer = credential, .cookies = request.header("cookie")}, path_match,
-        Tree::Explorer, "directory")};
+    const sourcemeta::one::RequestCookies cookies{request};
+    const auto resolution{
+        this->artifact_resolve_path({.bearer = credential, .cookies = cookies},
+                                    path_match, Tree::Explorer, "directory")};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       sourcemeta::one::json_error_unauthorized(request, response,

--- a/src/actions/action_schema_search_v1.h
+++ b/src/actions/action_schema_search_v1.h
@@ -177,10 +177,10 @@ public:
       }
     }
 
-    const auto cookies{request.header("cookie")};
+    const sourcemeta::one::RequestCookies cookies{request};
     auto result{this->search_view_.search(
         query, limit, scope,
-        [this, &credential, cookies](const std::string_view path) -> bool {
+        [this, &credential, &cookies](const std::string_view path) -> bool {
           const auto &authentication{this->dispatcher().authentication()};
           const auto location{this->canonical_path(path)};
           return location.has_value() &&

--- a/src/actions/action_serve_explorer_artifact_v1.h
+++ b/src/actions/action_serve_explorer_artifact_v1.h
@@ -70,9 +70,10 @@ public:
 
     const std::string_view path_match{matches.empty() ? std::string_view{}
                                                       : matches.front()};
+    const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{this->artifact_resolve_path(
-        {.bearer = credential, .cookies = request.header("cookie")}, path_match,
-        Tree::Explorer, this->artifact_)};
+        {.bearer = credential, .cookies = cookies}, path_match, Tree::Explorer,
+        this->artifact_)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       sourcemeta::one::json_error_unauthorized(request, response,

--- a/src/actions/action_serve_schema_artifact_v1.h
+++ b/src/actions/action_serve_schema_artifact_v1.h
@@ -77,9 +77,10 @@ public:
       return;
     }
 
+    const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{this->artifact_resolve_path(
-        {.bearer = credential, .cookies = request.header("cookie")},
-        matches.front(), Tree::Schemas, this->artifact_)};
+        {.bearer = credential, .cookies = cookies}, matches.front(),
+        Tree::Schemas, this->artifact_)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       sourcemeta::one::json_error_unauthorized(request, response,

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -25,11 +25,13 @@
 namespace sourcemeta::one {
 
 // Everything a request presented for authentication: the bearer value from
-// the authorization header and the raw request cookie header, either of
-// which may admit the caller under a covering policy
+// the authorization header and every cookie field it carried, either of which
+// may admit the caller under a covering policy. The cookie fields are kept as
+// they arrived rather than joined, since a request may carry more than one and
+// what a cookie means is decided by whoever reads it
 struct Credentials {
   std::string_view bearer{};
-  std::string_view cookies{};
+  std::span<const std::string_view> cookies{};
 };
 
 class SOURCEMETA_ONE_AUTHENTICATION_EXPORT Authentication {

--- a/src/http/include/sourcemeta/one/http_request.h
+++ b/src/http/include/sourcemeta/one/http_request.h
@@ -8,6 +8,7 @@
 #include <sourcemeta/one/http_uwebsockets.h>
 
 #include <chrono>      // std::chrono::system_clock
+#include <concepts>    // std::invocable
 #include <cstddef>     // std::size_t
 #include <exception>   // std::exception_ptr, std::current_exception
 #include <memory>      // std::shared_ptr, std::make_shared
@@ -67,16 +68,32 @@ public:
     return this->request_ ? this->request_->getFullUrl() : this->path_;
   }
 
-  // TODO: This answers with the first field of a given name, which is the
-  // wrong answer for cookies. RFC 9113 Section 8.2.3 lets a client split those
-  // across several fields and asks whoever reads them to rejoin them first, so
-  // a browser behind a proxy that forwards the split unchanged has every
-  // cookie past the first ignored here. A cookie only ever admits, so missing
-  // one denies rather than lets anybody in, though somebody would experience
-  // it as signing in and then not being signed in
+  // The first value of a field, which is all a field carrying one value has.
+  // Where a field may arrive more than once, ask for every value instead
   [[nodiscard]] auto header(const std::string_view name) const noexcept
       -> std::string_view {
     return this->request_->getHeader(name);
+  }
+
+  // Every value a field carries, in the order they arrived. RFC 9110 Section
+  // 5.2 lets a field appear more than once, and Section 5.3 only permits
+  // repeats to be folded into one line for a field defined as a
+  // comma-separated list, which is why RFC 9113 Section 8.2.3 has to name the
+  // separator for cookies specifically. So how repeats combine is left to
+  // whoever knows the field, and this only says what arrived
+  template <typename Callback>
+    requires std::invocable<Callback, std::string_view>
+  auto header_values(const std::string_view name, Callback callback) const
+      -> void {
+    if (this->request_ == nullptr) {
+      return;
+    }
+
+    for (const auto [key, value] : *this->request_) {
+      if (key == name) {
+        callback(value);
+      }
+    }
   }
 
   // uWebSockets stores header field-names lowercased, so `name` must be

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -19,13 +19,62 @@
 #include <mutex>       // std::once_flag
 #include <optional>    // std::optional
 #include <span>        // std::span
+#include <string>      // std::string
 #include <string_view> // std::string_view
 #include <utility>     // std::move, std::pair
+#include <vector>      // std::vector
 
 namespace sourcemeta::one {
 
 class Router;
 class RouterAction;
+
+// The cookie fields a request carried, held for as long as the credentials
+// that view them. A request may present the field more than once, so every
+// occurrence is kept rather than the first, and they are not joined, since
+// what a cookie means is decided by whoever reads it
+class RequestCookies {
+public:
+  explicit RequestCookies(const HTTPRequest &request) {
+    request.header_values("cookie",
+                          [this](const std::string_view value) -> void {
+                            this->fields_.emplace_back(value);
+                          });
+  }
+
+  // Storage for an asynchronous body, where the request is gone by the time
+  // the credentials are read, so the fields must be owned rather than viewed
+  explicit RequestCookies(const std::vector<std::string> &owned) {
+    this->fields_.reserve(owned.size());
+    for (const auto &field : owned) {
+      this->fields_.emplace_back(field);
+    }
+  }
+
+  [[nodiscard]] operator std::span<const std::string_view>() const noexcept {
+    return this->fields_;
+  }
+
+  // Whether the request carried no cookie at all, which is one of the two
+  // things that make a caller anonymous
+  [[nodiscard]] auto empty() const noexcept -> bool {
+    return this->fields_.empty();
+  }
+
+private:
+  std::vector<std::string_view> fields_;
+};
+
+// The same fields, copied, for a handler that outlives the request
+[[nodiscard]] inline auto owned_cookies(const HTTPRequest &request)
+    -> std::vector<std::string> {
+  std::vector<std::string> result;
+  request.header_values("cookie",
+                        [&result](const std::string_view value) -> void {
+                          result.emplace_back(value);
+                        });
+  return result;
+}
 
 // Proof that a path was produced by the artifact resolver. Only the
 // action base class can mint one, so every artifact read must have

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -51,9 +51,17 @@ public:
     }
   }
 
-  [[nodiscard]] operator std::span<const std::string_view>() const noexcept {
+  // What this views has to outlive it, so it cannot be built from storage that
+  // ends with the expression that built it
+  explicit RequestCookies(std::vector<std::string> &&) = delete;
+
+  [[nodiscard]] operator std::span<const std::string_view>() const & noexcept {
     return this->fields_;
   }
+
+  // For the same reason, what it hands out cannot outlive it either, so a
+  // temporary is refused rather than left to be read once it is gone
+  operator std::span<const std::string_view>() const && = delete;
 
   // Whether the request carried no cookie at all, which is one of the two
   // things that make a caller anonymous

--- a/src/router/router.cc
+++ b/src/router/router.cc
@@ -126,12 +126,12 @@ auto Router::dispatch(
   // authorises that same spelling rather than the location it resolves to. A
   // target reaching past a governed prefix is therefore still governed by it,
   // while one that merely addresses content relative to its own route is not
+  const RequestCookies cookies{request};
   if (identifier != 0 && request.method() != "options" &&
       !instance->is_authentication_exempt() &&
       !this->authentication_
-           .admits_route(
-               request.path(), instance->server_uri_base_path(),
-               {.bearer = credential, .cookies = request.header("cookie")})
+           .admits_route(request.path(), instance->server_uri_base_path(),
+                         {.bearer = credential, .cookies = cookies})
            .allowed) {
     if (instance->serve_login(request, response)) {
       return;


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

