### PR TITLE
Return which views a configuration declares

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -1741,13 +1741,7 @@ auto Authentication::views(
     }
   }
 
-  for (std::size_t group{0}; group < groups.size(); group++) {
-    const auto &members{groups[group]};
-    if (members.size() > Authentication::MAXIMUM_POLICIES_PER_ISSUER) {
-      throw AuthenticationTooManyViewsError(std::string{issuers[group]},
-                                            members.size());
-    }
-
+  for (const auto &members : groups) {
     // Every non-empty combination of the group, since a credential satisfying
     // several of them is shown what all of them admit
     const auto total{std::uint64_t{1} << members.size()};

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -1750,7 +1750,8 @@ auto Authentication::views(
 
   for (std::size_t group{0}; group < groups.size(); group++) {
     const auto &members{groups[group]};
-    // Past this the shift below is not even defined, let alone allocatable
+    // A doubling enumeration has to stop somewhere, and the shift below stops
+    // being defined once a group reaches the ceiling on policies
     if (members.size() > Authentication::MAXIMUM_COMBINABLE_POLICIES) {
       throw AuthenticationTooManyViewsError(std::string{issuers[group]},
                                             members.size());

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -1720,6 +1720,13 @@ auto Authentication::views(
   // is read, so only token policies declared against the same issuer can ever
   // be satisfied together. Every other policy stands alone, since a caller
   // presents one key or holds one session
+  // One view takes another's name if two policies share one, which the
+  // configuration refuses long before this is reached
+  assert(std::ranges::all_of(policies, [&policies](const auto &policy) -> bool {
+    return std::ranges::count(policies, policy.name,
+                              &Authentication::Policy::name) == 1;
+  }));
+
   std::vector<std::string_view> issuers;
   std::vector<std::vector<std::size_t>> groups;
   std::vector<Authentication::View> named;
@@ -1741,7 +1748,14 @@ auto Authentication::views(
     }
   }
 
-  for (const auto &members : groups) {
+  for (std::size_t group{0}; group < groups.size(); group++) {
+    const auto &members{groups[group]};
+    // Past this the shift below is not even defined, let alone allocatable
+    if (members.size() > Authentication::MAXIMUM_COMBINABLE_POLICIES) {
+      throw AuthenticationTooManyViewsError(std::string{issuers[group]},
+                                            members.size());
+    }
+
     // Every non-empty combination of the group, since a credential satisfying
     // several of them is shown what all of them admit
     const auto total{std::uint64_t{1} << members.size()};

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -1750,8 +1750,6 @@ auto Authentication::views(
 
   for (std::size_t group{0}; group < groups.size(); group++) {
     const auto &members{groups[group]};
-    // A doubling enumeration has to stop somewhere, and the shift below stops
-    // being defined once a group reaches the ceiling on policies
     if (members.size() > Authentication::MAXIMUM_COMBINABLE_POLICIES) {
       throw AuthenticationTooManyViewsError(std::string{issuers[group]},
                                             members.size());

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -1680,6 +1680,98 @@ Authentication::Authentication(const std::filesystem::path &path,
 
 Authentication::~Authentication() = default;
 
+namespace {
+
+// A view is spelled as the names of the policies it comprises, ordered so that
+// one combination has one spelling whatever order they were declared in
+auto view_name(const std::span<const Authentication::Policy> policies,
+               const std::span<const std::size_t> members) -> std::string {
+  std::vector<std::string_view> names;
+  names.reserve(members.size());
+  for (const auto member : members) {
+    names.emplace_back(policies[member].name);
+  }
+
+  std::ranges::sort(names);
+  std::string result;
+  for (const auto name : names) {
+    if (!result.empty()) {
+      result += '+';
+    }
+
+    result += name;
+  }
+
+  return result;
+}
+
+} // namespace
+
+auto Authentication::views(
+    const std::span<const Authentication::Policy> policies)
+    -> std::vector<Authentication::View> {
+  std::vector<Authentication::View> result;
+  // Always present, and the only entry when nothing is declared. A registry
+  // whose every path is governed still has one, since it is what a caller
+  // holding nothing is shown and what a lookup falls back to
+  result.push_back({.name = std::string{VIEW_PUBLIC}, .policies = {}});
+
+  // A credential carries one issuer and is checked against it before any rule
+  // is read, so only token policies declared against the same issuer can ever
+  // be satisfied together. Every other policy stands alone, since a caller
+  // presents one key or holds one session
+  std::vector<std::string_view> issuers;
+  std::vector<std::vector<std::size_t>> groups;
+  std::vector<Authentication::View> named;
+
+  for (std::size_t index{0}; index < policies.size(); index++) {
+    const auto &policy{policies[index]};
+    if (policy.type != Authentication::Type::JWT) {
+      named.push_back({.name = std::string{policy.name}, .policies = {index}});
+      continue;
+    }
+
+    const auto match{std::ranges::find(issuers, policy.issuer)};
+    if (match == issuers.cend()) {
+      issuers.emplace_back(policy.issuer);
+      groups.push_back({index});
+    } else {
+      groups[static_cast<std::size_t>(match - issuers.begin())].push_back(
+          index);
+    }
+  }
+
+  for (std::size_t group{0}; group < groups.size(); group++) {
+    const auto &members{groups[group]};
+    if (members.size() > Authentication::MAXIMUM_POLICIES_PER_ISSUER) {
+      throw AuthenticationTooManyViewsError(std::string{issuers[group]},
+                                            members.size());
+    }
+
+    // Every non-empty combination of the group, since a credential satisfying
+    // several of them is shown what all of them admit
+    const auto total{std::uint64_t{1} << members.size()};
+    for (std::uint64_t mask{1}; mask < total; mask++) {
+      std::vector<std::size_t> combination;
+      for (std::size_t offset{0}; offset < members.size(); offset++) {
+        if ((mask & (std::uint64_t{1} << offset)) != 0) {
+          combination.push_back(members[offset]);
+        }
+      }
+
+      named.push_back({.name = view_name(policies, combination),
+                       .policies = std::move(combination)});
+    }
+  }
+
+  std::ranges::sort(named, [](const auto &left, const auto &right) -> bool {
+    return left.name < right.name;
+  });
+  result.insert(result.cend(), std::make_move_iterator(named.begin()),
+                std::make_move_iterator(named.end()));
+  return result;
+}
+
 auto Authentication::admits(const Authentication::Path &path,
                             const Credentials &credentials) const
     -> Authentication::Verdict {

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -4646,7 +4646,7 @@ TEST(views_hold_the_public_one_even_when_every_path_is_governed) {
                        {.name = "everything", .policies = {0}}}));
 }
 
-TEST(views_of_the_largest_group_a_configuration_may_declare_are_enumerated) {
+TEST(views_of_six_token_policies_under_one_issuer_are_every_combination) {
   const std::array<std::string_view, 1> paths{{"/one"}};
   std::array<sourcemeta::one::Authentication::Policy, 6> policies{};
   const std::array<std::string_view, 6> names{{"a", "b", "c", "d", "e", "f"}};
@@ -4657,36 +4657,12 @@ TEST(views_of_the_largest_group_a_configuration_may_declare_are_enumerated) {
     policies.at(index).name = names.at(index);
   }
 
-  // Every non-empty combination of six, and the anonymous one
+  // Two to the sixth, being every non-empty combination plus the anonymous one
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views.size(), 64);
 }
 
-TEST(views_refuse_more_token_policies_under_one_issuer_than_the_bound) {
-  const std::array<std::string_view, 1> paths{{"/one"}};
-  std::array<sourcemeta::one::Authentication::Policy, 7> policies{};
-  const std::array<std::string_view, 7> names{
-      {"a", "b", "c", "d", "e", "f", "g"}};
-  for (std::size_t index{0}; index < policies.size(); index++) {
-    policies.at(index).paths = paths;
-    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
-    policies.at(index).issuer = "https://idp.example.com/realms/staff";
-    policies.at(index).name = names.at(index);
-  }
-
-  try {
-    const auto views{sourcemeta::one::Authentication::views(policies)};
-    EXPECT_EQ(views.size(), 0);
-    FAIL();
-  } catch (const sourcemeta::one::AuthenticationTooManyViewsError &error) {
-    EXPECT_STREQ(error.what(),
-                 "Too many authentication policies share an issuer");
-    EXPECT_EQ(error.issuer(), "https://idp.example.com/realms/staff");
-    EXPECT_EQ(error.count(), 7);
-  }
-}
-
-TEST(views_count_a_group_by_its_own_issuer_rather_than_the_whole_declaration) {
+TEST(views_of_two_issuer_groups_are_a_sum_rather_than_a_product) {
   const std::array<std::string_view, 1> paths{{"/one"}};
   std::array<sourcemeta::one::Authentication::Policy, 8> policies{};
   const std::array<std::string_view, 8> names{
@@ -4700,7 +4676,8 @@ TEST(views_count_a_group_by_its_own_issuer_rather_than_the_whole_declaration) {
     policies.at(index).name = names.at(index);
   }
 
-  // Past the bound in total, but no issuer holds more than four
+  // Each group contributes its own combinations and nothing crosses between
+  // them, so the total adds rather than multiplies
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views.size(), 1 + 15 + 15);
 }

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -4393,22 +4393,10 @@ TEST(a_policy_path_carrying_a_repeated_separator_gates_its_location) {
       authentication.admits(at("/public/string"), {.bearer = ""}).allowed);
 }
 
-static auto
-view_names(const std::vector<sourcemeta::one::Authentication::View> &views)
-    -> std::vector<std::string> {
-  std::vector<std::string> result;
-  result.reserve(views.size());
-  for (const auto &view : views) {
-    result.push_back(view.name);
-  }
-
-  return result;
-}
-
 TEST(views_of_nothing_are_the_public_one_alone) {
   const auto views{sourcemeta::one::Authentication::views({})};
-  EXPECT_EQ(view_names(views), (std::vector<std::string>{"public"}));
-  EXPECT_TRUE(views.at(0).policies.empty());
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}}}));
 }
 
 TEST(views_name_a_static_key_policy_on_its_own) {
@@ -4421,9 +4409,9 @@ TEST(views_name_a_static_key_policy_on_its_own) {
         .name = "vault"}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views), (std::vector<std::string>{"public", "vault"}));
-  EXPECT_TRUE(views.at(0).policies.empty());
-  EXPECT_EQ(views.at(1).policies, (std::vector<std::size_t>{0}));
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "vault", .policies = {0}}}));
 }
 
 TEST(views_name_an_interactive_policy_on_its_own) {
@@ -4435,8 +4423,9 @@ TEST(views_name_an_interactive_policy_on_its_own) {
         .name = "desk"}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views), (std::vector<std::string>{"public", "desk"}));
