### PR TITLE
Say when a rule names a claim the provider answers with objects

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -465,6 +465,23 @@ auto scope_accepts(const sourcemeta::core::JSON &payload,
   return false;
 }
 
+// Whether a claim arrived carrying objects rather than the strings a rule
+// names. Question 6's reading compares such a claim on its `value`
+// sub-attribute alone, so a rule naming a display name matches nothing
+auto carries_objects(const sourcemeta::core::JSON &value) -> bool {
+  if (value.is_object()) {
+    return true;
+  }
+
+  if (!value.is_array()) {
+    return false;
+  }
+
+  return std::ranges::any_of(value.as_array(), [](const auto &entry) -> bool {
+    return entry.is_object();
+  });
+}
+
 // Whether a verified token carries every claim a policy requires. The rules are
 // the member map of a claims request parameter, so each member names a claim
 // and the values it may carry. Values within one rule are alternatives and the
@@ -1160,6 +1177,48 @@ struct Authentication::Impl {
     return interactive_policy(decoded);
   }
 
+  [[nodiscard]] auto
+  object_shaped_claims(const std::string_view policy,
+                       const sourcemeta::core::JSON &claims) const
+      -> std::vector<std::string_view> {
+    std::vector<std::string_view> result;
+    const auto *policies{
+        static_cast<const AuthenticationPolicyEntry *>(this->policies_)};
+    for (std::uint32_t index{0}; index < this->policy_count_; index += 1) {
+      const auto &entry{policies[index]};
+      if (static_cast<Authentication::Type>(entry.type) !=
+              Authentication::Type::OIDC ||
+          entry.metadata_length == 0) {
+        continue;
+      }
+
+      OIDCPolicyMetadata decoded;
+      if (!decode_oidc_metadata(
+              {this->view_->as<std::byte>(entry.metadata_offset),
+               entry.metadata_length},
+              decoded) ||
+          decoded.name != policy) {
+        continue;
+      }
+
+      const auto &rules{this->claims_[index]};
+      if (!rules.is_object()) {
+        return result;
+      }
+
+      for (const auto &rule : rules.as_object()) {
+        const auto *value{claims.try_at(rule.first)};
+        if (value != nullptr && carries_objects(*value)) {
+          result.push_back(rule.first);
+        }
+      }
+
+      return result;
+    }
+
+    return result;
+  }
+
   [[nodiscard]] auto admits_identity(const std::string_view policy,
                                      const sourcemeta::core::JSON &claims) const
       -> Authentication::Admission {
@@ -1704,6 +1763,12 @@ auto Authentication::combine_claims(const sourcemeta::core::JSON &token,
   }
 
   return result;
+}
+
+auto Authentication::object_shaped_claims(
+    const std::string_view policy, const sourcemeta::core::JSON &claims) const
+    -> std::vector<std::string_view> {
+  return this->impl_->object_shaped_claims(policy, claims);
 }
 
 auto Authentication::admits_identity(const std::string_view policy,

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -1207,6 +1207,14 @@ struct Authentication::Impl {
       }
 
       for (const auto &rule : rules.as_object()) {
+        // A scope is read as one space-delimited string rather than compared
+        // member by member, so one arriving as anything else is refused rather
+        // than compared on an identifier, and saying otherwise would send an
+        // operator looking for the wrong mistake
+        if (rule.first == "scope") {
+          continue;
+        }
+
         const auto *value{claims.try_at(rule.first)};
         if (value != nullptr && carries_objects(*value)) {
           result.push_back(rule.first);

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -19,7 +19,10 @@
 #include <array>       // std::array
 #include <chrono>      // std::chrono::seconds, std::chrono::system_clock
 #include <filesystem>  // std::filesystem::path
+#include <functional>  // std::less
+#include <mutex>       // std::mutex, std::scoped_lock
 #include <optional>    // std::optional, std::nullopt
+#include <set>         // std::set
 #include <span>        // std::span
 #include <sstream>     // std::ostringstream
 #include <string>      // std::string
@@ -274,6 +277,8 @@ public:
           "The provider authenticated somebody the policy does not admit, "
           "for the policy",
           policy_name);
+      this->report_object_shaped_claims(authentication, policy_name,
+                                        token.value().payload());
       this->not_admitted(silent, transaction.value(), request, response);
       return;
     }
@@ -638,6 +643,38 @@ private:
       return grant;
     } catch (...) {
       return std::nullopt;
+    }
+  }
+
+  // A rule compared against a claim carrying objects is compared on the
+  // `value` sub-attribute alone, so a rule naming what a person sees rather
+  // than what identifies them matches nothing. A denial cannot show that, and
+  // the token it concerns is sealed inside a cookie where an operator cannot
+  // look, so it is said here.
+  //
+  // Only a refusal reaches this, so a working policy stays quiet, and each
+  // claim is named once however often somebody signs in
+  static auto report_object_shaped_claims(
+      const sourcemeta::one::Authentication &authentication,
+      const std::string_view policy_name, const sourcemeta::core::JSON &claims)
+      -> void {
+    static std::mutex mutex;
+    static std::set<std::string, std::less<>> reported;
+    for (const auto claim :
+         authentication.object_shaped_claims(policy_name, claims)) {
+      std::string subject{claim};
+      subject += " of the policy ";
+      subject += policy_name;
+      const std::scoped_lock guard{mutex};
+      if (!reported.insert(subject).second) {
+        continue;
+      }
+
+      sourcemeta::one::HTTP_LOG(
+          "A rule names a claim the provider answers with objects, which are "
+          "compared on their identifier rather than on any name shown to a "
+          "person. The claim is",
+          subject);
     }
   }
 

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -252,6 +252,7 @@ public:
     // session only ever exists for somebody the policy admits. Answering it
     // afterwards would leave a valid session denied on every request, and a
     // denial asks the provider again, which is a loop rather than an answer
