### PR TITLE
Run Dockerfile `ctest` with the build parallelism number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ RUN cmake --build /build --config ${SOURCEMETA_ONE_BUILD_TYPE} \
 
 # Run a few times to rule out any flakiness
 RUN ctest --test-dir /build --build-config ${SOURCEMETA_ONE_BUILD_TYPE} \
-  --output-on-failure --parallel --repeat-until-fail 5
+  --output-on-failure --parallel ${SOURCEMETA_ONE_PARALLEL} \
+  --repeat-until-fail 5
 
 FROM debian:trixie-slim
 

--- a/enterprise/Dockerfile
+++ b/enterprise/Dockerfile
@@ -87,7 +87,8 @@ RUN cmake --build /build --config ${SOURCEMETA_ONE_BUILD_TYPE} \
 
 # Run a few times to rule out any flakiness
 RUN ctest --test-dir /build --build-config ${SOURCEMETA_ONE_BUILD_TYPE} \
-  --output-on-failure --parallel --repeat-until-fail 5
+  --output-on-failure --parallel ${SOURCEMETA_ONE_PARALLEL} \
+  --repeat-until-fail 5
 
 RUN mkdir -p /usr/share/sourcemeta/one \
   && cd /source && npm sbom --sbom-format spdx --sbom-type library --omit dev \


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