-  EXPECT_EQ(views.at(1).policies, (std::vector<std::size_t>{0}));
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "desk", .policies = {0}}}));
 }
 
 TEST(views_name_a_token_policy_on_its_own) {
@@ -4448,8 +4437,9 @@ TEST(views_name_a_token_policy_on_its_own) {
         .name = "machine"}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views), (std::vector<std::string>{"public", "machine"}));
-  EXPECT_EQ(views.at(1).policies, (std::vector<std::size_t>{0}));
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "machine", .policies = {0}}}));
 }
 
 TEST(views_combine_token_policies_that_name_one_issuer) {
@@ -4468,11 +4458,11 @@ TEST(views_combine_token_policies_that_name_one_issuer) {
   // A claim is a list and a rule is met by any of its values, so one token can
   // satisfy both
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views), (std::vector<std::string>{
-                                   "public", "legal", "legal+tech", "tech"}));
-  EXPECT_EQ(views.at(1).policies, (std::vector<std::size_t>{0}));
-  EXPECT_EQ(views.at(2).policies, (std::vector<std::size_t>{0, 1}));
-  EXPECT_EQ(views.at(3).policies, (std::vector<std::size_t>{1}));
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "legal", .policies = {0}},
+                       {.name = "legal+tech", .policies = {0, 1}},
+                       {.name = "tech", .policies = {1}}}));
 }
 
 TEST(views_never_combine_token_policies_across_issuers) {
@@ -4491,13 +4481,13 @@ TEST(views_never_combine_token_policies_across_issuers) {
   // A token carries one issuer and is verified against it before any rule is
   // read, so nobody can ever hold both
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views),
-            (std::vector<std::string>{"public", "partner", "staff"}));
-  EXPECT_EQ(views.at(1).policies, (std::vector<std::size_t>{1}));
-  EXPECT_EQ(views.at(2).policies, (std::vector<std::size_t>{0}));
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "partner", .policies = {1}},
+                       {.name = "staff", .policies = {0}}}));
 }
 
