### PR TITLE
Accept every asymmetric signature, and log which setting is missing

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -190,13 +190,15 @@ auto read_u32(const std::span<const std::byte> metadata, std::size_t &cursor,
 // a variable set to nothing holds no secret, so neither reaches a caller as a
 // value it might compare something against
 auto resolve_environment(const std::string_view variable)
-    -> std::optional<std::string> {
+    -> std::optional<sourcemeta::core::SecureString> {
   if (variable.empty()) {
     return std::nullopt;
   }
 
   static std::mutex mutex;
-  static std::unordered_map<std::string, std::optional<std::string>> cache;
+  static std::unordered_map<std::string,
+                            std::optional<sourcemeta::core::SecureString>>
+      cache;
   const std::string name{variable};
   const std::scoped_lock lock{mutex};
   const auto existing{cache.find(name)};
@@ -204,13 +206,13 @@ auto resolve_environment(const std::string_view variable)
     return existing->second;
   }
 
-  std::optional<std::string> resolved;
+  std::optional<sourcemeta::core::SecureString> resolved;
   // NOLINTNEXTLINE(concurrency-mt-unsafe)
   const char *value{std::getenv(name.c_str())};
   // A variable set to nothing holds no secret, so it reads here the same as
   // one that was never set at all
   if (value != nullptr && *value != '\0') {
-    resolved = value;
+    resolved.emplace(std::string_view{value});
   }
 
   cache.emplace(name, resolved);
@@ -778,7 +780,7 @@ struct Authentication::Impl {
   }
 
   [[nodiscard]] auto client_secret(const std::string_view policy) const
-      -> std::optional<std::string> {
+      -> std::optional<sourcemeta::core::SecureString> {
     OIDCPolicyMetadata decoded;
     if (!this->find_interactive(policy, decoded)) {
       return std::nullopt;
@@ -1151,7 +1153,7 @@ auto Authentication::interactive(const std::string_view name) const
 }
 
 auto Authentication::client_secret(const std::string_view policy) const
-    -> std::optional<std::string> {
+    -> std::optional<sourcemeta::core::SecureString> {
   return this->impl_->client_secret(policy);
 }
 

--- a/enterprise/e2e/auth-sso/realm.json
+++ b/enterprise/e2e/auth-sso/realm.json
@@ -24,7 +24,8 @@
       "optionalClientScopes": [],
       "attributes": {
         "pkce.code.challenge.method": "S256",
-        "post.logout.redirect.uris": "http://localhost:8000"
+        "post.logout.redirect.uris": "http://localhost:8000",
+        "id.token.signed.response.alg": "PS256"
       }
     }
   ],

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -266,8 +266,6 @@ public:
     }
 
     if (!session_cookie.has_value()) {
-      sourcemeta::one::HTTP_LOG("No session secret is set for the policy",
-                                policy_name);
       this->fail(request, response,
                  sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
                  "urn:sourcemeta:one:auth-misconfigured",
@@ -413,17 +411,26 @@ private:
         policy_name, sourcemeta::one::Authentication::Purpose::Session,
         payload_text.str(), expiry)};
     if (!sealed.has_value()) {
+      sourcemeta::one::HTTP_LOG("No session secret is set for the policy",
+                                policy_name);
       return std::nullopt;
     }
 
-    return sourcemeta::core::http_serialize_cookie(
+    auto cookie{sourcemeta::core::http_serialize_cookie(
         {.name = sourcemeta::one::Authentication::SESSION_COOKIE,
          .value = sealed.value(),
          .path = scope,
          .max_age = SESSION_LIFETIME,
          .http_only = true,
          .secure = secure,
-         .same_site = sourcemeta::core::HTTPCookieSameSite::Lax});
+         .same_site = sourcemeta::core::HTTPCookieSameSite::Lax})};
+    if (!cookie.has_value()) {
+      sourcemeta::one::HTTP_LOG("The session could not be put in a cookie, "
+                                "for the policy",
+                                policy_name);
+    }
+
+    return cookie;
   }
 
   auto expire_transaction(sourcemeta::one::HTTPResponse &response,

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -173,9 +173,8 @@ public:
 
     const auto client_secret{authentication.client_secret(policy_name)};
     if (!client_secret.has_value()) {
-      sourcemeta::one::HTTP_LOG(
-          std::string{"No client secret is set for the policy "}.append(
-              policy_name));
+      sourcemeta::one::HTTP_LOG("No client secret is set for the policy",
+                                policy_name);
       this->fail(request, response,
                  sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
                  "urn:sourcemeta:one:auth-misconfigured",
@@ -185,10 +184,9 @@ public:
 
     const auto endpoints{authentication.endpoints(policy_name)};
     if (!endpoints.has_value() || endpoints.value().token.empty()) {
-      sourcemeta::one::HTTP_LOG(
-          std::string{"The provider named no token endpoint, or could not be "
-                      "reached, for the policy "}
-              .append(policy_name));
+      sourcemeta::one::HTTP_LOG("The provider named no token endpoint, or "
+                                "could not be reached, for the policy",
+                                policy_name);
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
                  "urn:sourcemeta:one:auth-provider-unreachable",
                  "The identity provider could not be reached");
@@ -268,9 +266,8 @@ public:
     }
 
     if (!session_cookie.has_value()) {
-      sourcemeta::one::HTTP_LOG(
-          std::string{"No session secret is set for the policy "}.append(
-              policy_name));
+      sourcemeta::one::HTTP_LOG("No session secret is set for the policy",
+                                policy_name);
       this->fail(request, response,
                  sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
                  "urn:sourcemeta:one:auth-misconfigured",

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -173,6 +173,9 @@ public:
 
     const auto client_secret{authentication.client_secret(policy_name)};
     if (!client_secret.has_value()) {
+      sourcemeta::one::HTTP_LOG(
+          std::string{"No client secret is set for the policy "}.append(
+              policy_name));
       this->fail(request, response,
                  sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
                  "urn:sourcemeta:one:auth-misconfigured",
@@ -182,6 +185,10 @@ public:
 
     const auto endpoints{authentication.endpoints(policy_name)};
     if (!endpoints.has_value() || endpoints.value().token.empty()) {
+      sourcemeta::one::HTTP_LOG(
+          std::string{"The provider named no token endpoint, or could not be "
+                      "reached, for the policy "}
+              .append(policy_name));
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
                  "urn:sourcemeta:one:auth-provider-unreachable",
                  "The identity provider could not be reached");
@@ -261,6 +268,9 @@ public:
     }
 
     if (!session_cookie.has_value()) {
+      sourcemeta::one::HTTP_LOG(
+          std::string{"No session secret is set for the policy "}.append(
+              policy_name));
       this->fail(request, response,
                  sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
                  "urn:sourcemeta:one:auth-misconfigured",
@@ -299,12 +309,24 @@ public:
   }
 
 private:
-  // The signature algorithms an identity token may be signed with. The major
-  // providers sign with one of these, and the policy does not yet let an
-  // operator narrow the set
-  static constexpr std::array<sourcemeta::core::JWSAlgorithm, 2>
+  // The signature algorithms an identity token may be signed with: every
+  // asymmetric one, since a provider picks from these and an instance that
+  // named a narrower set would refuse a provider it could otherwise serve,
+  // after the person had already signed in. The symmetric ones are left out
+  // deliberately. They sign with the client secret rather than a key from the
+  // provider's published set, so admitting them alongside the rest is the
+  // shape that lets one algorithm be verified as though it were another
+  static constexpr std::array<sourcemeta::core::JWSAlgorithm, 10>
       ID_TOKEN_ALGORITHMS{{sourcemeta::core::JWSAlgorithm::RS256,
-                           sourcemeta::core::JWSAlgorithm::ES256}};
+                           sourcemeta::core::JWSAlgorithm::RS384,
+                           sourcemeta::core::JWSAlgorithm::RS512,
+                           sourcemeta::core::JWSAlgorithm::PS256,
+                           sourcemeta::core::JWSAlgorithm::PS384,
+                           sourcemeta::core::JWSAlgorithm::PS512,
+                           sourcemeta::core::JWSAlgorithm::ES256,
+                           sourcemeta::core::JWSAlgorithm::ES384,
+                           sourcemeta::core::JWSAlgorithm::ES512,
+                           sourcemeta::core::JWSAlgorithm::EdDSA}};
 
   // The tolerance allowed on an identity token's time-based claims, matching
   // what a presented access token is already given. A provider whose clock

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
@@ -103,9 +103,8 @@ public:
     // Starting a login that cannot be completed only strands the person at the
     // provider, so the secret the exchange will need is required up front
     if (!authentication.client_secret(policy_name).has_value()) {
-      sourcemeta::one::HTTP_LOG(
-          std::string{"No client secret is set for the policy "}.append(
-              policy_name));
+      sourcemeta::one::HTTP_LOG("No client secret is set for the policy",
+                                policy_name);
       sourcemeta::one::json_error(
           request, response,
           sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
@@ -117,10 +116,9 @@ public:
 
     const auto endpoints{authentication.endpoints(policy_name)};
     if (!endpoints.has_value() || endpoints.value().authorization.empty()) {
-      sourcemeta::one::HTTP_LOG(
-          std::string{"The provider named no authorization endpoint, or could "
-                      "not be reached, for the policy "}
-              .append(policy_name));
+      sourcemeta::one::HTTP_LOG("The provider named no authorization endpoint, "
+                                "or could not be reached, for the policy",
+                                policy_name);
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
           "urn:sourcemeta:one:auth-provider-unreachable",
@@ -177,9 +175,8 @@ public:
         policy_name, sourcemeta::one::Authentication::Purpose::Transaction,
         payload_text.str(), expiry)};
     if (!sealed.has_value()) {
-      sourcemeta::one::HTTP_LOG(
-          std::string{"No session secret is set for the policy "}.append(
-              policy_name));
+      sourcemeta::one::HTTP_LOG("No session secret is set for the policy",
+                                policy_name);
       sourcemeta::one::json_error(
           request, response,
           sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
@@ -204,10 +201,9 @@ public:
         endpoints.value().authorization, policy->client_id, redirect_uri, state,
         std::string_view{challenge.data(), challenge.size()}, nonce)};
     if (!url.has_value()) {
-      sourcemeta::one::HTTP_LOG(
-          std::string{"The authorization endpoint is not a URL a request can "
-                      "be built against, for the policy "}
-              .append(policy_name));
+      sourcemeta::one::HTTP_LOG("The authorization endpoint is not a URL a "
+                                "request can be built against, for the policy",
+                                policy_name);
       sourcemeta::one::json_error(
           request, response,
           sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
@@ -231,9 +227,8 @@ public:
     // callback, so it is not worth sending
     if (!cookie.has_value()) {
       sourcemeta::one::HTTP_LOG(
-          std::string{"The login transaction could not be put in a cookie, "
-                      "for the policy "}
-              .append(policy_name));
+          "The login transaction could not be put in a cookie, for the policy",
+          policy_name);
       sourcemeta::one::json_error(
           request, response,
           sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
@@ -103,6 +103,9 @@ public:
     // Starting a login that cannot be completed only strands the person at the
     // provider, so the secret the exchange will need is required up front
     if (!authentication.client_secret(policy_name).has_value()) {
+      sourcemeta::one::HTTP_LOG(
+          std::string{"No client secret is set for the policy "}.append(
+              policy_name));
       sourcemeta::one::json_error(
           request, response,
           sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
@@ -114,6 +117,10 @@ public:
 
     const auto endpoints{authentication.endpoints(policy_name)};
     if (!endpoints.has_value() || endpoints.value().authorization.empty()) {
+      sourcemeta::one::HTTP_LOG(
+          std::string{"The provider named no authorization endpoint, or could "
+                      "not be reached, for the policy "}
+              .append(policy_name));
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
           "urn:sourcemeta:one:auth-provider-unreachable",
@@ -170,6 +177,9 @@ public:
         policy_name, sourcemeta::one::Authentication::Purpose::Transaction,
         payload_text.str(), expiry)};
     if (!sealed.has_value()) {
+      sourcemeta::one::HTTP_LOG(
+          std::string{"No session secret is set for the policy "}.append(
+              policy_name));
       sourcemeta::one::json_error(
           request, response,
           sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
@@ -194,6 +204,10 @@ public:
         endpoints.value().authorization, policy->client_id, redirect_uri, state,
         std::string_view{challenge.data(), challenge.size()}, nonce)};
     if (!url.has_value()) {
+      sourcemeta::one::HTTP_LOG(
+          std::string{"The authorization endpoint is not a URL a request can "
+                      "be built against, for the policy "}
+              .append(policy_name));
       sourcemeta::one::json_error(
           request, response,
           sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
@@ -216,6 +230,10 @@ public:
     // A redirect without the transaction cookie could never complete at the
     // callback, so it is not worth sending
     if (!cookie.has_value()) {
+      sourcemeta::one::HTTP_LOG(
+          std::string{"The login transaction could not be put in a cookie, "
+                      "for the policy "}
+              .append(policy_name));
       sourcemeta::one::json_error(
           request, response,
           sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -64,7 +64,7 @@ auto Authentication::interactive(const std::string_view) const
 }
 
 auto Authentication::client_secret(const std::string_view) const
-    -> std::optional<std::string> {
+    -> std::optional<sourcemeta::core::SecureString> {
   return std::nullopt;
 }
 

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -227,7 +227,7 @@ public:
   // environment. Every secret this system holds is read here rather than by
   // whoever needs it, so no caller is in a position to read one differently
   [[nodiscard]] auto client_secret(std::string_view policy) const
-      -> std::optional<std::string>;
+      -> std::optional<sourcemeta::core::SecureString>;
 
   // Recover the payload of a session value, whichever interactive policy
   // minted it, returning nothing when no policy accepts it. A value is only

--- a/src/http/include/sourcemeta/one/http_helpers.h
+++ b/src/http/include/sourcemeta/one/http_helpers.h
@@ -25,12 +25,22 @@
 
 namespace sourcemeta::one {
 
-inline auto HTTP_LOG(const std::string_view message) -> void {
+// A line about something that happened, optionally naming the one value it
+// happened to, such as the policy a failure concerns. Keeping the value apart
+// from the message means neither has to be built into a string to say both
+inline auto HTTP_LOG(const std::string_view message,
+                     const std::string_view value = {}) -> void {
   static std::mutex log_mutex;
   std::scoped_lock guard{log_mutex};
-  std::print(stderr, "[{}] {} {}\n",
-             sourcemeta::core::to_imf_fixdate(std::chrono::system_clock::now()),
-             std::this_thread::get_id(), message);
+  const auto now{
+      sourcemeta::core::to_imf_fixdate(std::chrono::system_clock::now())};
+  if (value.empty()) {
+    std::print(stderr, "[{}] {} {}\n", now, std::this_thread::get_id(),
+               message);
+  } else {
+    std::print(stderr, "[{}] {} {}: {}\n", now, std::this_thread::get_id(),
+               message, value);
+  }
 }
 
 inline auto write_link_header(HTTPResponse &response,


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

