### PR TITLE
Send the client secret in a header where the provider takes one

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,6 +1,6 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
 uwebsockets https://github.com/uNetworking/uWebSockets v20.79.0
-core https://github.com/sourcemeta/core 1ffe47bdda541e13733d61116739f5a8b6092eea
+core https://github.com/sourcemeta/core d014705eb3a23866990065838e657f8c09d3324c
 blaze https://github.com/sourcemeta/blaze ca1949507ea5f4215f9a55ca796cd074602ff705
 jsonbinpack https://github.com/sourcemeta/jsonbinpack f775b2df5fa89d5a70acb940a5c938173811fea7
 jsonschema https://github.com/sourcemeta/jsonschema v16.3.0

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,6 +1,6 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
 uwebsockets https://github.com/uNetworking/uWebSockets v20.79.0
-core https://github.com/sourcemeta/core d014705eb3a23866990065838e657f8c09d3324c
+core https://github.com/sourcemeta/core 8aff35edd5285002de0ac87a2c06fc4bca4b4d5d
 blaze https://github.com/sourcemeta/blaze ca1949507ea5f4215f9a55ca796cd074602ff705
 jsonbinpack https://github.com/sourcemeta/jsonbinpack f775b2df5fa89d5a70acb940a5c938173811fea7
 jsonschema https://github.com/sourcemeta/jsonschema v16.3.0

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -957,6 +957,15 @@ struct Authentication::Impl {
         resolved.end_session = document.value().end_session_endpoint().value();
       }
 
+      // RFC 6749 Section 2.3.1 requires every server to accept the client
+      // secret in an authorization header and discourages carrying it in the
+      // request body, so the body is used only where the header is refused.
+      // A provider that lists nothing is taken to accept the header, which is
+      // what the specification assigns to saying nothing
+      resolved.token_endpoint_basic_auth =
+          document.value().supports_token_endpoint_auth_method(
+              "client_secret_basic");
+
       cached.source = server;
       cached.resolved = std::move(resolved);
     }

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -475,7 +475,7 @@ private:
         sourcemeta::core::SecureString authorization;
         sourcemeta::core::oauth_client_secret_basic(client_id, client_secret,
                                                     authorization);
-        fetch.header("authorization", std::string{authorization});
+        fetch.header("authorization", std::move(authorization));
       } else {
         sourcemeta::core::oauth_client_secret_post(client_id, client_secret,
                                                    body);

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -199,7 +199,8 @@ public:
 
     const auto id_token{this->exchange(
         endpoints.value().token, policy->client_id, client_secret.value(),
-        redirect_uri, code, verifier->to_string())};
+        redirect_uri, code, verifier->to_string(),
+        endpoints.value().token_endpoint_basic_auth)};
     if (!id_token.has_value()) {
       this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_GATEWAY,
                  "urn:sourcemeta:one:auth-exchange-failed",
@@ -449,13 +450,17 @@ private:
     }
   }
 