-TEST(views_combine_token_policies_that_share_a_claim_across_issuers_never) {
+TEST(views_never_combine_token_policies_testing_one_claim_across_issuers) {
   const std::array<std::string_view, 1> legal_paths{{"/legal"}};
   const std::array<std::string_view, 1> partner_paths{{"/partners"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
@@ -4515,8 +4505,10 @@ TEST(views_combine_token_policies_that_share_a_claim_across_issuers_never) {
   // The issuer is decisive and is read first, so testing the same claim for the
   // same value means nothing across them
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views),
-            (std::vector<std::string>{"public", "legal", "partner-legal"}));
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "legal", .policies = {0}},
+                       {.name = "partner-legal", .policies = {1}}}));
 }
 
 TEST(views_never_combine_interactive_policies_under_one_issuer) {
@@ -4535,8 +4527,10 @@ TEST(views_never_combine_interactive_policies_under_one_issuer) {
   // A browser holds one session naming one policy, so sharing an issuer buys an
   // interactive caller nothing
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views),
-            (std::vector<std::string>{"public", "first", "second"}));
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "first", .policies = {0}},
+                       {.name = "second", .policies = {1}}}));
 }
 
 TEST(views_never_combine_static_key_policies) {
@@ -4556,8 +4550,10 @@ TEST(views_never_combine_static_key_policies) {
 
   // A caller presents one key, so it satisfies one of these whatever it holds
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views),
-            (std::vector<std::string>{"public", "first", "second"}));
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "first", .policies = {0}},
+                       {.name = "second", .policies = {1}}}));
 }
 
 TEST(views_spell_a_combination_the_same_however_it_was_declared) {
@@ -4574,9 +4570,11 @@ TEST(views_spell_a_combination_the_same_however_it_was_declared) {
         .name = "legal"}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views), (std::vector<std::string>{
-                                   "public", "legal", "legal+tech", "tech"}));
-  EXPECT_EQ(views.at(2).policies, (std::vector<std::size_t>{0, 1}));
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "legal", .policies = {1}},
+                       {.name = "legal+tech", .policies = {0, 1}},
+                       {.name = "tech", .policies = {0}}}));
 }
 
 TEST(views_of_three_token_policies_under_one_issuer_are_every_combination) {
@@ -4596,9 +4594,15 @@ TEST(views_of_three_token_policies_under_one_issuer_are_every_combination) {
         .name = "c"}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views),
-            (std::vector<std::string>{"public", "a", "a+b", "a+b+c", "a+c", "b",
-                                      "b+c", "c"}));
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "a", .policies = {0}},
+                       {.name = "a+b", .policies = {0, 1}},
+                       {.name = "a+b+c", .policies = {0, 1, 2}},
+                       {.name = "a+c", .policies = {0, 2}},
+                       {.name = "b", .policies = {1}},
+                       {.name = "b+c", .policies = {1, 2}},
+                       {.name = "c", .policies = {2}}}));
 }
 
 TEST(views_mix_a_combining_group_with_policies_that_stand_alone) {
@@ -4619,78 +4623,56 @@ TEST(views_mix_a_combining_group_with_policies_that_stand_alone) {
         .name = "tech"}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views),
-            (std::vector<std::string>{"public", "legal", "legal+tech", "tech",
-                                      "vault"}));
-  EXPECT_EQ(views.at(4).policies, (std::vector<std::size_t>{0}));
-  EXPECT_EQ(views.at(2).policies, (std::vector<std::size_t>{1, 2}));
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "legal", .policies = {1}},
+                       {.name = "legal+tech", .policies = {1, 2}},
+                       {.name = "tech", .policies = {2}},
+                       {.name = "vault", .policies = {0}}}));
+}
+
+TEST(views_hold_the_public_one_even_when_every_path_is_governed) {
+  const std::array<std::string_view, 1> paths{{"/"}};
+  const std::array<std::string_view, 1> keys{{"secret"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .keys = keys,
+        .type = sourcemeta::one::Authentication::Type::ApiKey,
+        .name = "everything"}}};
+
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}},
+                       {.name = "everything", .policies = {0}}}));
 }
 
 TEST(views_of_the_largest_group_a_configuration_may_declare_are_enumerated) {
   const std::array<std::string_view, 1> paths{{"/one"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 6> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "a"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "b"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "c"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "d"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "e"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "f"}}};
+  std::array<sourcemeta::one::Authentication::Policy, 6> policies{};
+  const std::array<std::string_view, 6> names{{"a", "b", "c", "d", "e", "f"}};
+  for (std::size_t index{0}; index < policies.size(); index++) {
+    policies.at(index).paths = paths;
+    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
+    policies.at(index).issuer = "https://idp.example.com/realms/staff";
+    policies.at(index).name = names.at(index);
+  }
 
   // Every non-empty combination of six, and the anonymous one
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views.size(), 64);
-  EXPECT_EQ(views.at(0).name, "public");
 }
 
 TEST(views_refuse_more_token_policies_under_one_issuer_than_the_bound) {
   const std::array<std::string_view, 1> paths{{"/one"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 7> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "a"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "b"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "c"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "d"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "e"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "f"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "g"}}};
+  std::array<sourcemeta::one::Authentication::Policy, 7> policies{};
+  const std::array<std::string_view, 7> names{
+      {"a", "b", "c", "d", "e", "f", "g"}};
+  for (std::size_t index{0}; index < policies.size(); index++) {
+    policies.at(index).paths = paths;
+    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
+    policies.at(index).issuer = "https://idp.example.com/realms/staff";
+    policies.at(index).name = names.at(index);
+  }
 
   try {
     const auto views{sourcemeta::one::Authentication::views(policies)};
@@ -4718,21 +4700,7 @@ TEST(views_count_a_group_by_its_own_issuer_rather_than_the_whole_declaration) {
     policies.at(index).name = names.at(index);
   }
 
+  // Past the bound in total, but no issuer holds more than four
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views.size(), 1 + 15 + 15);
-}
-
-TEST(views_hold_the_public_one_even_when_every_path_is_governed) {
-  const std::array<std::string_view, 1> paths{{"/"}};
-  const std::array<std::string_view, 1> keys{{"secret"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .keys = keys,
-        .type = sourcemeta::one::Authentication::Type::ApiKey,
-        .name = "everything"}}};
-
-  const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(view_names(views),
-            (std::vector<std::string>{"public", "everything"}));
-  EXPECT_TRUE(views.at(0).policies.empty());
 }

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -4392,3 +4392,366 @@ TEST(a_policy_path_carrying_a_repeated_separator_gates_its_location) {
   EXPECT_TRUE(
       authentication.admits(at("/public/string"), {.bearer = ""}).allowed);
 }
