### PR TITLE
Serve each request from the view its caller resolves to

### DIFF
--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -77,7 +77,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
@@ -62,7 +62,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_logout_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_logout_v1.h
@@ -45,7 +45,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_jsonschema_rdf_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_jsonschema_rdf_v1.h
@@ -59,7 +59,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            const std::string_view credential,
+            const std::string_view credential, const std::string_view,
             sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     const auto &path{matches.front()};
@@ -106,9 +106,11 @@ public:
     schema_uri.append(path);
     const sourcemeta::one::RequestCookies cookies{request};
     const auto schema_present{
-        this->artifact_resolve_path({.bearer = credential, .cookies = cookies},
+        this->artifact_resolve_path(sourcemeta::one::VIEW_PUBLIC,
+                                    {.bearer = credential, .cookies = cookies},
                                     schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
+        sourcemeta::one::VIEW_PUBLIC,
         {.bearer = credential, .cookies = cookies}, schema_uri, Tree::Schemas,
         "blaze-exhaustive")};
     if (schema_present.outcome ==
@@ -349,10 +351,12 @@ public:
     }
 
     const auto &schema_uri{arguments.at("schema").to_string()};
-    const auto schema_present{this->artifact_resolve_path(
-        credentials, schema_uri, Tree::Schemas, "schema")};
+    const auto schema_present{
+        this->artifact_resolve_path(sourcemeta::one::VIEW_PUBLIC, credentials,
+                                    schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
-        credentials, schema_uri, Tree::Schemas, "blaze-exhaustive")};
+        sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri, Tree::Schemas,
+        "blaze-exhaustive")};
     if (schema_present.outcome ==
             sourcemeta::one::ArtifactResolution::Outcome::Denied ||
         evaluation_enabled.outcome ==

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_prm_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_prm_v1.h
@@ -65,7 +65,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
@@ -97,7 +97,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view credential,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     // MCP Streamable HTTP transport / Security Warning:
     // "Servers MUST validate the Origin header on all incoming connections
@@ -521,7 +521,8 @@ private:
     }
 
     const auto resolution{this->artifact_resolve_path(
-        credentials, uri, Tree::Schemas, bundle ? "bundle" : "schema")};
+        sourcemeta::one::VIEW_PUBLIC, credentials, uri, Tree::Schemas,
+        bundle ? "bundle" : "schema")};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       return sourcemeta::core::jsonrpc_make_error(&id, -32010,

--- a/src/actions/action_auth_callback_v1.h
+++ b/src/actions/action_auth_callback_v1.h
@@ -50,7 +50,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);

--- a/src/actions/action_auth_login_v1.h
+++ b/src/actions/action_auth_login_v1.h
@@ -50,7 +50,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);

--- a/src/actions/action_auth_logout_v1.h
+++ b/src/actions/action_auth_logout_v1.h
@@ -44,7 +44,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);