+    std::optional<sourcemeta::core::JSON> combined;
     auto admission{
         authentication.admits_identity(policy_name, token.value().payload())};
 
@@ -266,19 +267,26 @@ public:
                                       grant.value().access_token,
                                       identity.value().subject)};
       if (extra.has_value()) {
-        admission = authentication.admits_identity(
-            policy_name, sourcemeta::one::Authentication::combine_claims(
-                             token.value().payload(), extra.value()));
+        combined = sourcemeta::one::Authentication::combine_claims(
+            token.value().payload(), extra.value());
+        admission =
+            authentication.admits_identity(policy_name, combined.value());
       }
     }
+
+    // Whatever the decision was actually made against, which is the pair taken
+    // together once a second answer arrived. Explaining a refusal against the
+    // token alone would miss a claim the UserInfo endpoint supplied, and that
+    // is where a scope's claims arrive by default under this flow
+    const auto &asserted{combined.has_value() ? combined.value()
+                                              : token.value().payload()};
 
     if (admission != sourcemeta::one::Authentication::Admission::Admitted) {
       sourcemeta::one::HTTP_LOG(
           "The provider authenticated somebody the policy does not admit, "
           "for the policy",
           policy_name);
-      this->report_object_shaped_claims(authentication, policy_name,
-                                        token.value().payload());
+      this->report_object_shaped_claims(authentication, policy_name, asserted);
       this->not_admitted(silent, transaction.value(), request, response);
       return;
     }

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -1652,6 +1652,58 @@ TEST(admitting_reads_two_answers_only_once_they_are_combined) {
             Admission::Admitted);
 }
 