+
+// The view table: what segments a registry's output, as a pure function of what
+// a configuration declared. No filesystem, no request, no runtime knowledge,
+// since the issuer partition is declared rather than discovered.
+//
+// The rule in one sentence: one view per policy, plus every combination of the
+// token policies that name one issuer, plus the anonymous one. What follows
+// drives each half of that, and each reason a combination does or does not
+// arise, because getting it wrong changes what an instance builds rather than
+// what it answers, and nothing downstream would object.
+
+static auto
+view_names(const std::vector<sourcemeta::one::Authentication::View> &views)
+    -> std::vector<std::string> {
+  std::vector<std::string> result;
+  result.reserve(views.size());
+  for (const auto &view : views) {
+    result.push_back(view.name);
+  }
+
+  return result;
+}
+
+TEST(views_of_nothing_are_the_public_one_alone) {
+  const auto views{sourcemeta::one::Authentication::views({})};
+  EXPECT_EQ(view_names(views), (std::vector<std::string>{"public"}));
+  EXPECT_TRUE(views.at(0).policies.empty());
+}
+
+TEST(views_name_a_static_key_policy_on_its_own) {
+  const std::array<std::string_view, 1> paths{{"/private"}};
+  const std::array<std::string_view, 1> keys{{"secret"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .keys = keys,
+        .type = sourcemeta::one::Authentication::Type::ApiKey,
+        .name = "vault"}}};
+
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views), (std::vector<std::string>{"public", "vault"}));
+  EXPECT_TRUE(views.at(0).policies.empty());
+  EXPECT_EQ(views.at(1).policies, (std::vector<std::size_t>{0}));
+}
+
+TEST(views_name_an_interactive_policy_on_its_own) {
+  const std::array<std::string_view, 1> paths{{"/console"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "desk"}}};
+
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views), (std::vector<std::string>{"public", "desk"}));
+  EXPECT_EQ(views.at(1).policies, (std::vector<std::size_t>{0}));
+}
+
+TEST(views_name_a_token_policy_on_its_own) {
+  const std::array<std::string_view, 1> paths{{"/machine"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "machine"}}};
+
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views), (std::vector<std::string>{"public", "machine"}));
+  EXPECT_EQ(views.at(1).policies, (std::vector<std::size_t>{0}));
+}
+
+TEST(views_combine_token_policies_that_name_one_issuer) {
+  const std::array<std::string_view, 1> legal_paths{{"/legal"}};
+  const std::array<std::string_view, 1> tech_paths{{"/tech"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = legal_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "legal"},
+       {.paths = tech_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "tech"}}};
+
+  // One token can satisfy both, since a claim is a list and a rule is met by
+  // any of its values, so the pair is a way the registry can look to somebody
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views), (std::vector<std::string>{
+                                   "public", "legal", "legal+tech", "tech"}));
+  EXPECT_EQ(views.at(1).policies, (std::vector<std::size_t>{0}));
+  EXPECT_EQ(views.at(2).policies, (std::vector<std::size_t>{0, 1}));
+  EXPECT_EQ(views.at(3).policies, (std::vector<std::size_t>{1}));
+}
+
+TEST(views_never_combine_token_policies_across_issuers) {
+  const std::array<std::string_view, 1> staff_paths{{"/internal"}};
+  const std::array<std::string_view, 1> partner_paths{{"/partners"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = staff_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "staff"},
+       {.paths = partner_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.partner.com/realms/main",
+        .name = "partner"}}};
+
+  // A token carries one issuer and is verified against it before any rule is
+  // read, so nobody can ever hold both. This is the contrast to the pair above,
+  // differing in the issuer alone
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views),
+            (std::vector<std::string>{"public", "partner", "staff"}));
+  EXPECT_EQ(views.at(1).policies, (std::vector<std::size_t>{1}));
+  EXPECT_EQ(views.at(2).policies, (std::vector<std::size_t>{0}));
+}
+
+TEST(views_combine_token_policies_that_share_a_claim_across_issuers_never) {
+  const std::array<std::string_view, 1> legal_paths{{"/legal"}};
+  const std::array<std::string_view, 1> partner_paths{{"/partners"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = legal_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .claims = R"({"department":{"values":["legal"]}})",
+        .name = "legal"},
+       {.paths = partner_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.partner.com/realms/main",
+        .claims = R"({"department":{"values":["legal"]}})",
+        .name = "partner-legal"}}};
+
+  // Testing the same claim for the same value means nothing across issuers,
+  // because the issuer is decisive and is read first
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views),
+            (std::vector<std::string>{"public", "legal", "partner-legal"}));
+}
+
+TEST(views_never_combine_interactive_policies_under_one_issuer) {
+  const std::array<std::string_view, 1> first_paths{{"/one"}};
+  const std::array<std::string_view, 1> second_paths{{"/two"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = first_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "first"},
+       {.paths = second_paths,
+        .type = sourcemeta::one::Authentication::Type::OIDC,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "second"}}};
+
+  // A browser holds one session naming one policy, so sharing an issuer buys
+  // an interactive caller nothing. The contrast is the token pair above, which
+  // differs only in the credential type
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views),
+            (std::vector<std::string>{"public", "first", "second"}));
+}
+
+TEST(views_never_combine_static_key_policies) {
+  const std::array<std::string_view, 1> first_paths{{"/one"}};
+  const std::array<std::string_view, 1> second_paths{{"/two"}};
+  const std::array<std::string_view, 1> first_keys{{"one-secret"}};
+  const std::array<std::string_view, 1> second_keys{{"two-secret"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = first_paths,
+        .keys = first_keys,
+        .type = sourcemeta::one::Authentication::Type::ApiKey,
+        .name = "first"},
+       {.paths = second_paths,
+        .keys = second_keys,
+        .type = sourcemeta::one::Authentication::Type::ApiKey,
+        .name = "second"}}};
+
+  // A caller presents one key, so it satisfies one of these whatever it holds
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views),
+            (std::vector<std::string>{"public", "first", "second"}));
+}
+
+TEST(views_spell_a_combination_the_same_however_it_was_declared) {
+  const std::array<std::string_view, 1> tech_paths{{"/tech"}};
+  const std::array<std::string_view, 1> legal_paths{{"/legal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = tech_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "tech"},
+       {.paths = legal_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "legal"}}};
+
+  // Declared the other way round from the pair above, and named the same, so
+  // reordering a configuration cannot move where an artifact lives
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views), (std::vector<std::string>{
+                                   "public", "legal", "legal+tech", "tech"}));
+  EXPECT_EQ(views.at(2).policies, (std::vector<std::size_t>{0, 1}));
+}
+
+TEST(views_of_three_token_policies_under_one_issuer_are_every_combination) {
+  const std::array<std::string_view, 1> paths{{"/one"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "a"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "b"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "c"}}};
+
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views),
+            (std::vector<std::string>{"public", "a", "a+b", "a+b+c", "a+c", "b",
+                                      "b+c", "c"}));
+}
+
+TEST(views_mix_a_combining_group_with_policies_that_stand_alone) {
+  const std::array<std::string_view, 1> paths{{"/one"}};
+  const std::array<std::string_view, 1> keys{{"secret"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
+      {{.paths = paths,
+        .keys = keys,
+        .type = sourcemeta::one::Authentication::Type::ApiKey,
+        .name = "vault"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "legal"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "tech"}}};
+
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views),
+            (std::vector<std::string>{"public", "legal", "legal+tech", "tech",
+                                      "vault"}));
+  EXPECT_EQ(views.at(4).policies, (std::vector<std::size_t>{0}));
+  EXPECT_EQ(views.at(2).policies, (std::vector<std::size_t>{1, 2}));
+}
+
+TEST(views_of_the_largest_group_a_configuration_may_declare_are_enumerated) {
+  const std::array<std::string_view, 1> paths{{"/one"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 6> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "a"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "b"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "c"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "d"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "e"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "f"}}};
+
+  // Every non-empty combination of six, and the anonymous one
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(views.size(), 64);
+  EXPECT_EQ(views.at(0).name, "public");
+}
+
+TEST(views_refuse_more_token_policies_under_one_issuer_than_the_bound) {
+  const std::array<std::string_view, 1> paths{{"/one"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 7> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "a"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "b"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "c"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "d"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "e"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "f"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "g"}}};
+
+  try {
+    const auto views{sourcemeta::one::Authentication::views(policies)};
+    EXPECT_EQ(views.size(), 0);
+    FAIL();
+  } catch (const sourcemeta::one::AuthenticationTooManyViewsError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Too many authentication policies share an issuer");
+    EXPECT_EQ(error.issuer(), "https://idp.example.com/realms/staff");
+    EXPECT_EQ(error.count(), 7);
+  }
+}
+
+TEST(views_count_a_group_by_its_own_issuer_rather_than_the_whole_declaration) {
+  const std::array<std::string_view, 1> paths{{"/one"}};
+  std::array<sourcemeta::one::Authentication::Policy, 8> policies{};
+  const std::array<std::string_view, 8> names{
+      {"a", "b", "c", "d", "e", "f", "g", "h"}};
+  for (std::size_t index{0}; index < policies.size(); index++) {
+    policies.at(index).paths = paths;
+    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
+    policies.at(index).issuer = index < 4
+                                    ? "https://idp.example.com/realms/staff"
+                                    : "https://idp.partner.com/realms/main";
+    policies.at(index).name = names.at(index);
+  }
+
+  // Eight policies is past the bound, but no issuer holds more than four, and
+  // it is the group that doubles the views rather than the declaration
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(views.size(), 1 + 15 + 15);
+}
+
+TEST(views_hold_the_public_one_even_when_every_path_is_governed) {
+  const std::array<std::string_view, 1> paths{{"/"}};
+  const std::array<std::string_view, 1> keys{{"secret"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .keys = keys,
+        .type = sourcemeta::one::Authentication::Type::ApiKey,
+        .name = "everything"}}};
+
+  // Nothing is public here, and the anonymous view is still one of the answers.
+  // It is what a caller holding nothing is shown, which on such a registry is
+  // the refusal and the way in, and it is what a lookup falls back to
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(view_names(views),
+            (std::vector<std::string>{"public", "everything"}));
+  EXPECT_TRUE(views.at(0).policies.empty());
+}

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -4681,3 +4681,81 @@ TEST(views_of_two_issuer_groups_are_a_sum_rather_than_a_product) {
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views.size(), 1 + 15 + 15);
 }
