### PR TITLE
Let a browser session reach an MCP tool, not just the gate

### DIFF
--- a/enterprise/e2e/auth-closed/playwright/mcp-session.spec.js
+++ b/enterprise/e2e/auth-closed/playwright/mcp-session.spec.js
@@ -15,17 +15,21 @@ import { createHmac } from 'node:crypto';
 const SESSION_SECRET = 'a-session-signing-secret-for-the-auth-closed-sandbox';
 const SESSION_LABEL = 'sourcemeta/one/session';
 
-function sealSession(payload) {
+function sealSession(payload, secret = SESSION_SECRET) {
   const issued = Math.floor(Date.now() / 1000);
   const expiry = issued + 3600;
   const encoded = Buffer.from(JSON.stringify(payload)).toString('base64url');
   const prefix = `1.${issued}.${expiry}.${encoded}`;
-  const key = createHmac('sha256', SESSION_SECRET).update(SESSION_LABEL).digest();
+  const key = createHmac('sha256', secret).update(SESSION_LABEL).digest();
   const signature = createHmac('sha256', key).update(prefix).digest('base64url');
   return `${prefix}.${signature}`;
 }
 
-const SESSION = sealSession({ policy: 'keycloak', subject: 'jane' });
+// Minted per test rather than once, so that a slow run or a retry cannot drift
+// past the expiry and fail for a reason that has nothing to do with the subject
+function session() {
+  return sealSession({ policy: 'keycloak', subject: 'jane' });
+}
 
 async function mcp(request, body, cookie) {
   return request.post('/self/v1/mcp', {
@@ -52,7 +56,7 @@ test.describe('MCP under a browser session', () => {
         method: 'tools/call',
         params: { name: 'search_schemas', arguments: { q: 'object' } }
       },
-      SESSION
+      session()
     );
 
     expect(response.status()).toBe(200);
@@ -72,10 +76,14 @@ test.describe('MCP under a browser session', () => {
     const listed = await mcp(
       request,
       { jsonrpc: '2.0', id: 2, method: 'resources/list' },
-      SESSION
+      session()
     );
     expect(listed.status()).toBe(200);
-    const resources = (await listed.json()).result.resources;
+    // A refusal arrives as a JSON-RPC error under a 200, so it is named here
+    // rather than surfacing later as a failure to read a field off nothing
+    const listing = await listed.json();
+    expect(listing.error).toBeUndefined();
+    const resources = listing.result.resources;
     expect(resources.length).toBeGreaterThan(0);
 
     const read = await mcp(
@@ -86,7 +94,7 @@ test.describe('MCP under a browser session', () => {
         method: 'resources/read',
         params: { uri: resources[0].uri }
       },
-      SESSION
+      session()
     );
     expect(read.status()).toBe(200);
     const body = await read.json();
@@ -109,19 +117,10 @@ test.describe('MCP under a browser session', () => {
   test('a session forged under another secret is refused', async ({
     request
   }) => {
-    const forged = (() => {
-      const issued = Math.floor(Date.now() / 1000);
-      const encoded = Buffer.from(
-        JSON.stringify({ policy: 'keycloak', subject: 'jane' })
-      ).toString('base64url');
-      const prefix = `1.${issued}.${issued + 3600}.${encoded}`;
-      const key = createHmac('sha256', 'a-secret-nobody-here-signs-with')
-        .update(SESSION_LABEL)
-        .digest();
-      return `${prefix}.${createHmac('sha256', key)
-        .update(prefix)
-        .digest('base64url')}`;
-    })();
+    const forged = sealSession(
+      { policy: 'keycloak', subject: 'jane' },
+      'a-secret-nobody-here-signs-with'
+    );
 
     const response = await mcp(
       request,

--- a/enterprise/e2e/auth-closed/playwright/mcp-session.spec.js
+++ b/enterprise/e2e/auth-closed/playwright/mcp-session.spec.js
@@ -1,0 +1,138 @@
+import { test, expect } from '@playwright/test';
+import { createHmac } from 'node:crypto';
+
+// This instance is gated at the root by all three policy types at once, so
+// every path is covered, including the `/self` schemas the MCP endpoint reads
+// to do its own work. That is what makes it the case worth testing: a browser
+// admitted by its session cookie reaches a tool, and the tool then has to
+// resolve its own envelope schemas on that same caller's behalf. Carrying only
+// the bearer that far would leave a caller who passed the gate refused by the
+// work done behind it, for a credential the gate had already accepted.
+//
+// The session is minted here rather than obtained by signing in, since what is
+// under test is what a session admits once held, not how one is obtained.
+
+const SESSION_SECRET = 'a-session-signing-secret-for-the-auth-closed-sandbox';
+const SESSION_LABEL = 'sourcemeta/one/session';
+
+function sealSession(payload) {
+  const issued = Math.floor(Date.now() / 1000);
+  const expiry = issued + 3600;
+  const encoded = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const prefix = `1.${issued}.${expiry}.${encoded}`;
+  const key = createHmac('sha256', SESSION_SECRET).update(SESSION_LABEL).digest();
+  const signature = createHmac('sha256', key).update(prefix).digest('base64url');
+  return `${prefix}.${signature}`;
+}
+
+const SESSION = sealSession({ policy: 'keycloak', subject: 'jane' });
+
+async function mcp(request, body, cookie) {
+  return request.post('/self/v1/mcp', {
+    headers: {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      'mcp-protocol-version': '2025-11-25',
+      ...(cookie ? { cookie: `sourcemeta_one_session=${cookie}` } : {})
+    },
+    data: body,
+    failOnStatusCode: false
+  });
+}
+
+test.describe('MCP under a browser session', () => {
+  test('a session admits a tool call, arguments and all', async ({
+    request
+  }) => {
+    const response = await mcp(
+      request,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'search_schemas', arguments: { q: 'object' } }
+      },
+      SESSION
+    );
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    // A tool that ran. Not an authentication refusal, and not the internal
+    // error that resolving its own schemas on a bearer-only credential used to
+    // produce for a caller holding a cookie instead
+    expect(body.error).toBeUndefined();
+    expect(body.result).toBeDefined();
+    expect(body.result.isError).toBeFalsy();
+    expect(body.result.structuredContent).toBeDefined();
+  });
+
+  test('a session reads a resource', async ({ request }) => {
+    // `resources/read` resolves an artifact on the caller's behalf, which is
+    // the other place the credential has to reach
+    const listed = await mcp(
+      request,
+      { jsonrpc: '2.0', id: 2, method: 'resources/list' },
+      SESSION
+    );
+    expect(listed.status()).toBe(200);
+    const resources = (await listed.json()).result.resources;
+    expect(resources.length).toBeGreaterThan(0);
+
+    const read = await mcp(
+      request,
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'resources/read',
+        params: { uri: resources[0].uri }
+      },
+      SESSION
+    );
+    expect(read.status()).toBe(200);
+    const body = await read.json();
+    expect(body.error).toBeUndefined();
+    expect(body.result.contents.length).toBeGreaterThan(0);
+  });
+
+  test('a caller with no credential is still refused', async ({ request }) => {
+    // The gate is what this instance is for, so admitting a cookie must not
+    // have admitted everybody
+    const response = await mcp(request, {
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: { name: 'search_schemas', arguments: { q: 'object' } }
+    });
+    expect(response.status()).toBe(401);
+  });
+
+  test('a session forged under another secret is refused', async ({
+    request
+  }) => {
+    const forged = (() => {
+      const issued = Math.floor(Date.now() / 1000);
+      const encoded = Buffer.from(
+        JSON.stringify({ policy: 'keycloak', subject: 'jane' })
+      ).toString('base64url');
+      const prefix = `1.${issued}.${issued + 3600}.${encoded}`;
+      const key = createHmac('sha256', 'a-secret-nobody-here-signs-with')
+        .update(SESSION_LABEL)
+        .digest();
+      return `${prefix}.${createHmac('sha256', key)
+        .update(prefix)
+        .digest('base64url')}`;
+    })();
+
+    const response = await mcp(
+      request,
+      {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: { name: 'search_schemas', arguments: { q: 'object' } }
+      },
+      forged
+    );
+    expect(response.status()).toBe(401);
+  });
+});

--- a/enterprise/e2e/auth-closed/playwright/playwright.config.js
+++ b/enterprise/e2e/auth-closed/playwright/playwright.config.js
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// See https://playwright.dev/docs/test-configuration
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'list',
+  outputDir: '../../../../build/test-results',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL,
+    trace: 'on-first-retry',
+    // The identity provider's certificate chains to a sandbox-local authority
+    // the browser does not know, so certificate errors are tolerated here
+    // while the registry container verifies the chain for real
+    ignoreHTTPSErrors: true
+  },
+  // Chromium only: the OIDC redirect chain relies on a Chromium-specific
+  // host resolver rule, so the suite never runs under Firefox or WebKit
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Keycloak advertises itself as `keycloak:8443` (its KC_HOSTNAME), so
+        // the browser must resolve that container name to the mapped local
+        // port to follow the OIDC redirect, exactly as a developer would via
+        // /etc/hosts
+        launchOptions: {
+          args: ['--host-resolver-rules=MAP keycloak 127.0.0.1']
+        }
+      }
+    }
+  ]
+});

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -316,7 +316,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
@@ -251,7 +251,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_logout_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_logout_v1.h
@@ -110,7 +110,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_jsonschema_rdf_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_jsonschema_rdf_v1.h
@@ -338,11 +338,11 @@ public:
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
            const sourcemeta::core::JSON &arguments,
-           const std::string_view credential)
+           const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate({.bearer = credential}, this->rpc_request_schema_,
-                              arguments, sourcemeta::blaze::Mode::Exhaustive)};
+        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
+                              sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",
@@ -351,9 +351,9 @@ public:
 
     const auto &schema_uri{arguments.at("schema").to_string()};
     const auto schema_present{this->artifact_resolve_path(
-        {.bearer = credential}, schema_uri, Tree::Schemas, "schema")};
+        credentials, schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
-        {.bearer = credential}, schema_uri, Tree::Schemas, "blaze-exhaustive")};
+        credentials, schema_uri, Tree::Schemas, "blaze-exhaustive")};
     if (schema_present.outcome ==
             sourcemeta::one::ArtifactResolution::Outcome::Denied ||
         evaluation_enabled.outcome ==
@@ -412,8 +412,7 @@ public:
       auto payload{sourcemeta::core::JSON::make_object()};
       payload.assign("valid", sourcemeta::core::JSON{false});
       payload.assign("errors",
-                     this->schema_evaluate({.bearer = credential}, schema_uri,
-                                           instance,
+                     this->schema_evaluate(credentials, schema_uri, instance,
                                            sourcemeta::blaze::Mode::Exhaustive)
                          .second.at("errors"));
       return sourcemeta::core::mcp_make_tool_success(version, request_id,

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
@@ -217,6 +217,7 @@ public:
 
     request.body(
         [this, credential = std::string{credential},
+         cookies = sourcemeta::one::owned_cookies(request),
          version = negotiated_version.value()](
             sourcemeta::one::HTTPRequest &callback_request,
             sourcemeta::one::HTTPResponse &callback_response,
@@ -230,8 +231,10 @@ public:
                 version);
             return;
           }
+          const sourcemeta::one::RequestCookies fields{cookies};
           this->on_message(version, callback_request, callback_response,
-                           std::move(body), credential);
+                           std::move(body),
+                           {.bearer = credential, .cookies = fields});
         },
         [this, version = negotiated_version.value()](
             sourcemeta::one::HTTPRequest &callback_request,
@@ -250,7 +253,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 
@@ -305,7 +309,7 @@ private:
   }
 
   auto on_resources_list(const sourcemeta::core::JSON &request_json,
-                         const std::string_view credential)
+                         const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON {
     const auto &id{request_json.at("id")};
 
@@ -337,12 +341,11 @@ private:
     std::uint64_t admitted{0};
     this->search_view_.for_each(
         0, this->search_view_.count(),
-        [this, credential, &authentication, &resources, &admitted,
+        [this, &credentials, &authentication, &resources, &admitted,
          offset](const sourcemeta::one::SearchListEntry &entry) -> void {
           const auto location{this->canonical_path(entry.path)};
           if (!location.has_value() ||
-              !authentication.admits(location.value(), {.bearer = credential})
-                   .allowed) {
+              !authentication.admits(location.value(), credentials).allowed) {
             return;
           }
 
@@ -438,7 +441,7 @@ private:
   }
 
   auto on_resources_read(const sourcemeta::core::JSON &request_json,
-                         std::string_view credential) const
+                         const sourcemeta::one::Credentials &credentials) const
       -> sourcemeta::core::JSON {
     const auto &id{request_json.at("id")};
     const auto &uri{request_json.at("params").at("uri").to_string()};
@@ -486,9 +489,8 @@ private:
           "Resource not found");
     }
 
-    const auto resolution{
-        this->artifact_resolve_path({.bearer = credential}, uri, Tree::Schemas,
-                                    bundle ? "bundle" : "schema")};
+    const auto resolution{this->artifact_resolve_path(
+        credentials, uri, Tree::Schemas, bundle ? "bundle" : "schema")};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       return sourcemeta::core::jsonrpc_make_error(&id, -32010,
@@ -520,7 +522,8 @@ private:
 
   auto on_tools_call(const sourcemeta::core::MCPProtocolVersion version,
                      const sourcemeta::core::JSON &request_json,
-                     std::string_view credential) -> sourcemeta::core::JSON {
+                     const sourcemeta::one::Credentials &credentials)
+      -> sourcemeta::core::JSON {
     const auto &id{request_json.at("id")};
     const auto &name{request_json.at("params").at("name").to_string()};
     const auto &tool_routes{this->mcp_metadata_.at("toolRoutes")};
@@ -543,7 +546,7 @@ private:
     try {
       return instance->mcp(version, id,
                            arguments == nullptr ? empty_arguments : *arguments,
-                           credential);
+                           credentials);
     } catch (const std::exception &error) {
       return sourcemeta::core::mcp_make_tool_error(id, error.what());
     }
@@ -552,7 +555,7 @@ private:
   auto on_message(const sourcemeta::core::MCPProtocolVersion version,
                   sourcemeta::one::HTTPRequest &request,
                   sourcemeta::one::HTTPResponse &response, std::string &&body,
-                  std::string_view credential) -> void {
+                  const sourcemeta::one::Credentials &credentials) -> void {
     sourcemeta::core::JSON request_json{nullptr};
     try {
       request_json = sourcemeta::core::parse_json(body);
@@ -596,7 +599,7 @@ private:
           sub_id = *parsed_id;
         }
         try {
-          auto envelope{this->process_one(version, sub, credential)};
+          auto envelope{this->process_one(version, sub, credentials)};
           if (envelope.has_value()) {
             responses.push_back(std::move(envelope).value());
           }
@@ -629,7 +632,7 @@ private:
       return;
     }
 
-    auto envelope{this->process_one(version, request_json, credential)};
+    auto envelope{this->process_one(version, request_json, credentials)};
     if (envelope.has_value()) {
       this->write_envelope(request, response, sourcemeta::core::HTTP_STATUS_OK,
                            envelope.value(), version);
@@ -649,7 +652,7 @@ private:
 
   auto process_one(const sourcemeta::core::MCPProtocolVersion version,
                    const sourcemeta::core::JSON &request_json,
-                   std::string_view credential)
+                   const sourcemeta::one::Credentials &credentials)
       -> std::optional<sourcemeta::core::JSON> {
     if (sourcemeta::core::jsonrpc_is_notification(request_json)) {
       return std::nullopt;
@@ -669,8 +672,8 @@ private:
     // §4 only calls null-id "discouraged" (technically valid). Sourcemeta One
     // follows MCP's tighter rule and rejects null-id requests here.
     // https://www.jsonrpc.org/specification (§4)
-    if (!this->schema_evaluate_fast({.bearer = credential},
-                                    this->request_schema_, request_json)) {
+    if (!this->schema_evaluate_fast(credentials, this->request_schema_,
+                                    request_json)) {
       return sourcemeta::core::jsonrpc_make_error_invalid_request(id);
     }
     if (method == sourcemeta::core::MCP_METHOD_INITIALIZE) {
@@ -680,13 +683,13 @@ private:
       return this->on_tools_list(version, request_json);
     }
     if (method == sourcemeta::core::MCP_METHOD_RESOURCES_LIST) {
-      return this->on_resources_list(request_json, credential);
+      return this->on_resources_list(request_json, credentials);
     }
     if (method == sourcemeta::core::MCP_METHOD_RESOURCES_READ) {
-      return this->on_resources_read(request_json, credential);
+      return this->on_resources_read(request_json, credentials);
     }
     if (method == sourcemeta::core::MCP_METHOD_TOOLS_CALL) {
-      return this->on_tools_call(version, request_json, credential);
+      return this->on_tools_call(version, request_json, credentials);
     }
     if (this->mcp_metadata_.defines(method)) {
       return sourcemeta::core::jsonrpc_make_success(

--- a/src/actions/action_auth_callback_v1.h
+++ b/src/actions/action_auth_callback_v1.h
@@ -80,7 +80,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/src/actions/action_auth_login_v1.h
+++ b/src/actions/action_auth_login_v1.h
@@ -80,7 +80,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/src/actions/action_auth_logout_v1.h
+++ b/src/actions/action_auth_logout_v1.h
@@ -78,7 +78,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/src/actions/action_default_v1.h
+++ b/src/actions/action_default_v1.h
@@ -241,7 +241,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/src/actions/action_dependency_tree_v1.h
+++ b/src/actions/action_dependency_tree_v1.h
@@ -107,11 +107,12 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
-           const sourcemeta::core::JSON &arguments, std::string_view credential)
+           const sourcemeta::core::JSON &arguments,
+           const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate({.bearer = credential}, this->rpc_request_schema_,
-                              arguments, sourcemeta::blaze::Mode::Exhaustive)};
+        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
+                              sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",
@@ -119,8 +120,8 @@ public:
     }
 
     const auto resolution{this->artifact_resolve_path(
-        {.bearer = credential}, arguments.at("schema").to_string(),
-        Tree::Schemas, this->metapack_)};
+        credentials, arguments.at("schema").to_string(), Tree::Schemas,
+        this->metapack_)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       return sourcemeta::core::mcp_make_tool_error(request_id,

--- a/src/actions/action_health_check_v1.h
+++ b/src/actions/action_health_check_v1.h
@@ -68,7 +68,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/src/actions/action_jsonschema_evaluate_v1.h
+++ b/src/actions/action_jsonschema_evaluate_v1.h
@@ -77,11 +77,12 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
-           const sourcemeta::core::JSON &arguments, std::string_view credential)
+           const sourcemeta::core::JSON &arguments,
+           const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate({.bearer = credential}, this->rpc_request_schema_,
-                              arguments, sourcemeta::blaze::Mode::Exhaustive)};
+        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
+                              sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",
@@ -90,9 +91,9 @@ public:
 
     const auto &schema_uri{arguments.at("schema").to_string()};
     const auto schema_present{this->artifact_resolve_path(
-        {.bearer = credential}, schema_uri, Tree::Schemas, "schema")};
+        credentials, schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
-        {.bearer = credential}, schema_uri, Tree::Schemas, "blaze-exhaustive")};
+        credentials, schema_uri, Tree::Schemas, "blaze-exhaustive")};
     if (schema_present.outcome ==
             sourcemeta::one::ArtifactResolution::Outcome::Denied ||
         evaluation_enabled.outcome ==
@@ -126,8 +127,7 @@ public:
 
     return sourcemeta::core::mcp_make_tool_success(
         version, request_id,
-        this->schema_evaluate({.bearer = credential}, schema_uri,
-                              parsed_instance,
+        this->schema_evaluate(credentials, schema_uri, parsed_instance,
                               sourcemeta::blaze::Mode::Exhaustive)
             .second);
   }

--- a/src/actions/action_jsonschema_rdf_v1.h
+++ b/src/actions/action_jsonschema_rdf_v1.h
@@ -87,7 +87,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/src/actions/action_jsonschema_serve_v1.h
+++ b/src/actions/action_jsonschema_serve_v1.h
@@ -106,7 +106,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/src/actions/action_jsonschema_trace_v1.h
+++ b/src/actions/action_jsonschema_trace_v1.h
@@ -89,11 +89,12 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
-           const sourcemeta::core::JSON &arguments, std::string_view credential)
+           const sourcemeta::core::JSON &arguments,
+           const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate({.bearer = credential}, this->rpc_request_schema_,
-                              arguments, sourcemeta::blaze::Mode::Exhaustive)};
+        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
+                              sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",
@@ -102,9 +103,9 @@ public:
 
     const auto &schema_uri{arguments.at("schema").to_string()};
     const auto schema_present{this->artifact_resolve_path(
-        {.bearer = credential}, schema_uri, Tree::Schemas, "schema")};
+        credentials, schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
-        {.bearer = credential}, schema_uri, Tree::Schemas, "blaze-exhaustive")};
+        credentials, schema_uri, Tree::Schemas, "blaze-exhaustive")};
     if (schema_present.outcome ==
             sourcemeta::one::ArtifactResolution::Outcome::Denied ||
         evaluation_enabled.outcome ==
@@ -140,8 +141,8 @@ public:
 
     return sourcemeta::core::mcp_make_tool_success(
         version, request_id,
-        this->trace({.bearer = credential}, schema_uri, parsed_instance,
-                    &tracker, sourcemeta::core::Pointer{}));
+        this->trace(credentials, schema_uri, parsed_instance, &tracker,
+                    sourcemeta::core::Pointer{}));
   }
 
 private:

