### PR TITLE
Resolve the instance's own schemas without the caller's credential

### DIFF
--- a/enterprise/e2e/auth-closed/environment
+++ b/enterprise/e2e/auth-closed/environment
@@ -1,3 +1,4 @@
 ONE_E2E_FULL_KEY=full-secret-key
+ONE_E2E_MCP_KEY=mcp-secret-key
 ONE_E2E_OIDC_CLIENT_SECRET=registry-client-secret
 ONE_E2E_OIDC_SESSION_SECRET=a-session-signing-secret-for-the-auth-closed-sandbox

--- a/enterprise/e2e/auth-closed/hurl/mcp-scoped.all.hurl
+++ b/enterprise/e2e/auth-closed/hurl/mcp-scoped.all.hurl
@@ -1,0 +1,339 @@
+# A policy may be narrower than the whole instance, and the `mcp` policy here
+# governs the MCP endpoint alone while `registry` governs everything. A key
+# from the narrow policy therefore opens the transport without opening the
+# schema surface, and every JSON-RPC message it sends still has to be checked
+# for well-formedness against a schema that lives on that closed surface.
+# Checking it as if the caller had asked for it refused the instance its own
+# bookkeeping and aborted the process, so a bare ping on this key was enough to
+# take the server down. The instance owns those schemas rather than serving
+# them here, and this file holds that apart: the narrow key is answered, the
+# closed surface stays closed to it, and malformed messages are still rejected.
+
+# The narrow key cannot read the schema surface, which is what makes the rest
+# of this file meaningful rather than incidental
+GET {{base}}/self/v1/schemas/mcp/request
+Authorization: Bearer mcp-secret-key
+HTTP 401
+Cache-Control: no-store
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+Link: </self/v1/schemas/api/error>; rel="describedby"
+Access-Control-Allow-Origin: *
+[Captures]
+denied_body: body
+error_schema: header "Link" regex "<([^>]+)>"
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}
+
+# The round-trip runs on the wide key, since the evaluate endpoint is itself
+# behind the policy that closes the instance
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+Authorization: Bearer full-secret-key
+```
+{{denied_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# A bare ping is the whole regression: it names no schema and reads no
+# content, and it once aborted the process
+POST {{base}}/self/v1/mcp
+Authorization: Bearer mcp-secret-key
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{ "jsonrpc": "2.0", "id": 1, "method": "ping" }
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+Access-Control-Expose-Headers: Link, ETag
+[Captures]
+ping_body: body
+mcp_schema: header "Link" regex "<([^>]+)>"
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {}
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{mcp_schema}}
+Authorization: Bearer full-secret-key
+```
+{{ping_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# The handshake answers on the narrow key too
+POST {{base}}/self/v1/mcp
+Authorization: Bearer mcp-secret-key
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{ "jsonrpc": "2.0", "id": 2, "method": "initialize", "params": { "protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": { "name": "scoped", "version": "1" } } }
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+[Captures]
+initialize_body: body
+[Asserts]
+jsonpath "$.error" not exists
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 2
+jsonpath "$.result.protocolVersion" == "2025-11-25"
+jsonpath "$.result.capabilities.resources" exists
+jsonpath "$.result.capabilities.tools" exists
+jsonpath "$.result.serverInfo.name" == "sourcemeta-one-enterprise"
+jsonpath "$.result.serverInfo.title" == "Sourcemeta One Enterprise"
+jsonpath "$.result.serverInfo.websiteUrl" == "{{base}}"
+jsonpath "$.result.instructions" contains "Fully Private Sandbox"
+
+POST {{base}}/self/v1/api/schemas/evaluate{{mcp_schema}}
+Authorization: Bearer full-secret-key
+```
+{{initialize_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# The tool list is the instance's own description of itself rather than
+# catalog content, so the narrow key sees all of it
+POST {{base}}/self/v1/mcp
+Authorization: Bearer mcp-secret-key
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{ "jsonrpc": "2.0", "id": 3, "method": "tools/list" }
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+[Captures]
+tools_body: body
+[Asserts]
+jsonpath "$.error" not exists
+jsonpath "$.jsonrpc" == "2.0"
+jsonpath "$.id" == 3
+jsonpath "$.result.tools" count == 12
+jsonpath "$.result.tools[*].name" includes "list_directory"
+jsonpath "$.result.tools[*].name" includes "search_schemas"
+jsonpath "$.result.tools[*].name" includes "evaluate_schema"
+jsonpath "$.result.tools[*].name" includes "trace_schema_evaluation"
+jsonpath "$.result.tools[*].name" includes "instance_to_rdf"
+jsonpath "$.result.tools[*].name" includes "get_schema_metadata"
+jsonpath "$.result.tools[*].name" includes "get_schema_dependencies"
+jsonpath "$.result.tools[*].name" includes "get_schema_dependents"
+jsonpath "$.result.tools[*].name" includes "get_schema_health"
+jsonpath "$.result.tools[*].name" includes "get_schema_locations"
+jsonpath "$.result.tools[*].name" includes "get_schema_positions"
+jsonpath "$.result.tools[*].name" includes "get_schema_stats"
+
+POST {{base}}/self/v1/api/schemas/evaluate{{mcp_schema}}
+Authorization: Bearer full-secret-key
+```
+{{tools_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# Answering the transport is not the same as opening the catalog. Every schema
+# on this instance sits behind the wide policy, so the narrow key enumerates
+# nothing and the empty list is the whole body
+POST {{base}}/self/v1/mcp
+Authorization: Bearer mcp-secret-key
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{ "jsonrpc": "2.0", "id": 4, "method": "resources/list" }
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+[Captures]
+resources_body: body
+[Asserts]
+jsonpath "$.result.nextCursor" not exists
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "resources": []
+  }
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{mcp_schema}}
+Authorization: Bearer full-secret-key
+```
+{{resources_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# Naming a gated schema outright is refused rather than served
+POST {{base}}/self/v1/mcp
+Authorization: Bearer mcp-secret-key
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{ "jsonrpc": "2.0", "id": 5, "method": "resources/read", "params": { "uri": "{{base}}/catalog/classified" } }
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+[Captures]
+read_body: body
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "error": {
+    "code": -32010,
+    "message": "Authentication required"
+  }
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{mcp_schema}}
+Authorization: Bearer full-secret-key
+```
+{{read_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# A tool that walks the catalog is refused the same way, as a tool result
+# rather than a protocol error
+POST {{base}}/self/v1/mcp
+Authorization: Bearer mcp-secret-key
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{ "jsonrpc": "2.0", "id": 6, "method": "tools/call", "params": { "name": "list_directory", "arguments": { "path": "/" } } }
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+[Captures]
+call_body: body
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Authentication required"
+      }
+    ],
+    "isError": true
+  }
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{mcp_schema}}
+Authorization: Bearer full-secret-key
+```
+{{call_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# Resolving those schemas apart from the caller must not stop them being
+# applied, so a message the protocol forbids is still refused on the narrow key
+POST {{base}}/self/v1/mcp
+Authorization: Bearer mcp-secret-key
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{ "jsonrpc": "2.0", "id": null, "method": "ping" }
+```
+HTTP 200
+Cache-Control: no-store
+Content-Type: application/json
+Link: </self/v1/schemas/mcp/response>; rel="describedby"
+[Captures]
+malformed_body: body
+{
+  "jsonrpc": "2.0",
+  "id": null,
+  "error": {
+    "code": -32600,
+    "message": "Invalid Request"
+  }
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{mcp_schema}}
+Authorization: Bearer full-secret-key
+```
+{{malformed_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# A credential belonging to no policy is still refused at the transport
+POST {{base}}/self/v1/mcp
+Authorization: Bearer not-any-key
+MCP-Protocol-Version: 2025-11-25
+Content-Type: application/json
+```
+{ "jsonrpc": "2.0", "id": 7, "method": "ping" }
+```
+HTTP 401
+Cache-Control: no-store
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="registry"
+Link: </self/v1/schemas/api/error>; rel="describedby"
+[Captures]
+wrong_body: body
+{
+  "type": "urn:sourcemeta:one:authentication-required",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "This resource requires authentication"
+}
+
+POST {{base}}/self/v1/api/schemas/evaluate{{error_schema}}
+Authorization: Bearer full-secret-key
+```
+{{wrong_body}}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.valid" == true
+
+# The narrow policy reaches its own endpoint and no further, so the key that
+# opens the transport does not open a sibling surface
+GET {{base}}/self/v1/static/style.min.css
+Authorization: Bearer mcp-secret-key
+HTTP 401
+Cache-Control: no-store
+WWW-Authenticate: Bearer realm="registry"
+[Asserts]
+jsonpath "$.type" == "urn:sourcemeta:one:authentication-required"
+jsonpath "$.status" == 401
+
+GET {{base}}/catalog/example.json
+Authorization: Bearer mcp-secret-key
+HTTP 401
+Cache-Control: no-store
+WWW-Authenticate: Bearer realm="registry"
+[Asserts]
+jsonpath "$.type" == "urn:sourcemeta:one:authentication-required"
+jsonpath "$.status" == 401