+
+TEST(views_of_the_largest_combinable_group_are_every_combination) {
+  const std::array<std::string_view, 1> paths{{"/one"}};
+  std::array<sourcemeta::one::Authentication::Policy,
+             sourcemeta::one::Authentication::MAXIMUM_COMBINABLE_POLICIES>
+      policies{};
+  std::vector<std::string> names;
+  names.reserve(policies.size());
+  for (std::size_t index{0}; index < policies.size(); index++) {
+    names.push_back("p" + std::to_string(index));
+  }
+
+  for (std::size_t index{0}; index < policies.size(); index++) {
+    policies.at(index).paths = paths;
+    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
+    policies.at(index).issuer = "https://idp.example.com/realms/staff";
+    policies.at(index).name = names.at(index);
+  }
+
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(views.size(),
+            (std::size_t{1}
+             << sourcemeta::one::Authentication::MAXIMUM_COMBINABLE_POLICIES));
+  EXPECT_EQ(views.at(0).name, "public");
+}
+
+TEST(views_refuse_a_group_whose_combinations_cannot_be_produced) {
+  const std::array<std::string_view, 1> paths{{"/one"}};
+  std::array<sourcemeta::one::Authentication::Policy,
+             sourcemeta::one::Authentication::MAXIMUM_COMBINABLE_POLICIES + 1>
+      policies{};
+  std::vector<std::string> names;
+  names.reserve(policies.size());
+  for (std::size_t index{0}; index < policies.size(); index++) {
+    names.push_back("p" + std::to_string(index));
+  }
+
+  for (std::size_t index{0}; index < policies.size(); index++) {
+    policies.at(index).paths = paths;
+    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
+    policies.at(index).issuer = "https://idp.example.com/realms/staff";
+    policies.at(index).name = names.at(index);
+  }
+
+  try {
+    const auto views{sourcemeta::one::Authentication::views(policies)};
+    EXPECT_EQ(views.size(), 0);
+    FAIL();
+  } catch (const sourcemeta::one::AuthenticationTooManyViewsError &error) {
+    EXPECT_STREQ(error.what(),
+                 "Too many authentication policies share an issuer");
+    EXPECT_EQ(error.issuer(), "https://idp.example.com/realms/staff");
+    EXPECT_EQ(error.count(),
+              sourcemeta::one::Authentication::MAXIMUM_COMBINABLE_POLICIES + 1);
+  }
+}
+
+TEST(views_of_many_policies_across_issuers_are_never_refused) {
+  const std::array<std::string_view, 1> paths{{"/one"}};
+  std::array<sourcemeta::one::Authentication::Policy, 40> policies{};
+  std::vector<std::string> names;
+  names.reserve(policies.size());
+  for (std::size_t index{0}; index < policies.size(); index++) {
+    names.push_back("p" + std::to_string(index));
+  }
+
+  // Well past the ceiling in total, and no group approaches it, so nothing is
+  // refused. What a build makes of forty views is not decided here
+  for (std::size_t index{0}; index < policies.size(); index++) {
+    policies.at(index).paths = paths;
+    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
+    policies.at(index).issuer = names.at(index);
+    policies.at(index).name = names.at(index);
+  }
+
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(views.size(), 41);
+}

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -4393,16 +4393,6 @@ TEST(a_policy_path_carrying_a_repeated_separator_gates_its_location) {
       authentication.admits(at("/public/string"), {.bearer = ""}).allowed);
 }
 
-// The view table: what segments a registry's output, as a pure function of what
-// a configuration declared. No filesystem, no request, no runtime knowledge,
-// since the issuer partition is declared rather than discovered.
-//
-// The rule in one sentence: one view per policy, plus every combination of the
-// token policies that name one issuer, plus the anonymous one. What follows
-// drives each half of that, and each reason a combination does or does not
-// arise, because getting it wrong changes what an instance builds rather than
-// what it answers, and nothing downstream would object.
-
 static auto
 view_names(const std::vector<sourcemeta::one::Authentication::View> &views)
     -> std::vector<std::string> {
@@ -4475,8 +4465,8 @@ TEST(views_combine_token_policies_that_name_one_issuer) {
         .issuer = "https://idp.example.com/realms/staff",
         .name = "tech"}}};
 
-  // One token can satisfy both, since a claim is a list and a rule is met by
-  // any of its values, so the pair is a way the registry can look to somebody
+  // A claim is a list and a rule is met by any of its values, so one token can
+  // satisfy both
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(view_names(views), (std::vector<std::string>{
                                    "public", "legal", "legal+tech", "tech"}));
@@ -4499,8 +4489,7 @@ TEST(views_never_combine_token_policies_across_issuers) {
         .name = "partner"}}};
 
   // A token carries one issuer and is verified against it before any rule is