--- a/src/actions/action_default_v1.h
+++ b/src/actions/action_default_v1.h
@@ -43,7 +43,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view credential,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",
@@ -104,7 +104,7 @@ public:
       const auto serve_html{
           sourcemeta::one::prefers_html(request.header("accept"))};
       const auto root_html{this->artifact_resolve_path(
-          {.bearer = credential, .cookies = cookies}, "", Tree::Explorer,
+          view, {.bearer = credential, .cookies = cookies}, "", Tree::Explorer,
           "directory-html")};
       if (root_html.outcome ==
           sourcemeta::one::ArtifactResolution::Outcome::Denied) {
@@ -145,11 +145,11 @@ public:
     if (request.method() == "get" || request.method() == "head") {
       if (sourcemeta::one::prefers_html(request.header("accept"))) {
         const auto schema_html{this->artifact_resolve_path(
-            {.bearer = credential, .cookies = cookies}, path, Tree::Explorer,
-            "schema-html")};
+            view, {.bearer = credential, .cookies = cookies}, path,
+            Tree::Explorer, "schema-html")};
         const auto directory_html{this->artifact_resolve_path(
-            {.bearer = credential, .cookies = cookies}, path, Tree::Explorer,
-            "directory-html")};
+            view, {.bearer = credential, .cookies = cookies}, path,
+            Tree::Explorer, "directory-html")};
         if (schema_html.outcome ==
                 sourcemeta::one::ArtifactResolution::Outcome::Denied ||
             directory_html.outcome ==
@@ -199,14 +199,15 @@ public:
       // the response must be 405 with Allow listing what is supported.
       // https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.6
       const auto schema_json{this->artifact_resolve_path(
+          sourcemeta::one::VIEW_PUBLIC,
           {.bearer = credential, .cookies = cookies}, path, Tree::Schemas,
           "schema")};
       const auto schema_html{this->artifact_resolve_path(
-          {.bearer = credential, .cookies = cookies}, path, Tree::Explorer,
-          "schema-html")};
+          view, {.bearer = credential, .cookies = cookies}, path,
+          Tree::Explorer, "schema-html")};
       const auto directory_html{this->artifact_resolve_path(
-          {.bearer = credential, .cookies = cookies}, path, Tree::Explorer,
-          "directory-html")};
+          view, {.bearer = credential, .cookies = cookies}, path,
+          Tree::Explorer, "directory-html")};
       if (schema_json.outcome ==
               sourcemeta::one::ArtifactResolution::Outcome::Denied ||
           schema_html.outcome ==

--- a/src/actions/action_dependency_tree_v1.h
+++ b/src/actions/action_dependency_tree_v1.h
@@ -53,7 +53,8 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, sourcemeta::one::HTTPRequest &request,
+            std::string_view credential, std::string_view view,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",
@@ -82,7 +83,7 @@ public:
 
     const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{this->artifact_resolve_path(
-        {.bearer = credential, .cookies = cookies}, matches.front(),
+        view, {.bearer = credential, .cookies = cookies}, matches.front(),
         this->tree_, this->metapack_)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
@@ -118,8 +119,11 @@ public:
           std::move(request_output));
     }
 
+    // A tool call reaches one artifact, so placing the caller here is still
+    // once for the request that carried them
+    const auto view{this->dispatcher().authentication().view(credentials)};
     const auto resolution{this->artifact_resolve_path(
-        credentials, arguments.at("schema").to_string(), this->tree_,
+        view, credentials, arguments.at("schema").to_string(), this->tree_,
         this->metapack_)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {

--- a/src/actions/action_health_check_v1.h
+++ b/src/actions/action_health_check_v1.h
@@ -38,7 +38,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",

--- a/src/actions/action_jsonschema_evaluate_v1.h
+++ b/src/actions/action_jsonschema_evaluate_v1.h
@@ -51,7 +51,8 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, sourcemeta::one::HTTPRequest &request,
+            std::string_view credential, std::string_view,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     const sourcemeta::one::RequestCookies cookies{request};
     ActionJSONSchemaEvaluate_v1::serve_post(
@@ -89,10 +90,12 @@ public:
     }
 
     const auto &schema_uri{arguments.at("schema").to_string()};
-    const auto schema_present{this->artifact_resolve_path(
-        credentials, schema_uri, Tree::Schemas, "schema")};
+    const auto schema_present{
+        this->artifact_resolve_path(sourcemeta::one::VIEW_PUBLIC, credentials,
+                                    schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
-        credentials, schema_uri, Tree::Schemas, "blaze-exhaustive")};
+        sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri, Tree::Schemas,
+        "blaze-exhaustive")};
     if (schema_present.outcome ==
             sourcemeta::one::ArtifactResolution::Outcome::Denied ||
         evaluation_enabled.outcome ==
@@ -183,11 +186,11 @@ public:
     schema_uri.push_back('/');
     schema_uri.append(path);
     const auto schema_present{self.artifact_resolve_path(
-        credentials, schema_uri, sourcemeta::one::RouterAction::Tree::Schemas,
-        "schema")};
+        sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri,
+        sourcemeta::one::RouterAction::Tree::Schemas, "schema")};
     const auto evaluation_enabled{self.artifact_resolve_path(
-        credentials, schema_uri, sourcemeta::one::RouterAction::Tree::Schemas,
-        "blaze-exhaustive")};
+        sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri,
+        sourcemeta::one::RouterAction::Tree::Schemas, "blaze-exhaustive")};
     if (schema_present.outcome ==
             sourcemeta::one::ArtifactResolution::Outcome::Denied ||
         evaluation_enabled.outcome ==

--- a/src/actions/action_jsonschema_rdf_v1.h
+++ b/src/actions/action_jsonschema_rdf_v1.h
@@ -47,7 +47,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);

