### PR TITLE
Note MCP pre-rendered resource list scalability challenges

### DIFF
--- a/src/index/explorer.h
+++ b/src/index/explorer.h
@@ -883,6 +883,16 @@ struct GENERATE_MCP {
     // put together on each request. What a page holds follows from the index it
     // is built from, and that index already holds what this view may reach, so
     // the answer depends on neither who asks nor when
+    //
+    // TODO: Keep the pages out of the document that is parsed at startup. What
+    // is wanted is that answering reads an answer rather than builds one, and
+    // that does not require the answer to be a document. As written, every page
+    // of every view is materialised here and the whole of it is held parsed for
+    // as long as the server runs, which grows with the catalog and again with
+    // the number of views, where the search index beside it costs a mapping and
+    // no more. Worth exploring holding them pre-serialised, or in the mapped
+    // shape the search index already uses, so a page is written to the socket
+    // rather than reassembled from a tree
     auto resource_pages{sourcemeta::core::JSON::make_array()};
     {
       sourcemeta::one::SearchView search{action.dependencies.front()};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