-  // read, so nobody can ever hold both. This is the contrast to the pair above,
-  // differing in the issuer alone
+  // read, so nobody can ever hold both
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(view_names(views),
             (std::vector<std::string>{"public", "partner", "staff"}));
@@ -4523,8 +4512,8 @@ TEST(views_combine_token_policies_that_share_a_claim_across_issuers_never) {
         .claims = R"({"department":{"values":["legal"]}})",
         .name = "partner-legal"}}};
 
-  // Testing the same claim for the same value means nothing across issuers,
-  // because the issuer is decisive and is read first
+  // The issuer is decisive and is read first, so testing the same claim for the
+  // same value means nothing across them
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(view_names(views),
             (std::vector<std::string>{"public", "legal", "partner-legal"}));
@@ -4543,9 +4532,8 @@ TEST(views_never_combine_interactive_policies_under_one_issuer) {
         .issuer = "https://idp.example.com/realms/staff",
         .name = "second"}}};
 
-  // A browser holds one session naming one policy, so sharing an issuer buys
-  // an interactive caller nothing. The contrast is the token pair above, which
-  // differs only in the credential type
+  // A browser holds one session naming one policy, so sharing an issuer buys an
+  // interactive caller nothing
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(view_names(views),
             (std::vector<std::string>{"public", "first", "second"}));
@@ -4585,8 +4573,6 @@ TEST(views_spell_a_combination_the_same_however_it_was_declared) {
         .issuer = "https://idp.example.com/realms/staff",
         .name = "legal"}}};
 
-  // Declared the other way round from the pair above, and named the same, so
-  // reordering a configuration cannot move where an artifact lives
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(view_names(views), (std::vector<std::string>{
                                    "public", "legal", "legal+tech", "tech"}));
@@ -4732,8 +4718,6 @@ TEST(views_count_a_group_by_its_own_issuer_rather_than_the_whole_declaration) {
     policies.at(index).name = names.at(index);
   }
 
-  // Eight policies is past the bound, but no issuer holds more than four, and
-  // it is the group that doubles the views rather than the declaration
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views.size(), 1 + 15 + 15);
 }
@@ -4747,9 +4731,6 @@ TEST(views_hold_the_public_one_even_when_every_path_is_governed) {
         .type = sourcemeta::one::Authentication::Type::ApiKey,
         .name = "everything"}}};
 
-  // Nothing is public here, and the anonymous view is still one of the answers.
-  // It is what a caller holding nothing is shown, which on such a registry is
-  // the refusal and the way in, and it is what a lookup falls back to
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(view_names(views),
             (std::vector<std::string>{"public", "everything"}));

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -19,6 +19,16 @@ namespace sourcemeta::one {
 // emitted, empty, to keep the build output identical in shape across editions
 struct Authentication::Impl {};
 
+// This edition serves every path publicly, so the registry looks the same to
+// everybody and there is exactly one way to see it. The view is still named
+// rather than implied, which keeps the output one shape across editions
+auto Authentication::views(const std::span<const Authentication::Policy>)
+    -> std::vector<Authentication::View> {
+  std::vector<Authentication::View> result;
+  result.push_back({.name = std::string{VIEW_PUBLIC}, .policies = {}});
+  return result;
+}
+
 auto Authentication::save(
     const std::span<const Authentication::Policy> policies,
     const std::filesystem::path &configuration,

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -198,11 +198,23 @@ public:
   /// alone, since a caller presents one key or holds one session.
   ///
   /// The count is one, plus one per policy that stands alone, plus two to the
-  /// power of each issuer group's size less one. Nothing is refused here, since
-  /// what a number of views costs is known where they are built rather than
-  /// where they are named.
+  /// power of each issuer group's size less one.
+  ///
+  /// Whether that many views is affordable is not decided here, since what they
+  /// cost is known where they are built rather than where they are named. What
+  /// is decided here is only whether the answer can be produced at all, which
+  /// the ceiling below draws a line under.
+  ///
+  /// Every policy name must be distinct, which is what keeps one view from
+  /// taking another's name.
   [[nodiscard]] static auto views(std::span<const Policy> policies)
       -> std::vector<View>;
+
+  // How many policies may name one issuer. Each one doubles the combinations
+  // over that group, so past a point the answer cannot be held in memory at all
+  // and the largest a policy ceiling allows would not even be representable.
+  // This is where that becomes true, not a judgement about what is affordable
+  static constexpr std::size_t MAXIMUM_COMBINABLE_POLICIES{16};
 
   // Write the policies to the artifact the gate reads, refusing any policy
   // scoped to a path the guard does not recognise

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -188,12 +188,6 @@ public:
     [[nodiscard]] auto operator==(const View &other) const -> bool = default;
   };
 
-  // How many token policies may name one issuer. Each such group contributes a
-  // view per non-empty combination of its members, so the count doubles with
-  // every policy added to it, and past this a build refuses rather than
-  // producing an output nobody asked for
-  static constexpr std::size_t MAXIMUM_POLICIES_PER_ISSUER{6};
-
   /// Every view over a registry declaring these policies, which is what
   /// segments its output. A pure function of what was declared: the anonymous
   /// view first, then the rest ordered by name.
@@ -202,6 +196,11 @@ public:
   /// rule, so only token policies declared against the same issuer can be
   /// satisfied together, and only those combine. Every other policy stands
   /// alone, since a caller presents one key or holds one session.
+  ///
+  /// The count is one, plus one per policy that stands alone, plus two to the
+  /// power of each issuer group's size less one. Nothing is refused here, since
+  /// what a number of views costs is known where they are built rather than
+  /// where they are named.
   [[nodiscard]] static auto views(std::span<const Policy> policies)
       -> std::vector<View>;
 

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -178,6 +178,31 @@ public:
   // knows what this instance serves
   using PathGuard = std::function<bool(std::string_view)>;
 
+  // One way the registry looks to somebody: the name its artifacts live under
+  // and the policies a caller of it satisfies. The anonymous view comprises
+  // none, which is what makes it the base every other view adds to
+  struct View {
+    std::string name;
+    std::vector<std::size_t> policies;
+  };
+
+  // How many token policies may name one issuer. Each such group contributes a
+  // view per non-empty combination of its members, so the count doubles with
+  // every policy added to it, and past this a build refuses rather than
+  // producing an output nobody asked for
+  static constexpr std::size_t MAXIMUM_POLICIES_PER_ISSUER{6};
+
+  /// Every view over a registry declaring these policies, which is what
+  /// segments its output. A pure function of what was declared: the anonymous
+  /// view first, then the rest ordered by name.
+  ///
+  /// A credential carries one issuer and is checked against it before any
+  /// rule, so only token policies declared against the same issuer can be
+  /// satisfied together, and only those combine. Every other policy stands
+  /// alone, since a caller presents one key or holds one session.
+  [[nodiscard]] static auto views(std::span<const Policy> policies)
+      -> std::vector<View>;
+
   // Write the policies to the artifact the gate reads, refusing any policy
   // scoped to a path the guard does not recognise
   static auto save(std::span<const Policy> policies,

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -210,13 +210,13 @@ public:
   [[nodiscard]] static auto views(std::span<const Policy> policies)
       -> std::vector<View>;
 
-  // How many policies may name one issuer. Some bound is unavoidable, because
-  // the combinations double with each policy added to a group and the shift
-  // that enumerates them stops being defined once a group reaches the ceiling
-  // on policies. Exactly where to draw it is a choice rather than a discovery:
-  // this sits far above anything a configuration has reason to declare and far
-  // below the point where enumerating becomes impractical. It is not a
-  // judgement about what a build can afford, which is made where views are
+  // How many policies may name one issuer. The combinations over a group double
+  // with every policy added to it, so where to stop is a choice rather than a
+  // discovery: this sits far above anything a configuration has reason to
+  // declare and far below where enumerating them becomes a burden. Raising it
+  // is a decision about what a build should attempt, bounded only in that it
+  // can never reach the ceiling on policies, where the enumeration stops being
+  // expressible at all. What a number of views costs is decided where they are
   // built rather than where they are named
   static constexpr std::size_t MAXIMUM_COMBINABLE_POLICIES{16};
 

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -184,6 +184,8 @@ public:
   struct View {
     std::string name;
     std::vector<std::size_t> policies;
+
+    [[nodiscard]] auto operator==(const View &other) const -> bool = default;
   };
 
   // How many token policies may name one issuer. Each such group contributes a

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -202,18 +202,22 @@ public:
   ///
   /// Whether that many views is affordable is not decided here, since what they
   /// cost is known where they are built rather than where they are named. What
-  /// is decided here is only whether the answer can be produced at all, which
-  /// the ceiling below draws a line under.
+  /// is decided here is only that an enumeration doubling with every policy has
+  /// to stop somewhere, which the ceiling below picks a point for.
   ///
   /// Every policy name must be distinct, which is what keeps one view from
   /// taking another's name.
   [[nodiscard]] static auto views(std::span<const Policy> policies)
       -> std::vector<View>;
 
-  // How many policies may name one issuer. Each one doubles the combinations
-  // over that group, so past a point the answer cannot be held in memory at all
-  // and the largest a policy ceiling allows would not even be representable.
-  // This is where that becomes true, not a judgement about what is affordable
+  // How many policies may name one issuer. Some bound is unavoidable, because
+  // the combinations double with each policy added to a group and the shift
+  // that enumerates them stops being defined once a group reaches the ceiling
+  // on policies. Exactly where to draw it is a choice rather than a discovery:
+  // this sits far above anything a configuration has reason to declare and far
+  // below the point where enumerating becomes impractical. It is not a
+  // judgement about what a build can afford, which is made where views are
+  // built rather than where they are named
   static constexpr std::size_t MAXIMUM_COMBINABLE_POLICIES{16};
 
   // Write the policies to the artifact the gate reads, refusing any policy

--- a/src/authentication/include/sourcemeta/one/authentication_error.h
+++ b/src/authentication/include/sourcemeta/one/authentication_error.h
@@ -59,6 +59,32 @@ private:
   std::string scope_;
 };
 
+// Raised when so many token policies name one issuer that the combinations over
+// them cannot be produced. Not a statement about what a build can afford, which
+// is known where the views are built rather than where they are named
+class SOURCEMETA_ONE_AUTHENTICATION_EXPORT AuthenticationTooManyViewsError
+    : public std::exception {
+public:
+  AuthenticationTooManyViewsError(std::string issuer, const std::size_t count)
+      : issuer_{std::move(issuer)}, count_{count} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return "Too many authentication policies share an issuer";
+  }
+
+  [[nodiscard]] auto issuer() const noexcept -> const std::string & {
+    return this->issuer_;
+  }
+
+  [[nodiscard]] auto count() const noexcept -> std::size_t {
+    return this->count_;
+  }
+
+private:
+  std::string issuer_;
+  std::size_t count_;
+};
+
 } // namespace sourcemeta::one
 
 #endif