-  [[nodiscard]] auto exchange(const std::string_view token_endpoint,
-                              const std::string_view client_id,
-                              const std::string_view client_secret,
-                              const std::string_view redirect_uri,
-                              const std::string_view code,
-                              const std::string_view code_verifier) const
-      -> std::optional<std::string> {
+  // RFC 6749 Section 2.3.1 has every server accept the client secret in an
+  // authorization header, and asks that carrying it in the request body be
+  // limited to clients that cannot send one. A body is the part of a request
+  // that logging and proxies keep, while an authorization header is the part
+  // they already know to redact, so the header is used wherever the provider
+  // takes it
+  [[nodiscard]] auto exchange(
+      const std::string_view token_endpoint, const std::string_view client_id,
+      const std::string_view client_secret, const std::string_view redirect_uri,
+      const std::string_view code, const std::string_view code_verifier,
+      const bool basic_auth) const -> std::optional<std::string> {
     try {
       sourcemeta::core::HTTPSystemRequest fetch{
           std::string{token_endpoint}, sourcemeta::core::HTTPMethod::POST};
@@ -466,8 +471,16 @@ private:
       sourcemeta::core::SecureString body;
       sourcemeta::core::oauth_build_token_request_code(code, redirect_uri,
                                                        code_verifier, {}, body);
-      sourcemeta::core::oauth_client_secret_post(client_id, client_secret,
-                                                 body);
+      if (basic_auth) {
+        sourcemeta::core::SecureString authorization;
+        sourcemeta::core::oauth_client_secret_basic(client_id, client_secret,
+                                                    authorization);
+        fetch.header("authorization", std::string{authorization});
+      } else {
+        sourcemeta::core::oauth_client_secret_post(client_id, client_secret,
+                                                   body);
+      }
+
       fetch.body(std::move(body), "application/x-www-form-urlencoded");
       const auto result{fetch.send()};
       if (result.status.code < 200 || result.status.code >= 300) {

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -2174,6 +2174,110 @@ TEST(provider_endpoints_are_retrieved_once_and_reused) {
   EXPECT_EQ(*calls, 1);
 }
 
+TEST(a_provider_naming_no_authentication_method_takes_the_header) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://login.test",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_AUTH_ABSENT",
+        .name = "okta",
+        .session_secret_variable = SESSION_SECRET_VARIABLE}}};
+  const auto path{test_path("oidc_auth_absent.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const std::map<std::string, std::string> responses{
+      {"https://login.test/.well-known/openid-configuration",
+       R"JSON({
+         "issuer": "https://login.test",
+         "authorization_endpoint": "https://login.test/authorize",
+         "token_endpoint": "https://login.test/token",
+         "jwks_uri": "https://login.test/jwks",
+         
+         "response_types_supported": [ "code" ],
+         "subject_types_supported": [ "public" ],
+         "id_token_signing_alg_values_supported": [ "RS256" ]
+       })JSON"}};
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher(responses, nullptr)};
+
+  const auto endpoints{authentication.endpoints("okta")};
+  EXPECT_TRUE(endpoints.has_value());
+  // RFC 8414 Section 2 makes an absent list mean `client_secret_basic`, so
+  // saying nothing is an answer rather than the absence of one
+  EXPECT_TRUE(endpoints.value().token_endpoint_basic_auth);
+}
+
+TEST(a_provider_naming_the_header_takes_the_header) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://login.test",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_AUTH_BASIC",
+        .name = "okta",
+        .session_secret_variable = SESSION_SECRET_VARIABLE}}};
+  const auto path{test_path("oidc_auth_basic.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const std::map<std::string, std::string> responses{
+      {"https://login.test/.well-known/openid-configuration",
+       R"JSON({
+         "issuer": "https://login.test",
+         "authorization_endpoint": "https://login.test/authorize",
+         "token_endpoint": "https://login.test/token",
+         "jwks_uri": "https://login.test/jwks",
+         "token_endpoint_auth_methods_supported": [ "client_secret_basic", "client_secret_post" ],
+         "response_types_supported": [ "code" ],
+         "subject_types_supported": [ "public" ],
+         "id_token_signing_alg_values_supported": [ "RS256" ]
+       })JSON"}};
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher(responses, nullptr)};
+
+  const auto endpoints{authentication.endpoints("okta")};
+  EXPECT_TRUE(endpoints.has_value());
+  // Offering both, the header is the one RFC 6749 Section 2.3.1 asks for
+  EXPECT_TRUE(endpoints.value().token_endpoint_basic_auth);
+}
+
+TEST(a_provider_refusing_the_header_gets_the_body_instead) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://login.test",
+        .client_id = "client",
+        .client_secret_variable = "ONE_TEST_OIDC_AUTH_POST",
+        .name = "okta",
+        .session_secret_variable = SESSION_SECRET_VARIABLE}}};
+  const auto path{test_path("oidc_auth_post.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const std::map<std::string, std::string> responses{
+      {"https://login.test/.well-known/openid-configuration",
+       R"JSON({
+         "issuer": "https://login.test",
+         "authorization_endpoint": "https://login.test/authorize",
+         "token_endpoint": "https://login.test/token",
+         "jwks_uri": "https://login.test/jwks",
+         "token_endpoint_auth_methods_supported": [ "client_secret_post" ],
+         "response_types_supported": [ "code" ],
+         "subject_types_supported": [ "public" ],
+         "id_token_signing_alg_values_supported": [ "RS256" ]
+       })JSON"}};
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher(responses, nullptr)};
+
+  const auto endpoints{authentication.endpoints("okta")};
+  EXPECT_TRUE(endpoints.has_value());
+  // A provider that does not take the header leaves the body as the only way
+  // to authenticate, so the preference gives way rather than the login failing
+  EXPECT_FALSE(endpoints.value().token_endpoint_basic_auth);
+}
+
 TEST(provider_endpoints_of_an_unreachable_provider_are_absent) {
   const auto calls{std::make_shared<int>(0)};
   const std::array<std::string_view, 1> paths{{"/portal"}};

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -212,6 +212,9 @@ public:
     std::string jwks_uri{};
     // Absent from a provider that does not offer to end its own session
     std::string end_session{};
+    // Whether the provider takes the client secret in an authorization header
+    // rather than in the request body
+    bool token_endpoint_basic_auth{true};
   };
 
   // What the named interactive policy's provider says about itself, retrieved