--- a/enterprise/e2e/auth-closed/one.json
+++ b/enterprise/e2e/auth-closed/one.json
@@ -13,6 +13,13 @@
       "keys": [ { "environmentVariable": "ONE_E2E_FULL_KEY" } ]
     },
     {
+      "type": "apiKey",
+      "algorithm": "identity",
+      "name": "mcp",
+      "paths": [ "/self/v1/mcp" ],
+      "keys": [ { "environmentVariable": "ONE_E2E_MCP_KEY" } ]
+    },
+    {
       "type": "jwt",
       "name": "machine",
       "paths": [ "/" ],

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_jsonschema_rdf_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_jsonschema_rdf_v1.h
@@ -210,8 +210,8 @@ public:
           }
 
           const sourcemeta::one::RequestCookies fields{cookies};
-          if (!this->schema_evaluate_fast({.bearer = bearer, .cookies = fields},
-                                          this->request_schema_, envelope)) {
+          if (!this->structural_evaluate_fast(this->request_schema_,
+                                              envelope)) {
             sourcemeta::one::json_error(
                 callback_request, callback_response,
                 sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
@@ -341,8 +341,8 @@ public:
            const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
-                              sourcemeta::blaze::Mode::Exhaustive)};
+        this->structural_evaluate(this->rpc_request_schema_, arguments,
+                                  sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
@@ -676,8 +676,7 @@ private:
     // §4 only calls null-id "discouraged" (technically valid). Sourcemeta One
     // follows MCP's tighter rule and rejects null-id requests here.
     // https://www.jsonrpc.org/specification (§4)
-    if (!this->schema_evaluate_fast(credentials, this->request_schema_,
-                                    request_json)) {
+    if (!this->structural_evaluate_fast(this->request_schema_, request_json)) {
       return sourcemeta::core::jsonrpc_make_error_invalid_request(id);
     }
     if (method == sourcemeta::core::MCP_METHOD_INITIALIZE) {

--- a/src/actions/action_dependency_tree_v1.h
+++ b/src/actions/action_dependency_tree_v1.h
@@ -111,8 +111,8 @@ public:
            const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
-                              sourcemeta::blaze::Mode::Exhaustive)};
+        this->structural_evaluate(this->rpc_request_schema_, arguments,
+                                  sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",

--- a/src/actions/action_jsonschema_evaluate_v1.h
+++ b/src/actions/action_jsonschema_evaluate_v1.h
@@ -81,8 +81,8 @@ public:
            const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
-                              sourcemeta::blaze::Mode::Exhaustive)};
+        this->structural_evaluate(this->rpc_request_schema_, arguments,
+                                  sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",
@@ -286,8 +286,7 @@ public:
           }
 
           const sourcemeta::one::RequestCookies fields{cookies};
-          if (!self.schema_evaluate_fast({.bearer = bearer, .cookies = fields},
-                                         request_schema, instance)) {
+          if (!self.structural_evaluate_fast(request_schema, instance)) {
             sourcemeta::one::json_error(
                 callback_request, callback_response,
                 sourcemeta::core::HTTP_STATUS_BAD_REQUEST,

--- a/src/actions/action_jsonschema_trace_v1.h
+++ b/src/actions/action_jsonschema_trace_v1.h
@@ -93,8 +93,8 @@ public:
            const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
-                              sourcemeta::blaze::Mode::Exhaustive)};
+        this->structural_evaluate(this->rpc_request_schema_, arguments,
+                                  sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",

--- a/src/actions/action_list_directory_v1.h
+++ b/src/actions/action_list_directory_v1.h
@@ -90,8 +90,8 @@ public:
            const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
-                              sourcemeta::blaze::Mode::Exhaustive)};
+        this->structural_evaluate(this->rpc_request_schema_, arguments,
+                                  sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",

--- a/src/actions/action_schema_search_v1.h
+++ b/src/actions/action_schema_search_v1.h
@@ -219,8 +219,8 @@ public:
            const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
-                              sourcemeta::blaze::Mode::Exhaustive)};
+        this->structural_evaluate(this->rpc_request_schema_, arguments,
+                                  sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",

--- a/src/actions/action_serve_explorer_artifact_v1.h
+++ b/src/actions/action_serve_explorer_artifact_v1.h
@@ -100,8 +100,8 @@ public:
            const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
-                              sourcemeta::blaze::Mode::Exhaustive)};
+        this->structural_evaluate(this->rpc_request_schema_, arguments,
+                                  sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",

--- a/src/actions/action_serve_schema_artifact_v1.h
+++ b/src/actions/action_serve_schema_artifact_v1.h
@@ -107,8 +107,8 @@ public:
            const sourcemeta::one::Credentials &credentials)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
