### PR TITLE
Fix new `shellcheck` linter warnings

### DIFF
--- a/benchmark/index.sh
+++ b/benchmark/index.sh
@@ -2,7 +2,6 @@
 
 set -o errexit
 set -o nounset
-set -o pipefail
 
 if [ "$#" -ne 1 ]
 then
@@ -13,6 +12,13 @@ fi
 INDEX="$1"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 
+# Each case is collected before any of it is summed, so that a case which fails
+# stops the run rather than being summed away into a partial result that reads
+# like a complete one
+RESULTS="$(mktemp)"
+clean() { rm -f "$RESULTS"; }
+trap clean EXIT
+
 {
   "$HERE/index-add-update-rebuild.sh" "$INDEX"
   "$HERE/index-n.sh" "$INDEX" 100
@@ -20,4 +26,6 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
   "$HERE/index-n.sh" "$INDEX" 10000
   "$HERE/index-custom-meta-schema.sh" "$INDEX" 10000
   "$HERE/index-ref-fanout.sh" "$INDEX" 10000
-} | jq --slurp 'add'
+} >> "$RESULTS"
+
+jq --slurp 'add' < "$RESULTS"

--- a/docker/transaction-overlayfs.sh
+++ b/docker/transaction-overlayfs.sh
@@ -90,7 +90,7 @@ TIME_START=$(date +%s%3N)
 # Whiteouts are character devices with major:minor 0:0
 find "$OVERLAY_UPPER" -type c | while read -r WHITEOUT_PATH
 do
-  RELATIVE_PATH="${WHITEOUT_PATH#$OVERLAY_UPPER/}"
+  RELATIVE_PATH="${WHITEOUT_PATH#"$OVERLAY_UPPER"/}"
   rm -rf "${OUTPUT_DIR:?}/$RELATIVE_PATH"
   rm "$WHITEOUT_PATH"
 done


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