--- a/src/authentication/include/sourcemeta/one/authentication_error.h
+++ b/src/authentication/include/sourcemeta/one/authentication_error.h
@@ -5,6 +5,7 @@
 #include <sourcemeta/one/authentication_export.h>
 #endif
 
+#include <cstddef>    // std::size_t
 #include <exception>  // std::exception
 #include <filesystem> // std::filesystem::path
 #include <string>     // std::string
@@ -56,6 +57,31 @@ public:
 private:
   std::filesystem::path path_;
   std::string scope_;
+};
+
+// Raised when more token policies name one issuer than the views over them can
+// be enumerated for, since each such policy doubles the number of views
+class SOURCEMETA_ONE_AUTHENTICATION_EXPORT AuthenticationTooManyViewsError
+    : public std::exception {
+public:
+  AuthenticationTooManyViewsError(std::string issuer, const std::size_t count)
+      : issuer_{std::move(issuer)}, count_{count} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return "Too many authentication policies share an issuer";
+  }
+
+  [[nodiscard]] auto issuer() const noexcept -> const std::string & {
+    return this->issuer_;
+  }
+
+  [[nodiscard]] auto count() const noexcept -> std::size_t {
+    return this->count_;
+  }
+
+private:
+  std::string issuer_;
+  std::size_t count_;
 };
 
 } // namespace sourcemeta::one

--- a/src/authentication/include/sourcemeta/one/authentication_error.h
+++ b/src/authentication/include/sourcemeta/one/authentication_error.h
@@ -59,31 +59,6 @@ private:
   std::string scope_;
 };
 
-// Raised when more token policies name one issuer than the views over them can
-// be enumerated for, since each such policy doubles the number of views
-class SOURCEMETA_ONE_AUTHENTICATION_EXPORT AuthenticationTooManyViewsError
-    : public std::exception {
-public:
-  AuthenticationTooManyViewsError(std::string issuer, const std::size_t count)
-      : issuer_{std::move(issuer)}, count_{count} {}
-
-  [[nodiscard]] auto what() const noexcept -> const char * override {
-    return "Too many authentication policies share an issuer";
-  }
-
-  [[nodiscard]] auto issuer() const noexcept -> const std::string & {
-    return this->issuer_;
-  }
-
-  [[nodiscard]] auto count() const noexcept -> std::size_t {
-    return this->count_;
-  }
-
-private:
-  std::string issuer_;
-  std::size_t count_;
-};
-
 } // namespace sourcemeta::one
 
 #endif

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -89,11 +89,6 @@ TEST(permits_every_reference) {
       authentication.reference_permitted(at("/internal/a"), at("/internal/a")));
 }
 