-        this->schema_evaluate(credentials, this->rpc_request_schema_, arguments,
-                              sourcemeta::blaze::Mode::Exhaustive)};
+        this->structural_evaluate(this->rpc_request_schema_, arguments,
+                                  sourcemeta::blaze::Mode::Exhaustive)};
     if (!request_valid) {
       return sourcemeta::core::jsonrpc_make_error(
           &request_id, -32602, "Params fail against the tool request schema",

--- a/src/router/evaluate.cc
+++ b/src/router/evaluate.cc
@@ -25,6 +25,45 @@ auto Router::blaze_template(const ResolvedArtifact &artifact)
       });
 }
 
+// This instance's own structural schemas are resolved without the gate, since
+// they are never handed to the caller and only decide whether what the caller
+// sent is well formed. Reading them through the gate would make a policy that
+// covers a route but not `/self` fail here rather than answer
+auto RouterAction::structural_template(const std::string_view schema_uri,
+                                       const sourcemeta::blaze::Mode mode) const
+    -> std::shared_ptr<const sourcemeta::blaze::Template> {
+  const auto artifact{this->artifact_resolve_path_unauthenticated(
+      schema_uri, Tree::Schemas,
+      mode == sourcemeta::blaze::Mode::FastValidation ? "blaze-fast"
+                                                      : "blaze-exhaustive")};
+  assert(artifact.has_value());
+  return this->dispatcher_.blaze_template(artifact.value());
+}
+
+auto RouterAction::structural_evaluate(const std::string_view schema_uri,
+                                       const sourcemeta::core::JSON &instance,
+                                       const sourcemeta::blaze::Mode mode) const
+    -> std::pair<bool, sourcemeta::core::JSON> {
+  const auto schema_template{this->structural_template(schema_uri, mode)};
+  sourcemeta::blaze::Evaluator evaluator;
+  auto result{
+      sourcemeta::blaze::standard(evaluator, *schema_template, instance,
+                                  sourcemeta::blaze::StandardOutput::Basic)};
+  const auto *valid{result.try_at("valid")};
+  const bool is_valid{valid != nullptr && valid->is_boolean() &&
+                      valid->to_boolean()};
+  return {is_valid, std::move(result)};
+}
+
+auto RouterAction::structural_evaluate_fast(
+    const std::string_view schema_uri,
+    const sourcemeta::core::JSON &instance) const -> bool {
+  const auto schema_template{this->structural_template(
+      schema_uri, sourcemeta::blaze::Mode::FastValidation)};
+  sourcemeta::blaze::Evaluator evaluator;
+  return evaluator.validate(*schema_template, instance);
+}
+
 auto RouterAction::blaze_template(const Credentials credentials,
                                   const std::string_view schema_uri,
                                   const sourcemeta::blaze::Mode mode) const