--- a/src/actions/action_jsonschema_serve_v1.h
+++ b/src/actions/action_jsonschema_serve_v1.h
@@ -60,6 +60,7 @@ public:
                                         : std::string_view{"schema"}};
     const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{self.artifact_resolve_path(
+        sourcemeta::one::VIEW_PUBLIC,
         {.bearer = credential, .cookies = cookies}, schema_path,
         sourcemeta::one::RouterAction::Tree::Schemas, artifact)};
     if (resolution.outcome ==
@@ -91,7 +92,8 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, sourcemeta::one::HTTPRequest &request,
+            std::string_view credential, std::string_view,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",

--- a/src/actions/action_jsonschema_trace_v1.h
+++ b/src/actions/action_jsonschema_trace_v1.h
@@ -62,7 +62,8 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, sourcemeta::one::HTTPRequest &request,
+            std::string_view credential, std::string_view,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     const sourcemeta::one::RequestCookies cookies{request};
     ActionJSONSchemaEvaluate_v1::serve_post(
@@ -101,10 +102,12 @@ public:
     }
 
     const auto &schema_uri{arguments.at("schema").to_string()};
-    const auto schema_present{this->artifact_resolve_path(
-        credentials, schema_uri, Tree::Schemas, "schema")};
+    const auto schema_present{
+        this->artifact_resolve_path(sourcemeta::one::VIEW_PUBLIC, credentials,
+                                    schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
-        credentials, schema_uri, Tree::Schemas, "blaze-exhaustive")};
+        sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri, Tree::Schemas,
+        "blaze-exhaustive")};
     if (schema_present.outcome ==
             sourcemeta::one::ArtifactResolution::Outcome::Denied ||
         evaluation_enabled.outcome ==
@@ -164,7 +167,8 @@ private:
       auto cached{referenced_locations.find(schema_uri)};
       if (cached == referenced_locations.end()) {
         const auto locations_resolution{this->artifact_resolve_path(
-            credentials, keyword_location_string, Tree::Schemas, "locations")};
+            sourcemeta::one::VIEW_PUBLIC, credentials, keyword_location_string,
+            Tree::Schemas, "locations")};
         if (locations_resolution.outcome ==
             sourcemeta::one::ArtifactResolution::Outcome::Found) {
           auto locations{
@@ -218,8 +222,9 @@ private:
       -> sourcemeta::core::JSON {
     auto steps{sourcemeta::core::JSON::make_array()};
 
-    const auto locations_resolution{this->artifact_resolve_path(
-        credentials, schema_uri, Tree::Schemas, "locations")};
+    const auto locations_resolution{
+        this->artifact_resolve_path(sourcemeta::one::VIEW_PUBLIC, credentials,
+                                    schema_uri, Tree::Schemas, "locations")};
     if (locations_resolution.outcome !=
         sourcemeta::one::ArtifactResolution::Outcome::Found) {
       throw std::runtime_error{"Failed to read schema locations metadata"};

--- a/src/actions/action_list_directory_v1.h
+++ b/src/actions/action_list_directory_v1.h
@@ -49,7 +49,8 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, sourcemeta::one::HTTPRequest &request,
+            std::string_view credential, std::string_view view,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",
@@ -60,9 +61,9 @@ public:
     const std::string_view path_match{matches.empty() ? std::string_view{}
                                                       : matches.front()};
     const sourcemeta::one::RequestCookies cookies{request};
-    const auto resolution{
-        this->artifact_resolve_path({.bearer = credential, .cookies = cookies},
-                                    path_match, Tree::Explorer, "directory")};
+    const auto resolution{this->artifact_resolve_path(
+        view, {.bearer = credential, .cookies = cookies}, path_match,
+        Tree::Explorer, "directory")};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       sourcemeta::one::json_error_unauthorized(request, response,
@@ -99,8 +100,11 @@ public:
 
     static const sourcemeta::core::JSON EMPTY_STRING{""};
     const auto &path_arg{arguments.at_or("path", EMPTY_STRING).to_string()};
+    // A tool call reaches one artifact, so placing the caller here is still
+    // once for the request that carried them
+    const auto view{this->dispatcher().authentication().view(credentials)};
     const auto resolution{this->artifact_resolve_path(
-        credentials, path_arg, Tree::Explorer, "directory")};
+        view, credentials, path_arg, Tree::Explorer, "directory")};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       return sourcemeta::core::mcp_make_tool_error(request_id,

--- a/src/actions/action_mcp_prm_v1.h
+++ b/src/actions/action_mcp_prm_v1.h
@@ -53,7 +53,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",

--- a/src/actions/action_mcp_v1.h
+++ b/src/actions/action_mcp_v1.h
@@ -62,7 +62,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);

--- a/src/actions/action_not_found_v1.h
+++ b/src/actions/action_not_found_v1.h
@@ -38,7 +38,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     sourcemeta::one::json_error(
         request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,

--- a/src/actions/action_schema_search_v1.h
+++ b/src/actions/action_schema_search_v1.h
@@ -55,7 +55,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view>, std::string_view credential,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",

--- a/src/actions/action_serve_explorer_artifact_v1.h
+++ b/src/actions/action_serve_explorer_artifact_v1.h
@@ -48,7 +48,8 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, sourcemeta::one::HTTPRequest &request,
+            std::string_view credential, std::string_view view,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",
@@ -71,8 +72,8 @@ public:
                                                       : matches.front()};
     const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{this->artifact_resolve_path(
-        {.bearer = credential, .cookies = cookies}, path_match, Tree::Explorer,
-        this->artifact_)};
+        view, {.bearer = credential, .cookies = cookies}, path_match,
+        Tree::Explorer, this->artifact_)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       sourcemeta::one::json_error_unauthorized(request, response,
@@ -107,8 +108,11 @@ public:
           std::move(request_output));
     }
 
+    // A tool call reaches one artifact, so placing the caller here is still
+    // once for the request that carried them
+    const auto view{this->dispatcher().authentication().view(credentials)};
     const auto resolution{this->artifact_resolve_path(
-        credentials, arguments.at("schema").to_string(), Tree::Explorer,
+        view, credentials, arguments.at("schema").to_string(), Tree::Explorer,
         this->artifact_)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {

--- a/src/actions/action_serve_schema_artifact_v1.h
+++ b/src/actions/action_serve_schema_artifact_v1.h
@@ -49,7 +49,8 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, sourcemeta::one::HTTPRequest &request,
+            std::string_view credential, std::string_view,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",
@@ -78,6 +79,7 @@ public:
 
     const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{this->artifact_resolve_path(
+        sourcemeta::one::VIEW_PUBLIC,
         {.bearer = credential, .cookies = cookies}, matches.front(),
         Tree::Schemas, this->artifact_)};
     if (resolution.outcome ==
@@ -115,8 +117,8 @@ public:
     }
 
     const auto resolution{this->artifact_resolve_path(
-        credentials, arguments.at("schema").to_string(), Tree::Schemas,
-        this->artifact_)};
+        sourcemeta::one::VIEW_PUBLIC, credentials,
+        arguments.at("schema").to_string(), Tree::Schemas, this->artifact_)};
     if (resolution.outcome ==
         sourcemeta::one::ArtifactResolution::Outcome::Denied) {
       return sourcemeta::core::mcp_make_tool_error(request_id,

--- a/src/actions/action_serve_static_v1.h
+++ b/src/actions/action_serve_static_v1.h
@@ -40,7 +40,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches, std::string_view,
-            sourcemeta::one::HTTPRequest &request,
+            std::string_view, sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",

--- a/src/router/artifact.cc
+++ b/src/router/artifact.cc
@@ -38,12 +38,14 @@ auto RouterAction::canonical_path(const std::string_view input) const
 }
 
 auto RouterAction::artifact_locate(const Authentication::Path &path,
-                                   const Tree tree,
+                                   const Tree tree, const std::string_view view,
                                    const std::string_view artifact_name) const
     -> std::optional<std::filesystem::path> {
+  // The unit tree holds one answer whoever asks, so only the view tree carries
+  // the segment naming who is being served
   const auto tree_root{tree == Tree::Schemas
                            ? this->index_directory_ / "schemas"
-                           : this->index_directory_ / "explorer" / VIEW_PUBLIC};
+                           : this->index_directory_ / "explorer" / view};
   auto directory{tree_root};
   // The tree stores a resource once, whatever representation was asked for
   const auto location{
@@ -64,9 +66,9 @@ auto RouterAction::artifact_locate(const Authentication::Path &path,
 }
 
 auto RouterAction::artifact_resolve_path(
-    const Credentials credentials, const std::string_view input,
-    const Tree tree, const std::string_view artifact_name) const
-    -> ArtifactResolution {
+    const std::string_view view, const Credentials credentials,
+    const std::string_view input, const Tree tree,
+    const std::string_view artifact_name) const -> ArtifactResolution {
   // The gate and the locator have to agree on where a request points, so both
   // read the one canonical path rather than each deriving its own. A path that
   // names nowhere in this instance is refused without consulting the gate,
@@ -92,7 +94,7 @@ auto RouterAction::artifact_resolve_path(
             .is_public = false};
   }
 
-  auto located{this->artifact_locate(path.value(), tree, artifact_name)};
+  auto located{this->artifact_locate(path.value(), tree, view, artifact_name)};
   if (!located.has_value()) {
     return {.outcome = ArtifactResolution::Outcome::NotFound,
             .path = std::nullopt,
@@ -120,7 +122,8 @@ auto RouterAction::artifact_resolve_path_unauthenticated(
     return std::nullopt;
   }
 
-  auto located{this->artifact_locate(path.value(), tree, artifact_name)};
+  auto located{
+      this->artifact_locate(path.value(), tree, VIEW_PUBLIC, artifact_name)};
   if (!located.has_value()) {
     return std::nullopt;
   }

--- a/src/router/evaluate.cc
+++ b/src/router/evaluate.cc
@@ -64,8 +64,11 @@ auto RouterAction::blaze_template(const Credentials credentials,
                                   const std::string_view schema_uri,
                                   const sourcemeta::blaze::Mode mode) const
     -> std::shared_ptr<const sourcemeta::blaze::Template> {
+  // A compiled schema lives in the unit tree, which holds one answer whoever
+  // asks and carries no segment naming a view, so what is named here reaches
+  // no path and the anonymous one stands for every caller
   const auto resolution{this->artifact_resolve_path(
-      credentials, schema_uri, Tree::Schemas,
+      sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri, Tree::Schemas,
       mode == sourcemeta::blaze::Mode::FastValidation ? "blaze-fast"
                                                       : "blaze-exhaustive")};
   assert(resolution.outcome == ArtifactResolution::Outcome::Found);

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -126,9 +126,13 @@ public:
   auto operator=(const RouterAction &) -> RouterAction & = delete;
   auto operator=(RouterAction &&) -> RouterAction & = delete;
 
+  // The view a caller is served arrives alongside what they presented, because
+  // it follows from the same reading and a request resolves several artifacts.
+  // Working it out where a path is built would place the same caller once per
+  // artifact rather than once per request
   virtual auto rest(const std::span<std::string_view> matches,
-                    std::string_view credential, HTTPRequest &request,
-                    HTTPResponse &response) -> void = 0;
+                    std::string_view credential, std::string_view view,
+                    HTTPRequest &request, HTTPResponse &response) -> void = 0;
 
   // The whole credential rather than the bearer alone, since a browser reaching
   // a tool is admitted by its session cookie and would otherwise pass the gate
@@ -205,7 +209,8 @@ public:
     std::string_view x_frame_options{};
   };
 
-  [[nodiscard]] auto artifact_resolve_path(Credentials credentials,
+  [[nodiscard]] auto artifact_resolve_path(std::string_view view,
+                                           Credentials credentials,
                                            std::string_view input, Tree tree,
                                            std::string_view artifact_name) const
       -> ArtifactResolution;
@@ -289,7 +294,7 @@ protected:
 
 private:
   [[nodiscard]] auto artifact_locate(const Authentication::Path &path,
-                                     Tree tree,
+                                     Tree tree, std::string_view view,
                                      std::string_view artifact_name) const
       -> std::optional<std::filesystem::path>;
 

--- a/src/router/router.cc
+++ b/src/router/router.cc
@@ -145,7 +145,12 @@ auto Router::dispatch(
     return;
   }
 
-  instance->rest(matches, credential, request, response);
+  // Resolved once here, since the same caller is served every artifact this
+  // request reaches and placing them again for each of them would repeat the
+  // reading rather than the lookup
+  const auto view{
+      this->authentication_.view({.bearer = credential, .cookies = cookies})};
+  instance->rest(matches, credential, view, request, response);
 }
 
 // A denial only becomes a silent renewal when the browser carries the marker a


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