--- a/vendor/core/src/core/http/aws_sigv4.cc
+++ b/vendor/core/src/core/http/aws_sigv4.cc
@@ -53,15 +53,16 @@ auto sorted_headers(
   return entries;
 }
 
-auto append_lowercased(std::string &output, const std::string_view name)
-    -> void {
+template <typename Output>
+auto append_lowercased(Output &output, const std::string_view name) -> void {
   for (const auto character : name) {
     output.push_back(sourcemeta::core::to_lowercase(character));
   }
 }
 
+template <typename Output>
 auto append_canonical_headers(
-    std::string &output,
+    Output &output,
     const std::vector<std::pair<std::string_view, std::string_view>> &entries)
     -> void {
   std::size_t index{0};
@@ -85,8 +86,9 @@ auto append_canonical_headers(
   }
 }
 
+template <typename Output>
 auto append_signed_headers(
-    std::string &output,
+    Output &output,
     const std::vector<std::pair<std::string_view, std::string_view>> &entries)
     -> void {
   std::string_view previous;
@@ -106,7 +108,8 @@ auto append_signed_headers(
   }
 }
 
-auto append_canonical_uri(std::string &output, std::string_view path,
+template <typename Output>
+auto append_canonical_uri(Output &output, std::string_view path,
                           const bool normalize) -> void {
   std::string normalized;
   if (normalize) {
@@ -139,7 +142,8 @@ auto append_canonical_uri(std::string &output, std::string_view path,
   }
 }
 
-auto append_canonical_query(std::string &output, const std::string_view query)
+template <typename Output>
+auto append_canonical_query(Output &output, const std::string_view query)
     -> void {
   if (query.empty()) {
     return;
@@ -182,7 +186,10 @@ auto http_aws_sigv4_canonical_request(
         headers,
     const std::string_view payload_hash, const bool normalize) -> std::string {
   const auto entries{sorted_headers(headers)};
-  std::string result;
+  // A signed header value may live in wiping storage, so the assembly happens
+  // in wiping storage as well, keeping every intermediate growth buffer out
+  // of ordinary freed memory. The single returned copy is the caller's to wipe
+  SecureString result;
   result.append(method);
   result.push_back('\n');
   append_canonical_uri(result, path, normalize);
@@ -194,7 +201,7 @@ auto http_aws_sigv4_canonical_request(
   append_signed_headers(result, entries);
   result.push_back('\n');
   result.append(payload_hash);
-  return result;
+  return std::string{std::string_view{result}};
 }
 
 auto http_aws_sigv4_signed_headers(
@@ -314,12 +321,15 @@ auto HTTPSystemRequest::sign_aws_sigv4(
   }
 
   for (const auto &[name, value] : this->headers_) {
-    headers.emplace_back(name, value);
+    headers.emplace_back(name, value.bytes());
   }
 
-  const auto canonical{http_aws_sigv4_canonical_request(
+  // The canonical request spells out every signed header value, which may
+  // include one held in wiping storage, so it is wiped once consumed
+  auto canonical{http_aws_sigv4_canonical_request(
       http_method_string(this->method_), path, query, headers, payload_hash,
       service != "s3")};
+  const SecureStringScope canonical_scope{canonical};
   const auto scope{http_aws_sigv4_credential_scope(date, region, service)};
   const auto string_to_sign{
       http_aws_sigv4_string_to_sign(amz_date, scope, canonical)};

--- a/vendor/core/src/core/http/client_curl.cc
+++ b/vendor/core/src/core/http/client_curl.cc
@@ -6,6 +6,7 @@
 
 #include <cstddef>     // std::size_t
 #include <cstdint>     // std::uint16_t
+#include <cstring>     // std::strlen
 #include <optional>    // std::optional
 #include <string>      // std::string
 #include <string_view> // std::string_view
@@ -33,7 +34,10 @@ using CURLoption = int;
 using CURLINFO = int;
 using curl_off_t = long long;
 
-struct curl_slist;
+struct curl_slist {
+  char *data;
+  curl_slist *next;
+};
 
 auto curl_global_init(long flags) -> CURLcode;
 auto curl_easy_init() -> CURL *;
@@ -122,6 +126,15 @@ public:
   explicit CurlHeaderList(const CurlApi &api) : api_{api} {}
   ~CurlHeaderList() {
     if (this->list_) {
+      // libcurl duplicates every appended line and does not clear its copy
+      // on release, so wipe each one first to keep a secret header value
+      // out of freed memory
+      for (auto *entry{this->list_}; entry; entry = entry->next) {
+        if (entry->data) {
+          sourcemeta::core::secure_zero(entry->data, std::strlen(entry->data));
+        }
+      }
+
       this->api_.slist_free_all(this->list_);
     }
   }
@@ -349,14 +362,19 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
 
   CurlHeaderList header_list{api};
   for (const auto &[name, value] : this->headers_) {
-    std::string line{name};
+    // Reserve the whole line up front, so appending a possibly secret value
+    // can never reallocate storage that is wiped only at scope exit
+    std::string line;
+    line.reserve(name.size() + value.bytes().size() + 2);
+    const SecureStringScope line_scope{line};
+    line += name;
     // The semicolon form is how cURL distinguishes a header with an
     // empty value from a header to suppress
-    if (value.empty()) {
+    if (value.bytes().empty()) {
       line += ";";
     } else {
       line += ": ";
-      line += value;
+      line += value.bytes();
     }
 
     header_list.append(line);

--- a/vendor/core/src/core/http/client_darwin.mm
+++ b/vendor/core/src/core/http/client_darwin.mm
@@ -136,7 +136,7 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
       for (const auto &[name, value] : this->headers_) {
         // Repeated headers are folded into a single comma-separated field
         // line, which is semantically equivalent per RFC 9110
-        [url_request addValue:to_nsstring(value)
+        [url_request addValue:to_nsstring(value.bytes())
             forHTTPHeaderField:to_nsstring(name)];
       }
 

--- a/vendor/core/src/core/http/client_windows.cc
+++ b/vendor/core/src/core/http/client_windows.cc
@@ -189,7 +189,11 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
   WinHttpSetOption(request_handle.get(), WINHTTP_OPTION_DECOMPRESSION,
                    &decompression, sizeof(decompression));
 
-  auto serialized_headers{http_serialize_headers(this->headers_)};
+  // The possibly secret header lines are appended last, so this buffer never
+  // grows once it holds a secret, which would leave the previous storage in
+  // freed memory without a wipe
+  std::string serialized_headers;
+  const SecureStringScope serialized_headers_scope{serialized_headers};
   LPVOID body_data{WINHTTP_NO_REQUEST_DATA};
   DWORD body_size{0};
   if (this->body_.has_value()) {
@@ -206,16 +210,22 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
     body_size = static_cast<DWORD>(this->body_.value().bytes().size());
   }
 
-  const auto request_headers{
-      sourcemeta::core::utf8_to_wide(serialized_headers)};
+  {
+    auto header_lines{http_serialize_headers(this->headers_)};
+    const SecureStringScope header_lines_scope{header_lines};
+    serialized_headers += header_lines;
+  }
 
-  if (!WinHttpSendRequest(
-          request_handle.get(),
-          request_headers.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS
-                                  : request_headers.c_str(),
-          request_headers.empty() ? 0
-                                  : static_cast<DWORD>(request_headers.size()),
-          body_data, body_size, body_size, 0)) {
+  auto request_headers{sourcemeta::core::utf8_to_wide(serialized_headers)};
+
+  const auto sent{WinHttpSendRequest(
+      request_handle.get(),
+      request_headers.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS
+                              : request_headers.c_str(),
+      request_headers.empty() ? 0 : static_cast<DWORD>(request_headers.size()),
+      body_data, body_size, body_size, 0)};
+  secure_zero(request_headers.data(), request_headers.size() * sizeof(wchar_t));
+  if (!sent) {
     throw HTTPError{this->method_, this->url_,
                     "Failed to send the HTTP request"};
   }

--- a/vendor/core/src/core/http/include/sourcemeta/core/http_message.h
+++ b/vendor/core/src/core/http/include/sourcemeta/core/http_message.h
@@ -350,7 +350,11 @@ inline auto http_serialize_headers(const Headers &headers) -> std::string {
   std::size_t total_size{0};
   for (const auto &[name, value] : headers) {
     // Account for the colon, the space, and the trailing CRLF
-    total_size += name.size() + value.size() + 4;
+    if constexpr (requires { value.bytes(); }) {
+      total_size += name.size() + value.bytes().size() + 4;
+    } else {
+      total_size += name.size() + value.size() + 4;
+    }
   }
 
   std::string result;
@@ -360,7 +364,12 @@ inline auto http_serialize_headers(const Headers &headers) -> std::string {
     // value is preferred for consistent readability by humans"
     result += name;
     result += ": ";
-    result += value;
+    if constexpr (requires { value.bytes(); }) {
+      result += value.bytes();
+    } else {
+      result += value;
+    }
+
     result += "\r\n";
   }
 

--- a/vendor/core/src/core/http/include/sourcemeta/core/http_system.h
+++ b/vendor/core/src/core/http/include/sourcemeta/core/http_system.h
@@ -125,9 +125,37 @@ public:
     return *this;
   }
 
+  /// A request header value, holding ordinary storage for a plain value and
+  /// wiping storage for one set from a secret
+  struct HeaderValue {
+    /// The held bytes. A plain value carries no secret and keeps the ordinary
+    /// string storage, while a value set from wiping storage stays in it, so
+    /// the common request pays nothing and a secret one is never retained in
+    /// an ordinary string
+    std::variant<std::string, SecureString> data;
+
+    /// Get a view of the held bytes
+    [[nodiscard]] auto bytes() const -> std::string_view {
+      return std::visit(
+          [](const auto &value) -> std::string_view { return value; },
+          this->data);
+    }
+  };
+
   /// Add a request header. Repeated names are permitted
   auto header(std::string name, std::string value) -> HTTPSystemRequest & {
-    this->headers_.emplace_back(std::move(name), std::move(value));
+    this->headers_.emplace_back(std::move(name),
+                                HeaderValue{.data = std::move(value)});
+    return *this;
+  }
+
+  /// Add a request header from wiping storage. The value is held in the wiping
+  /// storage so a secret it carries, such as a client credential, is never
+  /// retained in an ordinary string, and the transient serialisation a backend
+  /// builds at send time is wiped
+  auto header(std::string name, SecureString value) -> HTTPSystemRequest & {
+    this->headers_.emplace_back(std::move(name),
+                                HeaderValue{.data = std::move(value)});
     return *this;
   }
 
@@ -146,7 +174,7 @@ public:
       -> std::optional<std::string_view> {
     for (const auto &[key, value] : this->headers_) {
       if (equals_ignore_case(key, name)) {
-        return value;
+        return value.bytes();
       }
     }
 
@@ -255,7 +283,7 @@ private:
 
   std::string url_;
   HTTPMethod method_;
-  std::vector<std::pair<std::string, std::string>> headers_;
+  std::vector<std::pair<std::string, HeaderValue>> headers_;
   std::optional<Body> body_;
   bool follow_redirects_{true};
   std::size_t maximum_redirects_{20};

--- a/vendor/core/src/core/jose/include/sourcemeta/core/jose_jwks_provider.h
+++ b/vendor/core/src/core/jose/include/sourcemeta/core/jose_jwks_provider.h
@@ -67,6 +67,9 @@ public:
     /// identifier.
     std::chrono::seconds unknown_kid_cooldown{std::chrono::minutes{5}};
     /// The tolerance applied to time-based claims, uniform or per claim.
+    /// Unlike the other fields, the default is zero tolerance, so set it
+    /// deliberately when validating tokens minted by a clock that is not
+    /// your own.
     JWTClockSkew clock_skew{};
   };
 

--- a/vendor/core/src/core/jose/include/sourcemeta/core/jose_verify.h
+++ b/vendor/core/src/core/jose/include/sourcemeta/core/jose_verify.h
@@ -228,6 +228,7 @@ enum class JWTVerificationError : std::uint8_t {
 /// #include <array>
 /// #include <cassert>
 /// #include <chrono>
+/// #include <optional>
 /// #include <string>
 ///
 /// const std::string input{
@@ -240,7 +241,8 @@ enum class JWTVerificationError : std::uint8_t {
 /// const std::array allowed{sourcemeta::core::JWSAlgorithm::RS256};
 /// const auto error{sourcemeta::core::jwt_verify(
 ///     token.value(), keys.value(), allowed, "acme", "client",
-///     std::chrono::system_clock::from_time_t(1500000000))};
+///     std::chrono::system_clock::from_time_t(1500000000), {}, std::nullopt,
+///     std::nullopt)};
 /// assert(error.has_value());
 /// ```
 SOURCEMETA_CORE_JOSE_EXPORT

--- a/vendor/core/src/core/oidc/include/sourcemeta/core/oidc_metadata.h
+++ b/vendor/core/src/core/oidc/include/sourcemeta/core/oidc_metadata.h
@@ -138,6 +138,13 @@ public:
   [[nodiscard]] auto supports_response_type(const std::string_view value) const
       -> bool;
 
+  /// Whether a token endpoint authentication method is supported, defaulting
+  /// to `client_secret_basic` when absent (OpenID Connect Discovery 1.0
+  /// Section 3).
+  [[nodiscard]] auto
+  supports_token_endpoint_auth_method(const std::string_view value) const
+      -> bool;
+
   /// Whether a scope is supported (OpenID Connect Discovery 1.0 Section 3).
   [[nodiscard]] auto supports_scope(const std::string_view value) const -> bool;
 

--- a/vendor/core/src/core/oidc/oidc_metadata.cc
+++ b/vendor/core/src/core/oidc/oidc_metadata.cc
@@ -246,6 +246,11 @@ auto OIDCProviderMetadata::supports_response_type(
   return this->oauth_.supports_response_type(value);
 }
 
+auto OIDCProviderMetadata::supports_token_endpoint_auth_method(
+    const std::string_view value) const -> bool {
+  return this->oauth_.supports_token_endpoint_auth_method(value);
+}
+
 auto OIDCProviderMetadata::supports_scope(const std::string_view value) const
     -> bool {
   return this->oauth_.data().array_member_contains(

--- a/vendor/core/src/lang/text/include/sourcemeta/core/text.h
+++ b/vendor/core/src/lang/text/include/sourcemeta/core/text.h
@@ -766,8 +766,8 @@ auto squeeze(const std::string_view input, const char character) -> std::string;
 /// @ingroup text
 ///
 /// Collapse consecutive runs of a character into a single occurrence, appending
-/// the result to an existing string rather than allocating a new one. The
-/// output must not alias the input. For example:
+/// the result to a string like output sink rather than allocating a new
+/// string. The output must not alias the input. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/text.h>
@@ -778,9 +778,23 @@ auto squeeze(const std::string_view input, const char character) -> std::string;
 /// sourcemeta::core::squeeze("a//b", '/', output);
 /// assert(output == "path=a/b");
 /// ```
-SOURCEMETA_CORE_TEXT_EXPORT
-auto squeeze(const std::string_view input, const char character,
-             std::string &output) -> void;
+template <typename Output>
+auto squeeze(const std::string_view input, const char character, Output &output)
+    -> void {
+  bool in_run{false};
+  for (const auto value : input) {
+    if (value == character) {
+      if (!in_run) {
+        output.push_back(value);
+      }
+
+      in_run = true;
+    } else {
+      output.push_back(value);
+      in_run = false;
+    }
+  }
+}
 
 /// @ingroup text
 ///

--- a/vendor/core/src/lang/text/text.cc
+++ b/vendor/core/src/lang/text/text.cc
@@ -174,23 +174,6 @@ auto split_once(const std::string_view input,
   return std::pair{before, after};
 }
 
-auto squeeze(const std::string_view input, const char character,
-             std::string &output) -> void {
-  bool in_run{false};
-  for (const auto value : input) {
-    if (value == character) {
-      if (!in_run) {
-        output.push_back(value);
-      }
-
-      in_run = true;
-    } else {
-      output.push_back(value);
-      in_run = false;
-    }
-  }
-}
-
 auto squeeze(const std::string_view input, const char character)
     -> std::string {
   std::string result;


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