--- a/src/router/evaluate.cc
+++ b/src/router/evaluate.cc
@@ -25,10 +25,6 @@ auto Router::blaze_template(const ResolvedArtifact &artifact)
       });
 }
 
-// This instance's own structural schemas are resolved without the gate, since
-// they are never handed to the caller and only decide whether what the caller
-// sent is well formed. Reading them through the gate would make a policy that
-// covers a route but not `/self` fail here rather than answer
 auto RouterAction::structural_template(const std::string_view schema_uri,
                                        const sourcemeta::blaze::Mode mode) const
     -> std::shared_ptr<const sourcemeta::blaze::Template> {

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -220,6 +220,22 @@ public:
                       std::string_view cache_control,
                       std::string_view vary) const -> void;
 
+  // Validate against one of this instance's own structural schemas, such as
+  // the envelope a request has to match before it is acted on. Those are this
+  // instance's bookkeeping rather than catalog content and are never handed to
+  // the caller, so they resolve without the gate. Passing a caller's
+  // credential here instead would refuse whoever was admitted to a route but
+  // not to `/self`, which is a policy shape an operator may reasonably write
+  [[nodiscard]] auto structural_evaluate(std::string_view schema_uri,
+                                         const sourcemeta::core::JSON &instance,
+                                         sourcemeta::blaze::Mode mode) const
+      -> std::pair<bool, sourcemeta::core::JSON>;
+
+  [[nodiscard]] auto
+  structural_evaluate_fast(std::string_view schema_uri,
+                           const sourcemeta::core::JSON &instance) const
+      -> bool;
+
   [[nodiscard]] auto
   schema_evaluate_fast(Credentials credentials, std::string_view schema_uri,
                        const sourcemeta::core::JSON &instance) const -> bool;
@@ -275,6 +291,10 @@ private:
   artifact_resolve_ancestor(std::string_view input, Tree tree,
                             std::string_view artifact_name) const
       -> std::optional<ResolvedArtifact>;
+
+  [[nodiscard]] auto structural_template(std::string_view schema_uri,
+                                         sourcemeta::blaze::Mode mode) const
+      -> std::shared_ptr<const sourcemeta::blaze::Template>;
 
   [[nodiscard]] auto blaze_template(Credentials credentials,
                                     std::string_view schema_uri,


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