+TEST(oidc_identity_names_a_claim_the_provider_answers_with_objects) {
+  setenv("ONE_TEST_OIDC_SHAPE", "confidential", 1);
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://acme.test",
+        .claims = CLAIMS_ONE_GROUP,
+        .client_id = "dashboard",
+        .client_secret_variable = "ONE_TEST_OIDC_SHAPE",
+        .name = "okta",
+        .session_secrets = SESSION_SECRETS_UNUSED}}};
+  const auto path{test_path("oidc_shape.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  const auto objects{sourcemeta::core::parse_json(R"JSON({
+    "sub": "a1b2",
+    "groups": [ { "value": "g-1", "display": "platform" } ]
+  })JSON")};
+  const auto strings{sourcemeta::core::parse_json(R"JSON({
+    "sub": "a1b2",
+    "groups": [ "platform" ]
+  })JSON")};
+  const auto absent{sourcemeta::core::parse_json(R"JSON({
+    "sub": "a1b2"
+  })JSON")};
+
+  // The rule compares an identifier, so a rule naming what a person sees
+  // matches nothing, and that is what an operator has no other way to learn
+  EXPECT_EQ(authentication.object_shaped_claims("okta", objects),
+            (std::vector<std::string_view>{"groups"}));
+  // Nothing to say where a claim arrived in the shape a rule names
+  EXPECT_EQ(authentication.object_shaped_claims("okta", strings),
+            (std::vector<std::string_view>{}));
+  // Nor where it never arrived, which is a different problem with its own word
+  EXPECT_EQ(authentication.object_shaped_claims("okta", absent),
+            (std::vector<std::string_view>{}));
+  // A claim no rule names is nobody's business here
+  const auto elsewhere{sourcemeta::core::parse_json(R"JSON({
+    "sub": "a1b2",
+    "groups": [ "platform" ],
+    "roles": [ { "value": "r-1" } ]
+  })JSON")};
+  EXPECT_EQ(authentication.object_shaped_claims("okta", elsewhere),
+            (std::vector<std::string_view>{}));
+  // And a policy that names no rule has nothing to report about
+  EXPECT_EQ(authentication.object_shaped_claims("nowhere", objects),
+            (std::vector<std::string_view>{}));
+}
+
 TEST(oidc_identity_under_an_unknown_policy_is_refused) {
   setenv("ONE_TEST_OIDC_ADMIT_UNKNOWN", "confidential", 1);
   const std::array<std::string_view, 1> paths{{"/portal"}};

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -1704,6 +1704,35 @@ TEST(oidc_identity_names_a_claim_the_provider_answers_with_objects) {
             (std::vector<std::string_view>{}));
 }
 
+TEST(oidc_identity_says_nothing_about_the_shape_of_a_scope) {
+  setenv("ONE_TEST_OIDC_SHAPE_SCOPE", "confidential", 1);
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://acme.test",
+        .claims = CLAIMS_SCOPE,
+        .client_id = "dashboard",
+        .client_secret_variable = "ONE_TEST_OIDC_SHAPE_SCOPE",
+        .name = "okta",
+        .session_secrets = SESSION_SECRETS_UNUSED}}};
+  const auto path{test_path("oidc_shape_scope.bin")};
+  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+
+  const sourcemeta::one::Authentication authentication{
+      path, stub_fetcher({}, nullptr)};
+  const auto objects{sourcemeta::core::parse_json(R"JSON({
+    "sub": "a1b2",
+    "scope": [ { "value": "registry:read" } ]
+  })JSON")};
+
+  // A scope is read whole rather than member by member, so one arriving as
+  // anything else is refused outright, and naming an identifier here would
+  // point an operator at a mistake they did not make
+  EXPECT_EQ(authentication.object_shaped_claims("okta", objects),
+            (std::vector<std::string_view>{}));
+}
+
 TEST(oidc_identity_under_an_unknown_policy_is_refused) {
   setenv("ONE_TEST_OIDC_ADMIT_UNKNOWN", "confidential", 1);
   const std::array<std::string_view, 1> paths{{"/portal"}};

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -84,6 +84,14 @@ auto Authentication::open_session(const std::string_view) const
   return std::nullopt;
 }
 
+// Only an interactive login ever answers for a claim, and this edition
+// establishes none, so there is never a shape to report
+auto Authentication::object_shaped_claims(const std::string_view,
+                                          const sourcemeta::core::JSON &) const
+    -> std::vector<std::string_view> {
+  return {};
+}
+
 // Only an interactive login ever has two answers to combine, and this edition
 // establishes none, so nothing here reaches this
 auto Authentication::combine_claims(const sourcemeta::core::JSON &token,

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -329,7 +329,12 @@ public:
   //
   // A denial cannot show this, and the token it concerns is sealed inside a
   // cookie, so an operator has no way to see it for themselves. Empty where
-  // every named claim arrived in a shape the rules compare directly
+  // every named claim arrived in a shape the rules compare directly.
+  //
+  // A rule on `scope` is never named here. That claim is read as one
+  // space-delimited string rather than compared member by member, so one
+  // arriving as anything else is refused outright, and calling it an
+  // identifier mismatch would describe a mistake nobody made
   [[nodiscard]] auto
   object_shaped_claims(std::string_view policy,
                        const sourcemeta::core::JSON &claims) const

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -321,6 +321,20 @@ public:
     Incomplete
   };
 
+  // The claims this policy's rules name that arrived carrying objects rather
+  // than strings. Such a claim is compared on its `value` sub-attribute alone,
+  // which RFC 9068 gives group, role, and entitlement claims by way of RFC
+  // 7643, so a rule naming what a person sees rather than what identifies them
+  // matches nothing and says nothing about why.
+  //
+  // A denial cannot show this, and the token it concerns is sealed inside a
+  // cookie, so an operator has no way to see it for themselves. Empty where
+  // every named claim arrived in a shape the rules compare directly
+  [[nodiscard]] auto
+  object_shaped_claims(std::string_view policy,
+                       const sourcemeta::core::JSON &claims) const
+      -> std::vector<std::string_view>;
+
   // What the claims a provider asserted about a person make of what the named
   // interactive policy requires. The claims are the payload of an identity
   // token this instance has already validated, so this decides admission


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