-// This edition serves every path publicly, so however a configuration is
-// written there is one way to see the registry. These pin that the answer does
-// not depend on the question, since the enterprise edition's answer does, and a
-// build reads whichever edition it was compiled against.
-
 TEST(views_of_nothing_are_the_public_one_alone) {
   const auto views{sourcemeta::one::Authentication::views({})};
   EXPECT_EQ(views.size(), 1);
@@ -134,9 +129,7 @@ TEST(views_of_several_policies_are_the_public_one_alone) {
 }
 
 TEST(views_never_refuse_a_configuration_this_edition_cannot_hold) {
-  // The count that would trip the bound elsewhere. This edition rejects such a
-  // configuration when it is written rather than when its views are asked for,
-  // so asking is answerable whatever it names
+  // The count that would trip the bound elsewhere
   const std::array<std::string_view, 1> paths{{"/one"}};
   const std::array<sourcemeta::one::Authentication::Policy, 7> policies{
       {{.paths = paths,

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -6,6 +6,7 @@
 #include <span>        // std::span
 #include <string>      // std::string
 #include <string_view> // std::string_view
+#include <vector>      // std::vector
 
 // Every gate question is asked about a canonical location, so the tests name
 // one the same way a request would
@@ -86,4 +87,87 @@ TEST(permits_every_reference) {
                                                  at("/private/two")));
   EXPECT_TRUE(
       authentication.reference_permitted(at("/internal/a"), at("/internal/a")));
+}
+
+// This edition serves every path publicly, so however a configuration is
+// written there is one way to see the registry. These pin that the answer does
+// not depend on the question, since the enterprise edition's answer does, and a
+// build reads whichever edition it was compiled against.
+
+TEST(views_of_nothing_are_the_public_one_alone) {
+  const auto views{sourcemeta::one::Authentication::views({})};
+  EXPECT_EQ(views.size(), 1);
+  EXPECT_EQ(views.at(0).name, "public");
+  EXPECT_TRUE(views.at(0).policies.empty());
+}
+
+TEST(views_of_a_static_key_policy_are_the_public_one_alone) {
+  const std::array<std::string_view, 1> paths{{"/private"}};
+  const std::array<std::string_view, 1> keys{{"secret"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .keys = keys,
+        .type = sourcemeta::one::Authentication::Type::ApiKey,
+        .name = "vault"}}};
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(views.size(), 1);
+  EXPECT_EQ(views.at(0).name, "public");
+  EXPECT_TRUE(views.at(0).policies.empty());
+}
+
+TEST(views_of_several_policies_are_the_public_one_alone) {
+  const std::array<std::string_view, 1> first_paths{{"/legal"}};
+  const std::array<std::string_view, 1> second_paths{{"/tech"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = first_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "legal"},
+       {.paths = second_paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "tech"}}};
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(views.size(), 1);
+  EXPECT_EQ(views.at(0).name, "public");
+  EXPECT_TRUE(views.at(0).policies.empty());
+}
+
+TEST(views_never_refuse_a_configuration_this_edition_cannot_hold) {
+  // The count that would trip the bound elsewhere. This edition rejects such a
+  // configuration when it is written rather than when its views are asked for,
+  // so asking is answerable whatever it names
+  const std::array<std::string_view, 1> paths{{"/one"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 7> policies{
+      {{.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "a"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "b"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "c"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "d"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "e"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "f"},
+       {.paths = paths,
+        .type = sourcemeta::one::Authentication::Type::JWT,
+        .issuer = "https://idp.example.com/realms/staff",
+        .name = "g"}}};
+  const auto views{sourcemeta::one::Authentication::views(policies)};
+  EXPECT_EQ(views.size(), 1);
+  EXPECT_EQ(views.at(0).name, "public");
 }

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -2,6 +2,7 @@
 #include <sourcemeta/one/authentication.h>
 
 #include <array>       // std::array
+#include <cstddef>     // std::size_t
 #include <filesystem>  // std::filesystem::path
 #include <span>        // std::span
 #include <string>      // std::string
@@ -91,9 +92,8 @@ TEST(permits_every_reference) {
 
 TEST(views_of_nothing_are_the_public_one_alone) {
   const auto views{sourcemeta::one::Authentication::views({})};
-  EXPECT_EQ(views.size(), 1);
-  EXPECT_EQ(views.at(0).name, "public");
-  EXPECT_TRUE(views.at(0).policies.empty());
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}}}));
 }
 
 TEST(views_of_a_static_key_policy_are_the_public_one_alone) {
@@ -104,10 +104,10 @@ TEST(views_of_a_static_key_policy_are_the_public_one_alone) {
         .keys = keys,
         .type = sourcemeta::one::Authentication::Type::ApiKey,
         .name = "vault"}}};
+
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(views.size(), 1);
-  EXPECT_EQ(views.at(0).name, "public");
-  EXPECT_TRUE(views.at(0).policies.empty());
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}}}));
 }
 
 TEST(views_of_several_policies_are_the_public_one_alone) {
@@ -122,45 +122,26 @@ TEST(views_of_several_policies_are_the_public_one_alone) {
         .type = sourcemeta::one::Authentication::Type::JWT,
         .issuer = "https://idp.example.com/realms/staff",
         .name = "tech"}}};
+
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(views.size(), 1);
-  EXPECT_EQ(views.at(0).name, "public");
-  EXPECT_TRUE(views.at(0).policies.empty());
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}}}));
 }
 
 TEST(views_never_refuse_a_configuration_this_edition_cannot_hold) {
   // The count that would trip the bound elsewhere
   const std::array<std::string_view, 1> paths{{"/one"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 7> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "a"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "b"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "c"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "d"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "e"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "f"},
-       {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "g"}}};
+  std::array<sourcemeta::one::Authentication::Policy, 7> policies{};
+  const std::array<std::string_view, 7> names{
+      {"a", "b", "c", "d", "e", "f", "g"}};
+  for (std::size_t index{0}; index < policies.size(); index++) {
+    policies.at(index).paths = paths;
+    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
+    policies.at(index).issuer = "https://idp.example.com/realms/staff";
+    policies.at(index).name = names.at(index);
+  }
+
   const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(views.size(), 1);
-  EXPECT_EQ(views.at(0).name, "public");
+  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
+                       {.name = "public", .policies = {}}}));
 }

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -127,21 +127,3 @@ TEST(views_of_several_policies_are_the_public_one_alone) {
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}}}));
 }
-
-TEST(views_never_refuse_a_configuration_this_edition_cannot_hold) {
-  // The count that would trip the bound elsewhere
-  const std::array<std::string_view, 1> paths{{"/one"}};
-  std::array<sourcemeta::one::Authentication::Policy, 7> policies{};
-  const std::array<std::string_view, 7> names{
-      {"a", "b", "c", "d", "e", "f", "g"}};
-  for (std::size_t index{0}; index < policies.size(); index++) {
-    policies.at(index).paths = paths;
-    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
-    policies.at(index).issuer = "https://idp.example.com/realms/staff";
-    policies.at(index).name = names.at(index);
-  }
-
-  const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}}}));
-}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

