### PR TITLE
Pre-render MCP resource lists during indexing

### DIFF
--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
@@ -322,14 +322,6 @@ public:
 private:
   static constexpr std::string_view MCP_TEMPLATE_MIME_TYPE{
       "application/schema+json"};
-  static constexpr std::size_t MCP_RESOURCES_PAGE_SIZE{50};
-
-  static constexpr std::string_view MCP_KEY_RESOURCES{"resources"};
-  static constexpr std::string_view MCP_KEY_NEXT_CURSOR{"nextCursor"};
-  static inline const auto MCP_HASH_RESOURCES{
-      sourcemeta::core::JSON::Object::hash(MCP_KEY_RESOURCES)};
-  static inline const auto MCP_HASH_NEXT_CURSOR{
-      sourcemeta::core::JSON::Object::hash(MCP_KEY_NEXT_CURSOR)};
 
   auto
   write_envelope(sourcemeta::one::HTTPRequest &request,
@@ -373,8 +365,13 @@ private:
                          const std::string_view view) const
       -> sourcemeta::core::JSON {
     const auto &id{request_json.at("id")};
-    const auto &pages{this->metadata_for(view).at(
-        sourcemeta::core::MCP_METHOD_RESOURCES_LIST)};
+    const auto &metadata{this->metadata_for(view)};
+    const auto &pages{metadata.at(sourcemeta::core::MCP_METHOD_RESOURCES_LIST)};
+    // The pages were cut somewhere, and the artifact says where, so a cursor is
+    // read against how these very pages were written
+    const auto page_size{static_cast<std::uint64_t>(
+        metadata.at("resourcePageSize").to_integer())};
+    assert(page_size > 0);
 
     std::uint64_t offset{0};
     const auto *params{sourcemeta::core::jsonrpc_params(request_json)};
@@ -384,8 +381,7 @@ private:
         const auto parsed{sourcemeta::core::to_uint64_t(cursor_input)};
         // A cursor names a page boundary, so one that parses to anything else
         // names no page at all
-        if (!parsed.has_value() ||
-            parsed.value() % MCP_RESOURCES_PAGE_SIZE != 0) {
+        if (!parsed.has_value() || parsed.value() % page_size != 0) {
           return sourcemeta::core::jsonrpc_make_error(
               &id, -32602, "Invalid resource list cursor",
               sourcemeta::core::JSON{
@@ -399,7 +395,7 @@ private:
     // The pages were written for this view, so answering is finding the one
     // asked for. A catalog holding nothing still has a first page, which is why
     // the beginning is always a page and anything past the end is not
-    const auto index{offset / MCP_RESOURCES_PAGE_SIZE};
+    const auto index{offset / page_size};
     if (index >= pages.size()) {
       return sourcemeta::core::jsonrpc_make_error(
           &id, -32602, "Invalid resource list cursor",

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
@@ -12,7 +12,6 @@
 #include <sourcemeta/one/http.h>
 #include <sourcemeta/one/metapack.h>
 #include <sourcemeta/one/router.h>
-#include <sourcemeta/one/search.h>
 
 #include <cassert>   // assert
 #include <cstddef>   // std::size_t, std::ptrdiff_t
@@ -43,31 +42,6 @@ public:
                const sourcemeta::core::URITemplateRouter::Identifier identifier,
                sourcemeta::one::Router &dispatcher)
       : sourcemeta::one::RouterAction{base, router.base_url(), dispatcher} {
-    const auto &views{dispatcher.authentication()};
-    for (std::size_t index{0}; index < views.view_count(); index++) {
-      const auto recorded{views.view_at(index)};
-      this->search_views_.emplace(
-          recorded.name,
-          std::make_unique<sourcemeta::one::SearchView>(
-              base / "explorer" / recorded.name / "%" / "search.metapack"));
-    }
-
-    // The anonymous view is among the recorded ones, so this is a lookup
-    // rather than a second index. It stands for a caller whose view this
-    // instance no longer serves, which is a build behind a running server
-    auto fallback{this->search_views_.find(sourcemeta::one::VIEW_PUBLIC)};
-    if (fallback == this->search_views_.cend()) {
-      fallback =
-          this->search_views_
-              .emplace(sourcemeta::one::VIEW_PUBLIC,
-                       std::make_unique<sourcemeta::one::SearchView>(
-                           base / "explorer" / sourcemeta::one::VIEW_PUBLIC /
-                           "%" / "search.metapack"))
-              .first;
-    }
-
-    this->default_search_view_ = fallback->second.get();
-
     router.arguments(
         identifier, [this](const auto &key, const auto &value) -> void {
           if (key == "responseSchema") {
@@ -396,9 +370,11 @@ private:
   }
 
   auto on_resources_list(const sourcemeta::core::JSON &request_json,
-                         const sourcemeta::one::Credentials &credentials)
+                         const std::string_view view) const
       -> sourcemeta::core::JSON {
     const auto &id{request_json.at("id")};
+    const auto &pages{this->metadata_for(view).at(
+        sourcemeta::core::MCP_METHOD_RESOURCES_LIST)};
 
     std::uint64_t offset{0};
     const auto *params{sourcemeta::core::jsonrpc_params(request_json)};
@@ -406,8 +382,8 @@ private:
       const auto cursor_input{params->at("cursor").to_string()};
       if (!cursor_input.empty()) {
         const auto parsed{sourcemeta::core::to_uint64_t(cursor_input)};
-        // A cursor must parse and align to a page boundary. Reject before the
-        // catalog scan so a malformed cursor cannot force the O(N) walk
+        // A cursor names a page boundary, so one that parses to anything else
+        // names no page at all
         if (!parsed.has_value() ||
             parsed.value() % MCP_RESOURCES_PAGE_SIZE != 0) {
           return sourcemeta::core::jsonrpc_make_error(
@@ -420,30 +396,11 @@ private:
       }
     }
 
-    // What a caller may list was settled when their view was written, so the
-    // index read here holds that and nothing else. Only the page asked for is
-    // walked, rather than the whole of it to find out
-    auto &search_view{this->search_view_for(
-        this->dispatcher().authentication().view(credentials))};
-    const auto total{search_view.count()};
-    auto resources{sourcemeta::core::JSON::make_array()};
-    search_view.for_each(
-        offset, MCP_RESOURCES_PAGE_SIZE,
-        [this,
-         &resources](const sourcemeta::one::SearchListEntry &entry) -> void {
-          std::string uri{this->allowed_origin_};
-          uri.append(entry.path);
-          resources.push_back(sourcemeta::core::mcp_make_resource(
-              uri, entry.title.empty() ? entry.path : entry.title,
-              MCP_TEMPLATE_MIME_TYPE, entry.description,
-              static_cast<std::size_t>(entry.bytes_raw),
-              static_cast<double>(entry.priority) / 100.0));
-        });
-
-    // The alignment of a non-zero cursor is already validated above. A cursor
-    // past the end of the catalog is out of range, though zero is always valid
-    // even when the catalog is empty
-    if (offset != 0 && offset >= total) {
+    // The pages were written for this view, so answering is finding the one
+    // asked for. A catalog holding nothing still has a first page, which is why
+    // the beginning is always a page and anything past the end is not
+    const auto index{offset / MCP_RESOURCES_PAGE_SIZE};
+    if (index >= pages.size()) {
       return sourcemeta::core::jsonrpc_make_error(
           &id, -32602, "Invalid resource list cursor",
           sourcemeta::core::JSON{
@@ -451,17 +408,8 @@ private:
               "response, or omit it to start from the beginning"});
     }
 
-    auto page{sourcemeta::core::JSON::make_object()};
-    page.assign_assume_new("resources", std::move(resources),
-                           MCP_HASH_RESOURCES);
-    if (offset + MCP_RESOURCES_PAGE_SIZE < total) {
-      page.assign_assume_new("nextCursor",
-                             sourcemeta::core::JSON{std::to_string(
-                                 offset + MCP_RESOURCES_PAGE_SIZE)},
-                             MCP_HASH_NEXT_CURSOR);
-    }
-
-    return sourcemeta::core::jsonrpc_make_success(id, std::move(page));
+    return sourcemeta::core::jsonrpc_make_success(
+        id, pages.at(static_cast<std::size_t>(index)));
   }
 
   auto on_initialize(const sourcemeta::core::JSON &request_json,
@@ -758,7 +706,7 @@ private:
       return this->on_tools_list(version, request_json, view);
     }
     if (method == sourcemeta::core::MCP_METHOD_RESOURCES_LIST) {
-      return this->on_resources_list(request_json, credentials);
+      return this->on_resources_list(request_json, view);
     }
     if (method == sourcemeta::core::MCP_METHOD_RESOURCES_READ) {
       return this->on_resources_read(request_json, credentials);
@@ -781,19 +729,6 @@ private:
   std::unordered_map<std::string_view, sourcemeta::core::JSON> metadata_views_;
   std::string challenge_;
   std::string resource_identifier_;
-  // A caller is answered out of the index their view holds, so what a listing
-  // can name is what the caller could have reached by looking
-  [[nodiscard]] auto search_view_for(const std::string_view view)
-      -> sourcemeta::one::SearchView & {
-    const auto match{this->search_views_.find(view)};
-    return match == this->search_views_.cend() ? *this->default_search_view_
-                                               : *match->second;
-  }
-
-  std::unordered_map<std::string_view,
-                     std::unique_ptr<sourcemeta::one::SearchView>>
-      search_views_;
-  sourcemeta::one::SearchView *default_search_view_{nullptr};
 };
 
 #endif

--- a/src/index/explorer.h
+++ b/src/index/explorer.h
@@ -740,6 +740,13 @@ struct GENERATE_LOGIN {
   }
 };
 
+// What a listing calls a schema, and how many it names before it hands out a
+// cursor. Both are settled here, since the pages are written rather than
+// assembled
+inline constexpr std::string_view MCP_RESOURCE_MIME_TYPE{
+    "application/schema+json"};
+inline constexpr std::size_t MCP_RESOURCES_PAGE_SIZE{50};
+
 struct GENERATE_MCP {
   static auto handler(const sourcemeta::one::BuildState &,
                       const sourcemeta::one::BuildPlan::Action &action,
@@ -872,8 +879,48 @@ struct GENERATE_MCP {
     resource_templates_response.assign("resourceTemplates",
                                        std::move(resource_templates));
 
+    // Every page a caller could ask for, written once for the view rather than
+    // put together on each request. What a page holds follows from the index it
+    // is built from, and that index already holds what this view may reach, so
+    // the answer depends on neither who asks nor when
+    auto resource_pages{sourcemeta::core::JSON::make_array()};
+    {
+      sourcemeta::one::SearchView search{action.dependencies.front()};
+      const auto total{search.count()};
+      std::size_t offset{0};
+      do {
+        auto resources{sourcemeta::core::JSON::make_array()};
+        search.for_each(
+            offset, MCP_RESOURCES_PAGE_SIZE,
+            [&configuration, &resources](
+                const sourcemeta::one::SearchListEntry &entry) -> void {
+              std::string uri{configuration.origin};
+              uri.append(entry.path);
+              resources.push_back(sourcemeta::core::mcp_make_resource(
+                  uri, entry.title.empty() ? entry.path : entry.title,
+                  MCP_RESOURCE_MIME_TYPE, entry.description,
+                  static_cast<std::size_t>(entry.bytes_raw),
+                  static_cast<double>(entry.priority) / 100.0));
+            });
+
+        auto page{sourcemeta::core::JSON::make_object()};
+        page.assign("resources", std::move(resources));
+        if (offset + MCP_RESOURCES_PAGE_SIZE < total) {
+          page.assign("nextCursor", sourcemeta::core::JSON{std::to_string(
+                                        offset + MCP_RESOURCES_PAGE_SIZE)});
+        }
+
+        resource_pages.push_back(std::move(page));
+        offset += MCP_RESOURCES_PAGE_SIZE;
+        // A catalog holding nothing still has a first page, so that asking for
+        // the beginning is answered rather than refused
+      } while (offset < total);
+    }
+
     auto document{sourcemeta::core::JSON::make_object()};
     document.assign("origin", sourcemeta::core::JSON{configuration.origin});
+    document.assign(std::string{sourcemeta::core::MCP_METHOD_RESOURCES_LIST},
+                    std::move(resource_pages));
     document.assign(std::string{sourcemeta::core::MCP_METHOD_INITIALIZE},
                     std::move(initialize_ingredients));
     document.assign(

--- a/src/index/explorer.h
+++ b/src/index/explorer.h
@@ -921,6 +921,14 @@ struct GENERATE_MCP {
     document.assign("origin", sourcemeta::core::JSON{configuration.origin});
     document.assign(std::string{sourcemeta::core::MCP_METHOD_RESOURCES_LIST},
                     std::move(resource_pages));
+    // How many the pages above were cut at, so that whoever reads them maps a
+    // cursor the way they were actually written rather than the way a second
+    // copy of this number happens to say. An artifact outlives the build that
+    // wrote it, and the two are then free to disagree
+    document.assign(
+        "resourcePageSize",
+        sourcemeta::core::JSON{static_cast<sourcemeta::core::JSON::Integer>(
+            MCP_RESOURCES_PAGE_SIZE)});
     document.assign(std::string{sourcemeta::core::MCP_METHOD_INITIALIZE},
                     std::move(initialize_ingredients));
     document.assign(


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