--- a/src/actions/action_list_directory_v1.h
+++ b/src/actions/action_list_directory_v1.h
@@ -86,11 +86,12 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
-           const sourcemeta::core::JSON &arguments, std::string_view credential)
+           const sourcemeta::core::JSON &arguments,
+           const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate({.bearer = credential}, this->rpc_request_schema_,
-                              arguments, sourcemeta::blaze::Mode::Exhaustive)};
+        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
+                              sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",
@@ -100,7 +101,7 @@ public:
     static const sourcemeta::core::JSON EMPTY_STRING{""};
     const auto &path_arg{arguments.at_or("path", EMPTY_STRING).to_string()};
     const auto resolution{this->artifact_resolve_path(
-        {.bearer = credential}, path_arg, Tree::Explorer, "directory")};
+        credentials, path_arg, Tree::Explorer, "directory")};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       return sourcemeta::core::mcp_make_tool_error(request_id,

--- a/src/actions/action_mcp_v1.h
+++ b/src/actions/action_mcp_v1.h
@@ -317,7 +317,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/src/actions/action_not_found_v1.h
+++ b/src/actions/action_not_found_v1.h
@@ -49,7 +49,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/src/actions/action_schema_search_v1.h
+++ b/src/actions/action_schema_search_v1.h
@@ -215,11 +215,12 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
-           const sourcemeta::core::JSON &arguments, std::string_view credential)
+           const sourcemeta::core::JSON &arguments,
+           const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate({.bearer = credential}, this->rpc_request_schema_,
-                              arguments, sourcemeta::blaze::Mode::Exhaustive)};
+        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
+                              sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",
@@ -289,12 +290,11 @@ public:
 
     auto results{this->search_view_.search(
         arguments.at("q").to_string(), limit, scope,
-        [this, &credential](const std::string_view path) -> bool {
+        [this, &credentials](const std::string_view path) -> bool {
           const auto &authentication{this->dispatcher().authentication()};
           const auto location{this->canonical_path(path)};
           return location.has_value() &&
-                 authentication.admits(location.value(), {.bearer = credential})
-                     .allowed;
+                 authentication.admits(location.value(), credentials).allowed;
         })};
     auto envelope{sourcemeta::core::JSON::make_object()};
     envelope.assign_assume_new("results", std::move(results));

--- a/src/actions/action_serve_explorer_artifact_v1.h
+++ b/src/actions/action_serve_explorer_artifact_v1.h
@@ -96,11 +96,12 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
-           const sourcemeta::core::JSON &arguments, std::string_view credential)
+           const sourcemeta::core::JSON &arguments,
+           const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate({.bearer = credential}, this->rpc_request_schema_,
-                              arguments, sourcemeta::blaze::Mode::Exhaustive)};
+        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
+                              sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",
@@ -108,8 +109,8 @@ public:
     }
 
     const auto resolution{this->artifact_resolve_path(
-        {.bearer = credential}, arguments.at("schema").to_string(),
-        Tree::Explorer, this->artifact_)};
+        credentials, arguments.at("schema").to_string(), Tree::Explorer,
+        this->artifact_)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       return sourcemeta::core::mcp_make_tool_error(request_id,

--- a/src/actions/action_serve_schema_artifact_v1.h
+++ b/src/actions/action_serve_schema_artifact_v1.h
@@ -103,11 +103,12 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
-           const sourcemeta::core::JSON &arguments, std::string_view credential)
+           const sourcemeta::core::JSON &arguments,
+           const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate({.bearer = credential}, this->rpc_request_schema_,
-                              arguments, sourcemeta::blaze::Mode::Exhaustive)};
+        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
+                              sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",
@@ -115,8 +116,8 @@ public:
     }
 
     const auto resolution{this->artifact_resolve_path(
-        {.bearer = credential}, arguments.at("schema").to_string(),
-        Tree::Schemas, this->artifact_)};
+        credentials, arguments.at("schema").to_string(), Tree::Schemas,
+        this->artifact_)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       return sourcemeta::core::mcp_make_tool_error(request_id,

--- a/src/actions/action_serve_static_v1.h
+++ b/src/actions/action_serve_static_v1.h
@@ -99,7 +99,8 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           std::string_view) -> sourcemeta::core::JSON override {
+           const sourcemeta::one::Credentials &)
+      -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -132,10 +132,14 @@ public:
                     std::string_view credential, HTTPRequest &request,
                     HTTPResponse &response) -> void = 0;
 
+  // The whole credential rather than the bearer alone, since a browser reaching
+  // a tool is admitted by its session cookie and would otherwise pass the gate
+  // and then be refused by whatever the tool resolves on its behalf
   virtual auto mcp(const sourcemeta::core::MCPProtocolVersion version,
                    const sourcemeta::core::JSON &id,
                    const sourcemeta::core::JSON &arguments,
-                   std::string_view credential) -> sourcemeta::core::JSON = 0;
+                   const Credentials &credentials)
+      -> sourcemeta::core::JSON = 0;
 
   // Whether this route stays reachable no matter which policies cover its path.
   // A route that a caller must reach in order to establish authentication


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

