### PR TITLE
Simplify the `Authentication` module

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -7,8 +7,10 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/oauth.h>
 #include <sourcemeta/core/oidc.h>
+#include <sourcemeta/core/uri.h>
 
 #include "authentication_format.h"
+#include "session.h"
 
 #include <algorithm>     // std::ranges::all_of
 #include <bit>           // std::countr_zero
@@ -63,15 +65,266 @@ auto find_child(const sourcemeta::one::AuthenticationNode &node,
 // corruption could leave a header whose magic and version still match while
 // its offsets and counts point out of bounds. Validating the whole layout
 // once here keeps the matching hot path free of any per-call bounds checks
-auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
+// A browser holds one session, whichever policy established it, and the policy
+// travels inside the sealed value rather than in the name. One name means
+// signing out has a single thing to end, and means a caller cannot choose which
+// policy a value is read as by choosing what to call it
+constexpr std::string_view SESSION_COOKIE{"sourcemeta_one_session"};
+
+// A login transaction follows the same shape for the short window between the
+// login redirect and the callback
+constexpr std::string_view TRANSACTION_COOKIE{"sourcemeta_one_transaction"};
+
+// Names the policy a browser last signed in under, so that a denial can ask the
+// provider whether that sign-in still stands rather than asking the person
+// again. It outlives a session, since it is only of use once one has expired,
+// and it carries no credential: whoever holds it can start a login they were
+// free to start anyway
+constexpr std::string_view RENEWAL_COOKIE{"sourcemeta_one_renewal"};
+
+// An instance names an origin and nothing more, so every location it serves is
+// below the root, and a cookie scoped there travels to all of them
+constexpr std::string_view COOKIE_PATH{"/"};
+
+// Where a provider says its endpoints are. The values are copies, so they stay
+// usable across a refresh of what the provider last said
+struct ProviderEndpoints {
+  std::string authorization{};
+  std::string token{};
+  std::string jwks_uri{};
+  // Absent from a provider that does not offer to end its own session
+  std::string end_session{};
+  // Where a provider answers for the claims a scope requested, which under the
+  // authorization code flow is where they arrive by default rather than in the
+  // token itself
+  std::string userinfo{};
+  // Whether the provider takes the client secret in an authorization header
+  // rather than in the request body
+  bool token_endpoint_basic_auth{true};
+  // Whether the provider honours the claims request parameter, which is the
+  // standard way to ask for a claim no standard scope carries
+  bool claims_parameter_supported{false};
+  // The claims the provider says it may be able to supply. OpenID Connect
+  // Discovery Section 3 calls this list non-exhaustive, so a claim missing from
+  // it is worth reporting and never worth refusing over, and a provider
+  // publishing none says nothing at all
+  std::vector<std::string> claims_supported{};
+};
+
+// A provider answering twice about one person is two halves of one account,
+// but only one of them is signed. The address pair is carved out of the merge
+// because `email_verified` speaks for the address delivered with it, so the
+// pair is only ever taken from an answer that carried the address, and an
+// assertion left on its own is dropped whichever answer it came from
+auto combine_claims(const sourcemeta::core::JSON &token,
+                    const sourcemeta::core::JSON &extra)
+    -> sourcemeta::core::JSON {
+  if (!token.is_object()) {
+    return extra.is_object() ? extra : token;
+  }
+
+  // Nothing to combine leaves what the token said untouched, since an
+  // assertion it carried alone can vouch for no address but its own
+  if (!extra.is_object()) {
+    return token;
+  }
+
+  auto result{token};
+  const auto token_has_address{token.defines("email")};
+  const auto extra_has_address{extra.defines("email")};
+  if (!token_has_address) {
+    result.erase("email_verified");
+  }
+
+  for (const auto &claim : extra.as_object()) {
+    const auto address_pair{claim.first == "email" ||
+                            claim.first == "email_verified"};
+    // The answer that carried the address carries the assertion about it, so
+    // neither half is taken from an answer holding only one of them
+    if (address_pair && (token_has_address || !extra_has_address)) {
+      continue;
+    }
+
+    if (!result.defines(claim.first)) {
+      result.assign(claim.first, claim.second);
+    }
+  }
+
+  return result;
+}
+
+// What a policy's rules make of the claims a provider asserted
+enum class Admission : std::uint8_t {
+  // Every rule holds
+  Admitted,
+  // A rule names values that what arrived does not carry
+  Refused,
+  // A rule names a claim absent altogether. A provider answering the
+  // authorization code flow returns a scope's claims from its UserInfo endpoint
+  // rather than in the token by default, so this is the one outcome worth
+  // asking a second question about
+  Incomplete
+};
+
+// How long a login has to come back before the transaction that started it
+// stops opening
+constexpr std::chrono::seconds TRANSACTION_LIFETIME{std::chrono::minutes{10}};
+
+// The claims a policy's rules speak about, each asked for as essential, so that
+// a provider is told what is actually needed rather than being left to guess
+// from a scope. A domain rule reads an address, so it asks for the pair OpenID
+// Connect Core Section 5.1 defines for one
+auto wanted_claims(
+    const sourcemeta::one::Authentication::InteractivePolicy &policy,
+    const std::optional<sourcemeta::core::JSON> &rules)
+    -> std::vector<sourcemeta::core::OIDCClaimRequest> {
+  std::vector<sourcemeta::core::OIDCClaimRequest> result;
+  if (!policy.email_domains.empty()) {
+    result.push_back({.name = "email", .essential = true});
+    result.push_back({.name = "email_verified", .essential = true});
+  }
+
+  if (!rules.has_value() || !rules.value().is_object()) {
+    return result;
+  }
+
+  for (const auto &rule : rules.value().as_object()) {
+    result.push_back({.name = rule.first, .essential = true});
+  }
+
+  return result;
+}
+
+// The scope a login asks for. Every request carries `openid`, and a claim one
+// of the standard scopes carries adds that scope, which is the only mapping a
+// specification defines. A claim outside them adds nothing, since a scope this
+// invented could be refused outright by the provider
+auto requested_scope(
+    const std::vector<sourcemeta::core::OIDCClaimRequest> &wanted,
+    std::string &sink) -> void {
+  sink += "openid";
+  std::vector<std::string_view> scopes;
+  for (const auto &claim : wanted) {
+    const auto scope{sourcemeta::core::oidc_claim_to_scope(claim.name)};
+    if (scope.has_value() && scope.value() != "openid" &&
+        std::ranges::find(scopes, scope.value()) == scopes.cend()) {
+      scopes.push_back(scope.value());
+    }
+  }
+
+  std::ranges::sort(scopes);
+  for (const auto scope : scopes) {
+    sink += " ";
+    sink += scope;
+  }
+}
+
+// A rule naming a claim the provider never sends is one that can only ever
+// deny, and nothing in the exchange would say so: the login succeeds, the token
+// arrives, and admission fails for a reason nobody can see. So the provider's
+// own account of what it may supply is compared against what the rules ask for,
+// and a gap is named where an operator will find it.
+//
+// This reports and never refuses. OpenID Connect Discovery Section 3 says the
+// list "might not be an exhaustive list", so a claim missing from it is a hint
+// rather than a verdict, and a provider publishing no list at all is saying
+// nothing rather than saying no
+auto report_unadvertised_claims(
+    const std::vector<sourcemeta::core::OIDCClaimRequest> &wanted,
+    const ProviderEndpoints &endpoints, const std::string_view policy_name,
+    std::vector<std::string> &log) -> void {
+  if (endpoints.claims_supported.empty()) {
+    return;
+  }
+
+  // Anybody at all may start a login, so saying this on every attempt would
+  // leave a stranger able to bury everything else in the log. What it says
+  // concerns a policy and its provider rather than the attempt that surfaced
+  // it, so saying it once says all of it
+  static std::mutex mutex;
+  static std::set<std::string, std::less<>> reported;
+
+  for (const auto &claim : wanted) {
+    if (std::ranges::find(endpoints.claims_supported, claim.name) !=
+        endpoints.claims_supported.cend()) {
+      continue;
+    }
+
+    std::string subject{claim.name};
+    subject += " of the policy ";
+    subject += policy_name;
+    const std::scoped_lock guard{mutex};
+    if (!reported.insert(subject).second) {
+      continue;
+    }
+
+    std::string message{"The provider does not advertise a claim a rule "
+                        "requires, so the rule may never match. The claim is "};
+    message += subject;
+    log.push_back(std::move(message));
+  }
+}
+
+// The signature algorithms an identity token may be signed with: every
+// asymmetric one, since a provider picks from these and an instance that named
+// a narrower set would refuse a provider it could otherwise serve, after the
+// person had already signed in. The symmetric ones are left out deliberately.
+// They sign with the client secret rather than a key from the provider's
+// published set, so admitting them alongside the rest is the shape that lets
+// one algorithm be verified as though it were another
+constexpr std::array<sourcemeta::core::JWSAlgorithm, 10> ID_TOKEN_ALGORITHMS{
+    {sourcemeta::core::JWSAlgorithm::RS256,
+     sourcemeta::core::JWSAlgorithm::RS384,
+     sourcemeta::core::JWSAlgorithm::RS512,
+     sourcemeta::core::JWSAlgorithm::PS256,
+     sourcemeta::core::JWSAlgorithm::PS384,
+     sourcemeta::core::JWSAlgorithm::PS512,
+     sourcemeta::core::JWSAlgorithm::ES256,
+     sourcemeta::core::JWSAlgorithm::ES384,
+     sourcemeta::core::JWSAlgorithm::ES512,
+     sourcemeta::core::JWSAlgorithm::EdDSA}};
+
+// The tolerance allowed on an identity token's time-based claims, matching what
+// a presented access token is already given. A provider whose clock runs a
+// little fast otherwise mints a token this refuses the instant it arrives,
+// which ends a login that did everything right
+constexpr std::chrono::seconds ID_TOKEN_CLOCK_SKEW{60};
+
+// A session lasts an hour, kept short so that a lost cookie cannot outlive its
+// usefulness, with silent re-authentication as the eventual refresh
+constexpr std::chrono::seconds SESSION_LIFETIME{3600};
+
+// How long a browser stays eligible for a silent renewal after signing in.
+// Long enough to outlast a provider session, since the provider is the one that
+// decides whether a renewal succeeds, and losing it early only costs a sign-in
+// page that would otherwise have been skipped
+constexpr std::chrono::seconds RENEWAL_LIFETIME{43200};
+
+// RFC 6265 Section 6.1 asks a user agent to support "at least 4096 bytes per
+// cookie (as measured by the sum of the length of the cookie's name, value, and
+// attributes)". That is a floor they should honour rather than a ceiling they
+// must enforce, and what happens above it is left unsaid, so the whole
+// serialised cookie is kept under it with room to spare
+constexpr std::size_t MAXIMUM_COOKIE_LENGTH{4000};
+
+// Address a section of the artifact wherever it was read from, so that mapping
+// a file and holding the bytes outright reach the same structures
+template <typename T>
+auto at_offset(const std::span<const std::byte> bytes,
+               const std::size_t offset = 0) noexcept -> const T * {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  return reinterpret_cast<const T *>(bytes.data() + offset);
+}
+
+auto structurally_valid(const std::span<const std::byte> bytes) noexcept
     -> bool {
   using namespace sourcemeta::one;
-  const auto size{view.size()};
+  const auto size{bytes.size()};
   if (size < sizeof(AuthenticationHeader)) {
     return false;
   }
 
-  const auto *header{view.as<AuthenticationHeader>()};
+  const auto *header{at_offset<AuthenticationHeader>(bytes)};
   // The policy count must fit the bitmask width, otherwise matching would
   // shift past the width of a PolicySet, which is undefined behavior
   if (header->magic != AUTHENTICATION_MAGIC ||
@@ -118,7 +371,8 @@ auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
     return false;
   }
 
-  const auto *views{view.as<AuthenticationViewEntry>(header->views_offset)};
+  const auto *views{
+      at_offset<AuthenticationViewEntry>(bytes, header->views_offset)};
   bool names_the_anonymous{false};
   for (std::uint32_t index{0}; index < header->view_count; index += 1) {
     const auto &entry{views[index]};
@@ -152,7 +406,7 @@ auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
 
   if (header->policy_count > 0) {
     const auto *policies{
-        view.as<AuthenticationPolicyEntry>(header->policies_offset)};
+        at_offset<AuthenticationPolicyEntry>(bytes, header->policies_offset)};
     // Each policy's metadata is appended in declaration order after the string
     // blob, so a valid artifact lays them out contiguously from there onward
     auto metadata_cursor{strings_offset + strings_length};
@@ -172,7 +426,7 @@ auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
     }
   }
 
-  const auto *nodes{view.as<AuthenticationNode>(header->nodes_offset)};
+  const auto *nodes{at_offset<AuthenticationNode>(bytes, header->nodes_offset)};
   for (std::uint32_t index{0}; index < header->node_count; index += 1) {
     const auto &node{nodes[index]};
     if (node.edge_count > header->edge_count ||
@@ -182,7 +436,8 @@ auto structurally_valid(const sourcemeta::core::FileView &view) noexcept
   }
 
   if (header->edge_count > 0) {
-    const auto *edges{view.as<AuthenticationEdge>(header->edges_offset)};
+    const auto *edges{
+        at_offset<AuthenticationEdge>(bytes, header->edges_offset)};
     for (std::uint32_t index{0}; index < header->edge_count; index += 1) {
       const auto &edge{edges[index]};
       if (edge.child >= header->node_count ||
@@ -509,9 +764,7 @@ auto carries_objects(const sourcemeta::core::JSON &value) -> bool {
 // rules themselves are cumulative, which is what lets a policy widen who it
 // admits without also widening what they reach
 auto admits_claims(const sourcemeta::core::JSON &payload,
-                   const sourcemeta::core::JSON &rules)
-    -> sourcemeta::one::Authentication::Admission {
-  using Admission = sourcemeta::one::Authentication::Admission;
+                   const sourcemeta::core::JSON &rules) -> Admission {
   if (!rules.is_object()) {
     return Admission::Admitted;
   }
@@ -715,8 +968,7 @@ auto interactive_policy(const OIDCPolicyMetadata &decoded)
 // regard to case against domains the artifact already holds in lower case
 auto admits_email_domain(const sourcemeta::core::JSON &claims,
                          const std::span<const std::byte> domains)
-    -> sourcemeta::one::Authentication::Admission {
-  using Admission = sourcemeta::one::Authentication::Admission;
+    -> Admission {
   const auto *verified{claims.try_at("email_verified")};
   const auto *address{claims.try_at("email")};
   // Whatever arrived is judged before whatever did not. An address the
@@ -805,8 +1057,7 @@ struct Authentication::Impl {
   // everything: the section pointers below stay null, so matching yields the
   // empty set and admits no one. Opening the file covers the missing and
   // unreadable cases without a separate, throwing existence check
-  Impl(const std::filesystem::path &path,
-       sourcemeta::core::JWKSProvider::Fetcher fetcher)
+  Impl(const std::filesystem::path &path, Authentication::Fetcher fetcher)
       : fetcher_{std::move(fetcher)} {
     std::unique_ptr<sourcemeta::core::FileView> view;
     try {
@@ -815,11 +1066,31 @@ struct Authentication::Impl {
       return;
     }
 
-    if (!structurally_valid(*view)) {
-      return;
+    if (this->adopt({view->as<std::byte>(), view->size()})) {
+      this->view_ = std::move(view);
+    }
+  }
+
+  // A table compiled in this process is held rather than mapped, so the bytes
+  // are copied once and never move again, which is what keeps every section
+  // pointer below valid for as long as this exists
+  Impl(const std::span<const std::byte> bytes, Authentication::Fetcher fetcher)
+      : fetcher_{std::move(fetcher)} {
+    this->owned_.assign(bytes.begin(), bytes.end());
+    if (!this->adopt(this->owned_)) {
+      this->owned_.clear();
+    }
+  }
+
+  // Whether the artifact could be read, and every section pointer set where it
+  // could. Nothing is set on a refusal, so a caller that ignores the answer
+  // still denies everything
+  auto adopt(const std::span<const std::byte> bytes) -> bool {
+    if (!structurally_valid(bytes)) {
+      return false;
     }
 
-    const auto *header{view->as<AuthenticationHeader>()};
+    const auto *header{at_offset<AuthenticationHeader>(bytes)};
 
     // Claim rules are read and parsed once here rather than on each request,
     // since a request answers a rule by lookup while the bytes behind it never
@@ -833,7 +1104,7 @@ struct Authentication::Impl {
     std::vector<sourcemeta::core::JSON> claims;
     claims.assign(header->policy_count, sourcemeta::core::JSON{nullptr});
     const auto *policies{
-        view->as<AuthenticationPolicyEntry>(header->policies_offset)};
+        at_offset<AuthenticationPolicyEntry>(bytes, header->policies_offset)};
     for (std::uint32_t index{0}; index < header->policy_count; index += 1) {
       const auto &entry{policies[index]};
       const auto type{static_cast<Authentication::Type>(entry.type)};
@@ -844,16 +1115,17 @@ struct Authentication::Impl {
       }
 
       const std::span<const std::byte> metadata{
-          view->as<std::byte>(entry.metadata_offset), entry.metadata_length};
+          at_offset<std::byte>(bytes, entry.metadata_offset),
+          entry.metadata_length};
       std::string_view serialized;
       if (type == Authentication::Type::JWT) {
         if (!read_jwt_claims(metadata, serialized)) {
-          return;
+          return false;
         }
       } else {
         OIDCPolicyMetadata decoded;
         if (!decode_oidc_metadata(metadata, decoded)) {
-          return;
+          return false;
         }
 
         serialized = decoded.claims;
@@ -865,36 +1137,188 @@ struct Authentication::Impl {
 
       auto document{sourcemeta::core::try_parse_json(serialized)};
       if (!document.has_value() || !document.value().is_object()) {
-        return;
+        return false;
       }
 
       claims[index] = std::move(document).value();
     }
 
-    this->nodes_ = view->as<AuthenticationNode>(header->nodes_offset);
+    this->nodes_ = at_offset<AuthenticationNode>(bytes, header->nodes_offset);
     // The edge section is empty when no policy declares a nested prefix, in
     // which case it sits at the end of the buffer and must not be addressed
     if (header->edge_count > 0) {
-      this->edges_ = view->as<AuthenticationEdge>(header->edges_offset);
+      this->edges_ = at_offset<AuthenticationEdge>(bytes, header->edges_offset);
     }
 
     // Every name is a range into the string section, so it is addressed
     // whenever anything was named rather than only when a prefix was nested
     if (header->strings_length > 0) {
-      this->strings_ = view->as<char>(header->strings_offset);
+      this->strings_ = at_offset<char>(bytes, header->strings_offset);
     }
 
-    this->views_ = view->as<AuthenticationViewEntry>(header->views_offset);
+    this->views_ =
+        at_offset<AuthenticationViewEntry>(bytes, header->views_offset);
     this->view_count_ = header->view_count;
 
     if (header->policy_count > 0) {
       this->policies_ =
-          view->as<AuthenticationPolicyEntry>(header->policies_offset);
+          at_offset<AuthenticationPolicyEntry>(bytes, header->policies_offset);
       this->policy_count_ = header->policy_count;
     }
 
     this->claims_ = std::move(claims);
-    this->view_ = std::move(view);
+    this->bytes_ = bytes;
+    return true;
+  }
+
+  // The transaction a callback belongs to, if the request carries one. A
+  // request can present several cookies under one name, since a parent domain
+  // and the host itself can each set one and neither the header nor the order
+  // says which is which, so every value is tried. Letting whoever controls a
+  // neighbouring host decide which transaction this reads is what turns the
+  // cookie from a defence against a forged callback into the way to mount one
+  [[nodiscard]] auto transaction(const std::string_view policy_name,
+                                 const std::string_view state,
+                                 const Credentials &credentials) const
+      -> std::optional<sourcemeta::core::JSON> {
+    if (state.empty()) {
+      return std::nullopt;
+    }
+
+    std::vector<std::string_view> candidates;
+    for (const auto field : credentials.cookies) {
+      sourcemeta::core::http_cookie_values(field, TRANSACTION_COOKIE,
+                                           candidates);
+    }
+
+    for (const auto sealed : candidates) {
+      auto opened{this->open(policy_name, Authentication::Purpose::Transaction,
+                             sealed)};
+      if (!opened.has_value()) {
+        continue;
+      }
+
+      auto document{sourcemeta::core::try_parse_json(opened.value())};
+      if (!document.has_value() || !document.value().is_object()) {
+        continue;
+      }
+
+      const auto *sealed_policy{document.value().try_at("policy")};
+      const auto *sealed_state{document.value().try_at("state")};
+      const auto *nonce{document.value().try_at("nonce")};
+      const auto *verifier{document.value().try_at("verifier")};
+      if (sealed_policy == nullptr || !sealed_policy->is_string() ||
+          sealed_policy->to_string() != policy_name ||
+          sealed_state == nullptr || !sealed_state->is_string() ||
+          sealed_state->to_string() != state || nonce == nullptr ||
+          !nonce->is_string() || nonce->to_string().empty() ||
+          verifier == nullptr || !verifier->is_string() ||
+          verifier->to_string().empty()) {
+        continue;
+      }
+
+      return document;
+    }
+
+    return std::nullopt;
+  }
+
+  // The session cookie for a login, carrying the identity token when one is
+  // given. Building it is separated out so the caller can measure the result
+  // and ask for a smaller one
+  [[nodiscard]] auto session_cookie(const std::string_view policy_name,
+                                    const std::string_view subject,
+                                    const std::string_view id_token,
+                                    const std::chrono::sys_seconds expiry,
+                                    const bool secure,
+                                    std::vector<std::string> &log) const
+      -> std::optional<std::string> {
+    auto payload{sourcemeta::core::JSON::make_object()};
+    payload.assign_assume_new("policy",
+                              sourcemeta::core::JSON{std::string{policy_name}});
+    payload.assign_assume_new("subject",
+                              sourcemeta::core::JSON{std::string{subject}});
+    if (!id_token.empty()) {
+      payload.assign_assume_new("id_token",
+                                sourcemeta::core::JSON{std::string{id_token}});
+    }
+
+    std::ostringstream payload_text;
+    sourcemeta::core::stringify(payload, payload_text);
+    const auto sealed{this->seal(policy_name, Authentication::Purpose::Session,
+                                 payload_text.str(), expiry)};
+    if (!sealed.has_value()) {
+      log.emplace_back("No session secret is set for the policy");
+      return std::nullopt;
+    }
+
+    auto cookie{sourcemeta::core::http_serialize_cookie(
+        {.name = SESSION_COOKIE,
+         .value = sealed.value(),
+         .path = COOKIE_PATH,
+         .max_age = SESSION_LIFETIME,
+         .http_only = true,
+         .secure = secure,
+         .same_site = sourcemeta::core::HTTPCookieSameSite::Lax})};
+    if (!cookie.has_value()) {
+      log.emplace_back("The session could not be put in a cookie, for the "
+                       "policy");
+    }
+
+    return cookie;
+  }
+
+  // A rule compared against a claim carrying objects is compared on the `value`
+  // sub-attribute alone, so a rule naming what a person sees rather than what
+  // identifies them matches nothing. A denial cannot show that, and the token
+  // it concerns is sealed inside a cookie where an operator cannot look, so it
+  // is said here. Only a refusal reaches this, so a working policy stays quiet,
+  // and each claim is named once however often somebody signs in
+  auto report_object_shaped_claims(const std::string_view policy_name,
+                                   const sourcemeta::core::JSON &claims,
+                                   std::vector<std::string> &log) const
+      -> void {
+    static std::mutex mutex;
+    static std::set<std::string, std::less<>> reported;
+    for (const auto claim : this->object_shaped_claims(policy_name, claims)) {
+      std::string subject{claim};
+      subject += " of the policy ";
+      subject += policy_name;
+      const std::scoped_lock guard{mutex};
+      if (!reported.insert(subject).second) {
+        continue;
+      }
+
+      std::string message{
+          "A rule names a claim the provider answers with objects, which are "
+          "compared on their identifier rather than on any name shown to a "
+          "person. The claim is "};
+      message += subject;
+      log.push_back(std::move(message));
+    }
+  }
+
+  // Which policies govern a location, or nothing at all when the artifact
+  // could not be read. A missing or structurally broken one leaves the section
+  // pointers null and governs nothing it could answer for, which is why an
+  // empty set and an unreadable table are told apart here rather than by
+  // whoever asks
+  [[nodiscard]] auto governing_mask(const std::string_view path) const
+      -> std::optional<Authentication::PolicySet> {
+    if (this->nodes_ == nullptr) {
+      return std::nullopt;
+    }
+
+    return this->match(path);
+  }
+
+  // Whether a caller satisfying these policies is shown a location
+  [[nodiscard]] auto permits(const std::string_view path,
+                             const Authentication::PolicySet policies) const
+      -> bool {
+    const auto governing{this->governing_mask(path)};
+    return governing.has_value() &&
+           (governing.value() == 0 || (governing.value() & policies) != 0);
   }
 
   // The policies that govern a registry path, accumulated from every prefix
@@ -955,45 +1379,6 @@ struct Authentication::Impl {
     return result;
   }
 
-  [[nodiscard]] auto admits(const std::string_view registry_path,
-                            const std::string_view credential,
-                            const std::span<const std::string_view> cookies,
-                            const std::string_view required_audience = {}) const
-      -> Authentication::Verdict {
-    // A missing or structurally broken artifact leaves the section pointers
-    // null and denies everything. Only a valid policy fails open below
-    if (this->nodes_ == nullptr) {
-      return {.allowed = false, .principal = std::nullopt};
-    }
-
-    const auto governing{this->match(registry_path)};
-    if (governing == 0) {
-      // No policy covers this path, so it is public and the caller anonymous
-      return {.allowed = true, .principal = std::nullopt};
-    }
-
-    const auto token{sourcemeta::core::JWT::from(credential)};
-
-    const auto *policies{
-        static_cast<const AuthenticationPolicyEntry *>(this->policies_)};
-    for (std::uint32_t index{0}; index < this->policy_count_; index += 1) {
-      if ((governing & (PolicySet{1} << index)) == 0) {
-        continue;
-      }
-
-      if (this->admits_policy(index, credential, cookies, token,
-                              required_audience)) {
-        return {
-            .allowed = true,
-            .principal = Authentication::Principal{
-                .type = static_cast<Authentication::Type>(policies[index].type),
-                .policy = static_cast<std::size_t>(index)}};
-      }
-    }
-
-    return {.allowed = false, .principal = std::nullopt};
-  }
-
   // Whether one policy accepts what a request presented, which is the whole of
   // reading a credential and is asked both of a policy governing a path and of
   // every policy when placing a caller. Two answers to this could disagree,
@@ -1007,7 +1392,7 @@ struct Authentication::Impl {
         static_cast<const AuthenticationPolicyEntry *>(this->policies_)[index]};
     std::span<const std::byte> metadata;
     if (entry.metadata_length > 0) {
-      metadata = {this->view_->as<std::byte>(entry.metadata_offset),
+      metadata = {at_offset<std::byte>(this->bytes_, entry.metadata_offset),
                   entry.metadata_length};
     }
 
@@ -1140,8 +1525,7 @@ struct Authentication::Impl {
       return false;
     }
 
-    return admits_claims(token.payload(), claims) ==
-           Authentication::Admission::Admitted;
+    return admits_claims(token.payload(), claims) == Admission::Admitted;
   }
 
   [[nodiscard]] auto
@@ -1166,8 +1550,7 @@ struct Authentication::Impl {
     // when any of them is a session for this policy
     std::vector<std::string_view> candidates;
     for (const auto field : cookies) {
-      sourcemeta::core::http_cookie_values(
-          field, Authentication::SESSION_COOKIE, candidates);
+      sourcemeta::core::http_cookie_values(field, SESSION_COOKIE, candidates);
     }
     for (const auto sealed : candidates) {
       const auto payload{this->session_open(
@@ -1220,7 +1603,7 @@ struct Authentication::Impl {
       }
 
       const std::span<const std::byte> metadata{
-          this->view_->as<std::byte>(entry.metadata_offset),
+          at_offset<std::byte>(this->bytes_, entry.metadata_offset),
           entry.metadata_length};
       OIDCPolicyMetadata decoded;
       if (!decode_oidc_metadata(metadata, decoded) || decoded.name.empty()) {
@@ -1270,7 +1653,7 @@ struct Authentication::Impl {
       }
 
       const std::span<const std::byte> metadata{
-          this->view_->as<std::byte>(entry.metadata_offset),
+          at_offset<std::byte>(this->bytes_, entry.metadata_offset),
           entry.metadata_length};
       if (decode_oidc_metadata(metadata, result) && result.name == name) {
         return true;
@@ -1307,7 +1690,7 @@ struct Authentication::Impl {
 
       OIDCPolicyMetadata decoded;
       if (!decode_oidc_metadata(
-              {this->view_->as<std::byte>(entry.metadata_offset),
+              {at_offset<std::byte>(this->bytes_, entry.metadata_offset),
                entry.metadata_length},
               decoded) ||
           decoded.name != policy) {
@@ -1342,7 +1725,7 @@ struct Authentication::Impl {
 
   [[nodiscard]] auto admits_identity(const std::string_view policy,
                                      const sourcemeta::core::JSON &claims) const
-      -> Authentication::Admission {
+      -> Admission {
     const auto *policies{
         static_cast<const AuthenticationPolicyEntry *>(this->policies_)};
     for (std::uint32_t index{0}; index < this->policy_count_; index += 1) {
@@ -1355,7 +1738,7 @@ struct Authentication::Impl {
 
       OIDCPolicyMetadata decoded;
       if (!decode_oidc_metadata(
-              {this->view_->as<std::byte>(entry.metadata_offset),
+              {at_offset<std::byte>(this->bytes_, entry.metadata_offset),
                entry.metadata_length},
               decoded) ||
           decoded.name != policy) {
@@ -1367,28 +1750,28 @@ struct Authentication::Impl {
       std::uint32_t domains{0};
       std::size_t cursor{0};
       if (!read_u32(decoded.email_domains, cursor, domains)) {
-        return Authentication::Admission::Refused;
+        return Admission::Refused;
       }
 
       const auto address{
           domains > 0 ? admits_email_domain(claims, decoded.email_domains)
-                      : Authentication::Admission::Admitted};
-      if (address == Authentication::Admission::Refused) {
+                      : Admission::Admitted};
+      if (address == Admission::Refused) {
         return address;
       }
 
       const auto rules{admits_claims(claims, this->claims_[index])};
-      if (rules == Authentication::Admission::Refused) {
+      if (rules == Admission::Refused) {
         return rules;
       }
 
       // Either half wanting more is the whole wanting more
-      return rules == Authentication::Admission::Incomplete ? rules : address;
+      return rules == Admission::Incomplete ? rules : address;
     }
 
     // A name that no interactive policy answers to could never have minted a
     // session, so nothing it asserts is admitted
-    return Authentication::Admission::Refused;
+    return Admission::Refused;
   }
 
   [[nodiscard]] auto interactive(const std::string_view path,
@@ -1414,7 +1797,7 @@ struct Authentication::Impl {
       }
 
       const std::span<const std::byte> metadata{
-          this->view_->as<std::byte>(entry.metadata_offset),
+          at_offset<std::byte>(this->bytes_, entry.metadata_offset),
           entry.metadata_length};
       OIDCPolicyMetadata decoded;
       if (decode_oidc_metadata(metadata, decoded) && decoded.name == name) {
@@ -1469,8 +1852,7 @@ struct Authentication::Impl {
 
     const auto issued{std::chrono::time_point_cast<std::chrono::seconds>(
         std::chrono::system_clock::now())};
-    return Authentication::seal_value(payload, purpose, resolved.front(),
-                                      issued, expiry);
+    return seal_value(payload, purpose, resolved.front(), issued, expiry);
   }
 
   [[nodiscard]] auto session_open(const std::span<const std::byte> variables,
@@ -1491,7 +1873,7 @@ struct Authentication::Impl {
 
     const auto now{std::chrono::time_point_cast<std::chrono::seconds>(
         std::chrono::system_clock::now())};
-    return Authentication::open_value(value, purpose, secrets, now);
+    return open_value(value, purpose, secrets, now);
   }
 
   [[nodiscard]] auto seal(const std::string_view policy,
@@ -1526,7 +1908,7 @@ struct Authentication::Impl {
   // Connect layer is applied again only when that snapshot changes rather than
   // once per request
   [[nodiscard]] auto endpoints(const std::string_view policy) const
-      -> std::optional<Authentication::ProviderEndpoints> {
+      -> std::optional<ProviderEndpoints> {
     OIDCPolicyMetadata decoded;
     if (!this->find_interactive(policy, decoded) || !this->fetcher_) {
       return std::nullopt;
@@ -1542,7 +1924,7 @@ struct Authentication::Impl {
         // so the one transport this instance was given is adapted rather than
         // a second one being introduced
         auto transport{
-            [fetcher = this->fetcher_](const std::string_view url)
+            [fetcher = this->key_fetcher()](const std::string_view url)
                 -> std::optional<
                     sourcemeta::core::OAuthMetadataProvider::FetchResult> {
               auto result{fetcher(url)};
@@ -1579,7 +1961,7 @@ struct Authentication::Impl {
         return std::nullopt;
       }
 
-      Authentication::ProviderEndpoints resolved;
+      ProviderEndpoints resolved;
       if (document.value().authorization_endpoint().has_value()) {
         resolved.authorization =
             document.value().authorization_endpoint().value();
@@ -1655,7 +2037,7 @@ struct Authentication::Impl {
         return nullptr;
       }
 
-      const auto metadata{this->fetcher_(url.value())};
+      const auto metadata{this->retrieve(url.value())};
       if (!metadata.has_value()) {
         return nullptr;
       }
@@ -1679,7 +2061,7 @@ struct Authentication::Impl {
     sourcemeta::core::JWKSProvider::Options options;
     options.clock_skew = JWT_CLOCK_SKEW;
     auto provider{std::make_unique<sourcemeta::core::JWKSProvider>(
-        std::move(location), this->fetcher_, options)};
+        std::move(location), this->key_fetcher(), options)};
 
     // A concurrent caller may have installed this key while the lock was
     // released, so its provider wins and ours is discarded
@@ -1725,7 +2107,7 @@ struct Authentication::Impl {
       const auto &entry{policies[index]};
       if (entry.metadata_length > 0) {
         const std::span<const std::byte> metadata{
-            this->view_->as<std::byte>(entry.metadata_offset),
+            at_offset<std::byte>(this->bytes_, entry.metadata_offset),
             entry.metadata_length};
         const auto type{static_cast<Authentication::Type>(entry.type)};
         if (type == Authentication::Type::JWT) {
@@ -1790,9 +2172,54 @@ struct Authentication::Impl {
   // above, null where a policy declares none
   std::vector<sourcemeta::core::JSON> claims_;
 
+  // Whichever of the two holds the bytes every section above points into. A
+  // mapped table keeps the mapping, a compiled one keeps its own copy, and the
+  // span is how anything reads them without caring which
   std::unique_ptr<sourcemeta::core::FileView> view_;
+  std::vector<std::byte> owned_;
+  std::span<const std::byte> bytes_{};
 
-  sourcemeta::core::JWKSProvider::Fetcher fetcher_;
+  Authentication::Fetcher fetcher_;
+
+  [[nodiscard]] auto fetcher() const -> const Authentication::Fetcher & {
+    return this->fetcher_;
+  }
+
+  // A plain retrieval, which is what discovery and a key set both are
+  [[nodiscard]] auto retrieve(const std::string_view url) const
+      -> std::optional<Authentication::ProviderResponse> {
+    if (!this->fetcher_) {
+      return std::nullopt;
+    }
+
+    auto response{this->fetcher_({.url = url})};
+    if (!response.has_value() || response.value().status < 200 ||
+        response.value().status >= 300) {
+      return std::nullopt;
+    }
+
+    return response;
+  }
+
+  // What a key set is retrieved with, which is the one fetcher asked for a
+  // plain retrieval. Adapting here rather than holding two keeps every
+  // outbound call this makes going through the same place
+  [[nodiscard]] auto key_fetcher() const
+      -> sourcemeta::core::JWKSProvider::Fetcher {
+    return [fetcher = this->fetcher_](const std::string_view url)
+               -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
+      auto response{fetcher({.url = url})};
+      if (!response.has_value() || response.value().status < 200 ||
+          response.value().status >= 300) {
+        return std::nullopt;
+      }
+
+      const auto max_age{response.value().max_age};
+      return sourcemeta::core::JWKSProvider::FetchResult{
+          .body = std::move(response).value().body, .max_age = max_age};
+    };
+  }
+
   mutable std::mutex jwks_mutex_;
   mutable std::map<std::pair<std::string, std::string>,
                    std::unique_ptr<sourcemeta::core::JWKSProvider>>
@@ -1800,7 +2227,7 @@ struct Authentication::Impl {
 
   struct ResolvedEndpoints {
     std::shared_ptr<const sourcemeta::core::OAuthServerMetadata> source;
-    Authentication::ProviderEndpoints resolved;
+    ProviderEndpoints resolved;
   };
 
   mutable std::mutex metadata_mutex_;
@@ -1811,8 +2238,12 @@ struct Authentication::Impl {
 };
 
 Authentication::Authentication(const std::filesystem::path &path,
-                               sourcemeta::core::JWKSProvider::Fetcher fetcher)
+                               Authentication::Fetcher fetcher)
     : impl_{std::make_unique<Impl>(path, std::move(fetcher))} {}
+
+Authentication::Authentication(const std::span<const std::byte> bytes,
+                               Authentication::Fetcher fetcher)
+    : impl_{std::make_unique<Impl>(bytes, std::move(fetcher))} {}
 
 Authentication::~Authentication() = default;
 
@@ -1869,14 +2300,16 @@ auto Authentication::views(
 
   for (std::size_t index{0}; index < policies.size(); index++) {
     const auto &policy{policies[index]};
-    if (policy.type != Authentication::Type::JWT) {
+    const auto *token{
+        std::get_if<Authentication::Policy::Token>(&policy.credential)};
+    if (token == nullptr) {
       named.push_back({.name = std::string{policy.name}, .policies = {index}});
       continue;
     }
 
-    const auto match{std::ranges::find(issuers, policy.issuer)};
+    const auto match{std::ranges::find(issuers, token->issuer)};
     if (match == issuers.cend()) {
-      issuers.emplace_back(policy.issuer);
+      issuers.emplace_back(token->issuer);
       groups.push_back({index});
     } else {
       groups[static_cast<std::size_t>(match - issuers.begin())].push_back(
@@ -1915,122 +2348,692 @@ auto Authentication::views(
   return result;
 }
 
-auto Authentication::admits(const Authentication::Path &path,
-                            const Credentials &credentials) const
-    -> Authentication::Verdict {
-  return this->impl_->admits(path.value(), credentials.bearer,
-                             credentials.cookies);
+namespace {
+
+// Whether a value is somewhere on this instance rather than somewhere else, so
+// that what a login sealed cannot become a redirect to another origin
+auto is_local_path(const std::string_view value) -> bool {
+  if (value.empty() || value.front() != '/') {
+    return false;
+  }
+
+  if (value.size() >= 2 && (value[1] == '/' || value[1] == '\\')) {
+    return false;
+  }
+
+  for (const auto character : value) {
+    const auto code{static_cast<unsigned char>(character)};
+    if (code <= 0x20 || code == 0x7f || character == '\\') {
+      return false;
+    }
+  }
+
+  return true;
 }
 
-auto Authentication::classify(const Credentials &credentials) const
-    -> Authentication::PolicySet {
-  return this->impl_->classify(credentials.bearer, credentials.cookies);
+// What redeeming an authorization code yields, of which only the identity token
+// decides anything. The access token comes along solely so that a claim missing
+// from that token can be asked for at the UserInfo endpoint
+struct Grant {
+  std::string id_token;
+  std::string access_token;
+};
+
+// RFC 6749 Section 2.3.1 has every server accept the client secret in an
+// authorization header, and asks that carrying it in the request body be
+// limited to clients that cannot send one. A body is the part of a request that
+// logging and proxies keep, while an authorization header is the part they
+// already know to redact, so the header is used wherever the provider takes it
+auto exchange(const sourcemeta::one::Authentication::Fetcher &fetcher,
+              const std::string_view token_endpoint,
+              const std::string_view client_id,
+              const sourcemeta::core::SecureString &client_secret,
+              const std::string_view redirect_uri, const std::string_view code,
+              const std::string_view code_verifier, const bool basic_auth)
+    -> std::optional<Grant> {
+  if (!fetcher) {
+    return std::nullopt;
+  }
+
+  sourcemeta::one::Authentication::ProviderRequest request{.url =
+                                                               token_endpoint};
+  sourcemeta::core::oauth_build_token_request_code(
+      code, redirect_uri, code_verifier, {}, request.body);
+  if (basic_auth) {
+    sourcemeta::core::oauth_client_secret_basic(client_id, client_secret,
+                                                request.authorization);
+  } else {
+    sourcemeta::core::oauth_client_secret_post(client_id, client_secret,
+                                               request.body);
+  }
+
+  const auto result{fetcher(std::move(request))};
+  if (!result.has_value() || result.value().status < 200 ||
+      result.value().status >= 300) {
+    return std::nullopt;
+  }
+
+  const auto document{sourcemeta::core::try_parse_json(result.value().body)};
+  if (!document.has_value()) {
+    return std::nullopt;
+  }
+
+  auto identity{sourcemeta::core::oidc_parse_id_token(document.value())};
+  if (!identity.has_value()) {
+    return std::nullopt;
+  }
+
+  // The access token is kept only so that the UserInfo endpoint can be asked
+  // for a claim the identity token did not carry. It is never stored, never
+  // logged, and never leaves this exchange
+  Grant grant;
+  grant.id_token = std::move(identity).value();
+  const sourcemeta::core::OAuthTokenResponse response{document.value()};
+  if (response.access_token().has_value()) {
+    grant.access_token = response.access_token().value();
+  }
+
+  return grant;
 }
 
-auto Authentication::view(const Credentials &credentials) const
-    -> std::string_view {
-  return this->impl_->view_name(
-      this->impl_->classify(credentials.bearer, credentials.cookies));
+// What a provider answers at its UserInfo endpoint, which under the
+// authorization code flow is where the claims a scope requested arrive by
+// default (OpenID Connect Core Section 5.4).
+//
+// OpenID Connect Core Section 5.3.2 requires the subject it returns to match
+// the one the identity token asserted, and to be checked before anything it
+// says is used. Without that a response about somebody else would be read as
+// being about this person, which is the whole of what this is for
+auto userinfo(const sourcemeta::one::Authentication::Fetcher &fetcher,
+              const std::string_view endpoint,
+              const std::string_view access_token,
+              const std::string_view subject, std::vector<std::string> &log)
+    -> std::optional<sourcemeta::core::JSON> {
+  if (!fetcher || access_token.empty()) {
+    return std::nullopt;
+  }
+
+  std::string authorization;
+  if (!sourcemeta::core::oauth_bearer_header(access_token, authorization)) {
+    return std::nullopt;
+  }
+
+  // An access token is a secret, so what carries it travels in wiping storage
+  // even though what built it did not
+  sourcemeta::one::Authentication::ProviderRequest request{.url = endpoint};
+  request.authorization.append(authorization);
+
+  const auto result{fetcher(std::move(request))};
+  if (!result.has_value() || result.value().status < 200 ||
+      result.value().status >= 300) {
+    return std::nullopt;
+  }
+
+  auto document{sourcemeta::core::try_parse_json(result.value().body)};
+  if (!document.has_value() || !document.value().is_object()) {
+    return std::nullopt;
+  }
+
+  const auto *asserted{document.value().try_at("sub")};
+  if (asserted == nullptr || !asserted->is_string() ||
+      asserted->to_string() != subject) {
+    log.emplace_back("The UserInfo endpoint answered about a different subject "
+                     "than the identity token did");
+    return std::nullopt;
+  }
+
+  return document;
 }
 
-auto Authentication::interactive(const std::string_view name) const
-    -> std::optional<Authentication::InteractivePolicy> {
-  return this->impl_->interactive(name);
+auto id_token_keys(std::string location,
+                   sourcemeta::core::JWKSProvider::Fetcher fetcher)
+    -> sourcemeta::core::JWKSProvider {
+  return sourcemeta::core::JWKSProvider{std::move(location),
+                                        std::move(fetcher),
+                                        {.clock_skew = ID_TOKEN_CLOCK_SKEW}};
 }
 
-auto Authentication::interactive(const Authentication::Path &path,
-                                 const std::string_view name) const
-    -> std::optional<Authentication::InteractivePolicy> {
-  return this->impl_->interactive(path.value(), name);
-}
+// Expire a cookie under the attributes it was minted with, so the browser
 
-auto Authentication::client_secret(const std::string_view policy) const
-    -> std::optional<sourcemeta::core::SecureString> {
-  return this->impl_->client_secret(policy);
-}
-
-auto Authentication::endpoints(const std::string_view policy) const
-    -> std::optional<Authentication::ProviderEndpoints> {
-  return this->impl_->endpoints(policy);
-}
-
-auto Authentication::open_session(const std::string_view value) const
+// replaces it rather than keeping a second one of the same name beside it
+auto expired_cookie(const std::string_view name, const bool secure)
     -> std::optional<std::string> {
-  return this->impl_->open_session(value);
+  return sourcemeta::core::http_serialize_cookie(
+      {.name = name,
+       .value = "",
+       .path = COOKIE_PATH,
+       .max_age = std::chrono::seconds{0},
+       .http_only = true,
+       .secure = secure,
+       .same_site = sourcemeta::core::HTTPCookieSameSite::Lax});
 }
 
-// A provider answering twice about one person is two halves of one account,
-// but only one of them is signed. The address pair is carved out of the merge
-// because `email_verified` speaks for the address delivered with it, so the
-// pair is only ever taken from an answer that carried the address, and an
-// assertion left on its own is dropped whichever answer it came from
-auto Authentication::combine_claims(const sourcemeta::core::JSON &token,
-                                    const sourcemeta::core::JSON &extra)
-    -> sourcemeta::core::JSON {
-  if (!token.is_object()) {
-    return extra.is_object() ? extra : token;
+} // namespace
+
+auto Authentication::login(const std::string_view policy_name,
+                           const std::string_view instance_url,
+                           const std::string_view redirect_uri,
+                           const bool silent,
+                           const std::string_view return_to) const
+    -> Authentication::Outcome {
+  Authentication::Outcome result;
+
+  // An unknown or non-interactive policy name reveals nothing
+  const auto policy{this->impl_->interactive(policy_name)};
+  if (!policy.has_value()) {
+    result.result = Authentication::Outcome::Result::Missing;
+    return result;
   }
 
-  // Nothing to combine leaves what the token said untouched, since an
-  // assertion it carried alone can vouch for no address but its own
-  if (!extra.is_object()) {
-    return token;
+  // Starting a login that cannot be completed only strands the person at the
+  // provider, so the secret the exchange will need is required up front
+  if (!this->impl_->client_secret(policy_name).has_value()) {
+    result.log.emplace_back("No client secret is set for the policy");
+    return result;
   }
 
-  auto result{token};
-  const auto token_has_address{token.defines("email")};
-  const auto extra_has_address{extra.defines("email")};
-  if (!token_has_address) {
-    result.erase("email_verified");
+  const auto endpoints{this->impl_->endpoints(policy_name)};
+  if (!endpoints.has_value() || endpoints.value().authorization.empty()) {
+    result.log.emplace_back("The provider named no authorization endpoint, or "
+                            "could not be reached, for the policy");
+    return result;
   }
 
-  for (const auto &claim : extra.as_object()) {
-    const auto address_pair{claim.first == "email" ||
-                            claim.first == "email_verified"};
-    // The answer that carried the address carries the assertion about it, so
-    // neither half is taken from an answer holding only one of them
-    if (address_pair && (token_has_address || !extra_has_address)) {
+  const auto secrets{sourcemeta::core::oauth_transaction_mint()};
+  const std::string_view state{secrets.state.data(), secrets.state.size()};
+  const std::string_view verifier{secrets.code_verifier.data(),
+                                  secrets.code_verifier.size()};
+  const auto nonce_token{sourcemeta::core::oidc_nonce()};
+  const std::string_view nonce{nonce_token.data(), nonce_token.size()};
+
+  auto payload{sourcemeta::core::JSON::make_object()};
+  payload.assign_assume_new("policy",
+                            sourcemeta::core::JSON{std::string{policy_name}});
+  if (silent) {
+    payload.assign_assume_new("silent", sourcemeta::core::JSON{true});
+  }
+
+  payload.assign_assume_new("state", sourcemeta::core::JSON{state});
+  payload.assign_assume_new("nonce", sourcemeta::core::JSON{nonce});
+  payload.assign_assume_new("verifier", sourcemeta::core::JSON{verifier});
+
+  // Where the browser goes once this completes. What the request asked for
+  // wins, and what the policy governs stands in where it asked for nothing
+  if (!return_to.empty()) {
+    payload.assign_assume_new("to",
+                              sourcemeta::core::JSON{std::string{return_to}});
+  } else if (!policy->default_path.empty()) {
+    payload.assign_assume_new(
+        "to", sourcemeta::core::JSON{std::string{policy->default_path}});
+  }
+
+  std::ostringstream payload_text;
+  sourcemeta::core::stringify(payload, payload_text);
+
+  const auto expiry{std::chrono::time_point_cast<std::chrono::seconds>(
+                        std::chrono::system_clock::now()) +
+                    TRANSACTION_LIFETIME};
+  const auto sealed{this->impl_->seal(policy_name,
+                                      Authentication::Purpose::Transaction,
+                                      payload_text.str(), expiry)};
+  if (!sealed.has_value()) {
+    result.log.emplace_back("No session secret is set for the policy");
+    return result;
+  }
+
+  // A provider sends only the claims a request asks for, so a policy whose
+  // rules name any is asked for them here. The standard way is the claims
+  // request parameter, and where a provider does not honour that, the scopes
+  // that carry the standard claims are the fallback. A claim no standard scope
+  // carries is then arranged at the provider instead, since inventing a scope
+  // name risks a request refused outright.
+  // The rules outlive every request built from them, since a claim request
+  // names its claim by pointing into them rather than copying
+  const auto rules{policy->claims.empty()
+                       ? std::optional<sourcemeta::core::JSON>{std::nullopt}
+                       : sourcemeta::core::try_parse_json(policy->claims)};
+  const auto wanted{wanted_claims(policy.value(), rules)};
+  std::string scope_request;
+  std::string claims_parameter;
+  if (endpoints.value().claims_parameter_supported && !wanted.empty()) {
+    std::ostringstream text;
+    sourcemeta::core::stringify(
+        sourcemeta::core::oidc_build_claims_parameter({}, wanted), text);
+    claims_parameter = text.str();
+  }
+
+  requested_scope(wanted, scope_request);
+  report_unadvertised_claims(wanted, endpoints.value(), policy_name,
+                             result.log);
+
+  const auto challenge{sourcemeta::core::oauth_pkce_challenge(verifier)};
+  sourcemeta::core::OIDCAuthenticationRequest authentication_request{};
+  authentication_request.client_id = policy->client_id;
+  authentication_request.redirect_uri = redirect_uri;
+  authentication_request.scope = scope_request;
+  authentication_request.claims = claims_parameter;
+  authentication_request.response_type = "code";
+  authentication_request.state = state;
+  authentication_request.code_challenge = {challenge.data(), challenge.size()};
+  authentication_request.code_challenge_method = "S256";
+  authentication_request.nonce = nonce;
+  if (silent) {
+    authentication_request.prompt = "none";
+  }
+
+  std::string authorization_url;
+  if (!sourcemeta::core::oidc_build_authentication_url(
+          endpoints.value().authorization, authentication_request,
+          authorization_url)) {
+    result.log.emplace_back("The authorization endpoint is not a URL a request "
+                            "can be built against, for the policy");
+    return result;
+  }
+
+  // A redirect without the transaction cookie could never complete at the
+  // callback, so it is not worth sending
+  auto cookie{sourcemeta::core::http_serialize_cookie(
+      {.name = TRANSACTION_COOKIE,
+       .value = sealed.value(),
+       .path = COOKIE_PATH,
+       .max_age = TRANSACTION_LIFETIME,
+       .http_only = true,
+       .secure = sourcemeta::core::URI{std::string{instance_url}}.is_https(),
+       .same_site = sourcemeta::core::HTTPCookieSameSite::Lax})};
+  if (!cookie.has_value()) {
+    result.log.emplace_back(
+        "The login transaction could not be put in a cookie, for the policy");
+    return result;
+  }
+
+  result.cookies.push_back(std::move(cookie).value());
+  result.location = std::move(authorization_url);
+  result.result = Authentication::Outcome::Result::Redirect;
+  return result;
+}
+
+auto Authentication::renewal(const Authentication::Path &path,
+                             const Credentials &credentials) const
+    -> std::optional<std::string_view> {
+  if (credentials.cookies.empty()) {
+    return std::nullopt;
+  }
+
+  std::vector<std::string_view> candidates;
+  for (const auto field : credentials.cookies) {
+    sourcemeta::core::http_cookie_values(field, RENEWAL_COOKIE, candidates);
+  }
+
+  for (const auto candidate : candidates) {
+    const auto policy{this->impl_->interactive(path.value(), candidate)};
+    if (policy.has_value()) {
+      return candidate;
+    }
+  }
+
+  return std::nullopt;
+}
+
+auto Authentication::callback(const std::string_view policy_name,
+                              const std::string_view instance_url,
+                              const std::string_view redirect_uri,
+                              const Authentication::CallbackRequest &incoming,
+                              const Credentials &credentials) const
+    -> Authentication::Outcome {
+  Authentication::Outcome result;
+  result.result = Authentication::Outcome::Result::Invalid;
+  const auto secure{
+      sourcemeta::core::URI{std::string{instance_url}}.is_https()};
+
+  // The transaction is the only proof that this response belongs to a login
+  // this instance started, and the state it carries must match the one the
+  // provider echoes back. This runs before either the success or the decline is
+  // honoured, so a cross-site callback cannot even trigger an error on a
+  // person's behalf, per RFC 6749 Section 4.1.2.1
+  const auto transaction{
+      this->impl_->transaction(policy_name, incoming.state, credentials)};
+  if (!transaction.has_value()) {
+    return result;
+  }
+
+  // Nobody asked for a silent attempt, so from here on nothing it does is shown
+  // to them: every way this can end without a session puts the browser back
+  // where it started instead
+  const auto silent{transaction.value().try_at("silent") != nullptr};
+  const auto *nonce{transaction.value().try_at("nonce")};
+  const auto *verifier{transaction.value().try_at("verifier")};
+
+  // Where a silent attempt leaves the browser when it did not come back with a
+  // grant: back where it was denied, carrying neither a session nor the marker
+  // that would send it here again. The marker goes whatever the reason, so an
+  // attempt that failed is not made again on the next navigation, and every
+  // navigation after that
+  const auto abandon{[&](const Authentication::Outcome::Result outcome)
+                         -> Authentication::Outcome {
+    if (!silent) {
+      result.result = outcome;
+      return result;
+    }
+
+    result.result = Authentication::Outcome::Result::Redirect;
+    result.location = "";
+    const auto *sealed{transaction.value().try_at("to")};
+    if (sealed != nullptr && sealed->is_string() &&
+        is_local_path(sealed->to_string())) {
+      result.location = sealed->to_string();
+    }
+
+    for (const auto name : {RENEWAL_COOKIE, TRANSACTION_COOKIE}) {
+      auto cookie{expired_cookie(name, secure)};
+      if (cookie.has_value()) {
+        result.cookies.push_back(std::move(cookie).value());
+      }
+    }
+
+    result.log.emplace_back("A silent renewal did not end in a session");
+    return result;
+  }};
+
+  // Which policy a callback belongs to is settled by opening its transaction,
+  // so nothing reaching here names one this instance does not serve
+  const auto policy{this->impl_->interactive(policy_name)};
+  if (!policy.has_value()) {
+    return abandon(Authentication::Outcome::Result::Invalid);
+  }
+
+  // RFC 9207 Section 2.4 has a client compare the issuer an answer names
+  // against the one it addressed the request to, which is what catches an
+  // answer relayed from somewhere else. A provider naming none cannot be
+  // checked that way, so this runs only when one arrives, and it runs ahead of
+  // the outcome so that no answer is acted on before it is placed
+  if (incoming.has_issuer && incoming.issuer != policy->issuer) {
+    return abandon(Authentication::Outcome::Result::Invalid);
+  }
+
+  // Only once the callback is proven to belong to a real login is the
+  // provider's outcome honoured: a decline returns an error instead of a code,
+  // and a success without a code is malformed. RFC 6749 Section 4.1.2.1 has a
+  // decline name itself with an error code, so one that names nothing is not a
+  // decision this can report as the provider's. It is no grant either, and a
+  // code arriving beside it is left unredeemed
+  if (incoming.has_error) {
+    return abandon(incoming.error.empty()
+                       ? Authentication::Outcome::Result::Invalid
+                       : Authentication::Outcome::Result::Declined);
+  }
+
+  if (incoming.code.empty()) {
+    return abandon(Authentication::Outcome::Result::Invalid);
+  }
+
+  const auto client_secret{this->impl_->client_secret(policy_name)};
+  if (!client_secret.has_value()) {
+    result.log.emplace_back("No client secret is set for the policy");
+    return abandon(Authentication::Outcome::Result::Incomplete);
+  }
+
+  const auto endpoints{this->impl_->endpoints(policy_name)};
+  if (!endpoints.has_value() || endpoints.value().token.empty()) {
+    result.log.emplace_back("The provider named no token endpoint, or could "
+                            "not be reached, for the policy");
+    return abandon(Authentication::Outcome::Result::Incomplete);
+  }
+
+  const auto grant{exchange(this->impl_->fetcher(), endpoints.value().token,
+                            policy->client_id, client_secret.value(),
+                            redirect_uri, incoming.code, verifier->to_string(),
+                            endpoints.value().token_endpoint_basic_auth)};
+  if (!grant.has_value()) {
+    result.log.emplace_back(
+        "The authorization code could not be redeemed for the policy");
+    return abandon(Authentication::Outcome::Result::Incomplete);
+  }
+
+  const auto token{sourcemeta::core::JWT::from(grant.value().id_token)};
+  if (!token.has_value()) {
+    result.log.emplace_back("The provider returned an identity token that "
+                            "could not be read, for the policy");
+    return abandon(Authentication::Outcome::Result::Incomplete);
+  }
+
+  auto provider{
+      id_token_keys(endpoints.value().jwks_uri, this->impl_->key_fetcher())};
+  sourcemeta::core::OIDCValidationOptions options;
+  options.nonce = nonce->to_string();
+  const auto identity{sourcemeta::core::oidc_validate_id_token(
+      provider, token.value(), ID_TOKEN_ALGORITHMS, policy->issuer,
+      policy->client_id, options)};
+  if (!identity.has_value()) {
+    result.log.emplace_back("The identity token did not validate for the "
+                            "policy");
+    return abandon(Authentication::Outcome::Result::Incomplete);
+  }
+
+  // A policy's rules are answered here rather than at the gate, so that a
+  // session only ever exists for somebody the policy admits. Answering it
+  // afterwards would leave a valid session denied on every request, and a
+  // denial asks the provider again, which is a loop rather than an answer
+  std::optional<sourcemeta::core::JSON> combined;
+  auto admission{
+      this->impl_->admits_identity(policy_name, token.value().payload())};
+
+  // OpenID Connect Core Section 5.4 has a provider answer for the claims a
+  // scope requested at its UserInfo endpoint rather than in the token, by
+  // default, under the flow this is completing. So a rule naming a claim the
+  // token does not carry is asked there before it is refused, and only then,
+  // since a token carrying everything needed spares the round trip
+  if (admission == Admission::Incomplete &&
+      !endpoints.value().userinfo.empty()) {
+    const auto extra{userinfo(
+        this->impl_->fetcher(), endpoints.value().userinfo,
+        grant.value().access_token, identity.value().subject, result.log)};
+    if (extra.has_value()) {
+      combined = combine_claims(token.value().payload(), extra.value());
+      admission = this->impl_->admits_identity(policy_name, combined.value());
+    }
+  }
+
+  if (admission != Admission::Admitted) {
+    result.log.emplace_back("The provider authenticated somebody the policy "
+                            "does not admit, for the policy");
+    // Whatever the decision was actually made against, which is the pair taken
+    // together once a second answer arrived. Explaining a refusal against the
+    // token alone would miss a claim the UserInfo endpoint supplied
+    const auto &asserted{combined.has_value() ? combined.value()
+                                              : token.value().payload()};
+    this->impl_->report_object_shaped_claims(policy_name, asserted, result.log);
+    return abandon(Authentication::Outcome::Result::NotAdmitted);
+  }
+
+  const auto expiry{std::chrono::time_point_cast<std::chrono::seconds>(
+                        std::chrono::system_clock::now()) +
+                    SESSION_LIFETIME};
+
+  // The identity token is kept so that logging out can prove whose session it
+  // is asking the provider to end, which is what spares the person a
+  // confirmation page there. A provider that mints a large one can push the
+  // cookie past what a browser will store, and a browser drops such a cookie
+  // without saying so, which would look like signing in and then not being
+  // signed in. So the whole cookie is measured, and the token is left out when
+  // it does not fit, which costs the confirmation page and nothing else
+  auto session{this->impl_->session_cookie(
+      policy_name, identity.value().subject, grant.value().id_token, expiry,
+      secure, result.log)};
+  if (session.has_value() && session.value().size() > MAXIMUM_COOKIE_LENGTH) {
+    session = this->impl_->session_cookie(policy_name, identity.value().subject,
+                                          "", expiry, secure, result.log);
+  }
+
+  // Without the token there is very little left, so exceeding the limit here
+  // takes something extraordinary, such as a provider that identifies people by
+  // something enormous. Answering plainly beats handing over a cookie the
+  // browser discards, which would look like signing in and then not being
+  // signed in, with nothing anywhere to explain it
+  if (!session.has_value() || session.value().size() > MAXIMUM_COOKIE_LENGTH) {
+    if (session.has_value()) {
+      result.log.emplace_back("The provider returned more than a session can "
+                              "hold, for the policy");
+    }
+
+    return abandon(Authentication::Outcome::Result::Incomplete);
+  }
+
+  result.cookies.push_back(std::move(session).value());
+
+  // Signing in is what earns a browser a silent renewal later, and the marker
+  // outlives the session it accompanies because it is only of use once that
+  // session has expired
+  auto renewal{sourcemeta::core::http_serialize_cookie(
+      {.name = RENEWAL_COOKIE,
+       .value = policy_name,
+       .path = COOKIE_PATH,
+       .max_age = RENEWAL_LIFETIME,
+       .http_only = true,
+       .secure = secure,
+       .same_site = sourcemeta::core::HTTPCookieSameSite::Lax})};
+  if (renewal.has_value()) {
+    result.cookies.push_back(std::move(renewal).value());
+  }
+
+  // The single-use transaction has served its purpose, so it is expired
+  // alongside minting the session
+  auto spent{expired_cookie(TRANSACTION_COOKIE, secure)};
+  if (spent.has_value()) {
+    result.cookies.push_back(std::move(spent).value());
+  }
+
+  // The login may have sealed a page to return to. It came through this
+  // instance's own signature, yet it is re-checked as a local path before being
+  // trusted as a redirect target
+  result.location = "";
+  const auto *sealed_destination{transaction.value().try_at("to")};
+  if (sealed_destination != nullptr && sealed_destination->is_string() &&
+      is_local_path(sealed_destination->to_string())) {
+    result.location = sealed_destination->to_string();
+  }
+
+  result.result = Authentication::Outcome::Result::Redirect;
+  return result;
+}
+
+auto Authentication::logout(const Credentials &credentials,
+                            const std::string_view instance_url,
+                            const std::string_view return_to) const
+    -> Authentication::Outcome {
+  Authentication::Outcome result;
+  const auto secure{
+      sourcemeta::core::URI{std::string{instance_url}}.is_https()};
+
+  // Composed before anything that could fail, so no path below ends with a
+  // session surviving. Somebody who has signed out is asking not to be signed
+  // in, so the marker that would have renewed them silently goes with it
+  for (const auto name : {SESSION_COOKIE, TRANSACTION_COOKIE, RENEWAL_COOKIE}) {
+    auto cookie{expired_cookie(name, secure)};
+    if (cookie.has_value()) {
+      result.cookies.push_back(std::move(cookie).value());
+    }
+  }
+
+  result.location = return_to;
+
+  // Ending the session here leaves the provider's own untouched, so signing in
+  // again would not ask who you are. Where the session names a policy whose
+  // provider offers to end it, the browser finishes the job there, carrying the
+  // identity token as the proof of whose session it is. Every step that cannot
+  // be completed simply stops, since the local session is already gone
+  std::vector<std::string_view> candidates;
+  for (const auto field : credentials.cookies) {
+    sourcemeta::core::http_cookie_values(field, SESSION_COOKIE, candidates);
+  }
+
+  for (const auto sealed : candidates) {
+    const auto payload{this->impl_->open_session(sealed)};
+    if (!payload.has_value()) {
       continue;
     }
 
-    if (!result.defines(claim.first)) {
-      result.assign(claim.first, claim.second);
+    const auto document{sourcemeta::core::try_parse_json(payload.value())};
+    if (!document.has_value() || !document.value().is_object()) {
+      continue;
     }
+
+    const auto *policy{document.value().try_at("policy")};
+    const auto *token{document.value().try_at("id_token")};
+    if (policy == nullptr || !policy->is_string()) {
+      continue;
+    }
+
+    const auto endpoints{this->impl_->endpoints(policy->to_string())};
+    if (!endpoints.has_value() || endpoints.value().end_session.empty()) {
+      continue;
+    }
+
+    sourcemeta::core::OIDCLogoutRequest logout;
+    if (token != nullptr && token->is_string()) {
+      logout.id_token_hint = token->to_string();
+    }
+
+    // Where the provider sends the browser back to once it is done, which is
+    // this instance rather than the local path a caller without a provider
+    // session lands on
+    logout.post_logout_redirect_uri = instance_url;
+    std::string url;
+    sourcemeta::core::oidc_build_logout_url(endpoints.value().end_session,
+                                            logout, url);
+    result.location = std::move(url);
+    break;
   }
 
   return result;
 }
 
-auto Authentication::object_shaped_claims(
-    const std::string_view policy, const sourcemeta::core::JSON &claims) const
-    -> std::vector<std::string_view> {
-  return this->impl_->object_shaped_claims(policy, claims);
+auto Authentication::caller(const Credentials &credentials) const
+    -> Authentication::Caller {
+  Authentication::Caller result;
+  result.policies_ =
+      this->impl_->classify(credentials.bearer, credentials.cookies);
+  result.view_ = this->impl_->view_name(result.policies_);
+  result.bearer_ = credentials.bearer;
+  return result;
 }
 
-auto Authentication::admits_identity(const std::string_view policy,
-                                     const sourcemeta::core::JSON &claims) const
-    -> Authentication::Admission {
-  return this->impl_->admits_identity(policy, claims);
+auto Authentication::permits(const Authentication::Path &path,
+                             const Authentication::Caller &caller) const
+    -> bool {
+  return this->impl_->permits(path.value(), caller.policies_);
 }
 
-auto Authentication::seal(const std::string_view policy, const Purpose purpose,
-                          const std::string_view payload,
-                          const std::chrono::sys_seconds expiry) const
-    -> std::optional<std::string> {
-  return this->impl_->seal(policy, purpose, payload, expiry);
-}
+auto Authentication::permits(const RouteTarget &target,
+                             const Authentication::Caller &caller,
+                             const std::string_view required_audience) const
+    -> bool {
+  const auto governing{this->impl_->governing_mask(target.value())};
+  if (!governing.has_value()) {
+    return false;
+  }
 
-auto Authentication::open(const std::string_view policy, const Purpose purpose,
-                          const std::string_view value) const
-    -> std::optional<std::string> {
-  return this->impl_->open(policy, purpose, value);
-}
+  // A route nobody governs is reached by anybody, so there is nothing for an
+  // audience to narrow. Requiring one here would refuse a caller for presenting
+  // a credential they did not need, at a route they could have reached by
+  // presenting nothing at all
+  if (governing.value() == 0) {
+    return true;
+  }
 
-auto Authentication::admits_route(
-    const std::string_view target, const Credentials &credentials,
-    const std::string_view required_audience) const -> Authentication::Verdict {
-  return this->impl_->admits(target, credentials.bearer, credentials.cookies,
-                             required_audience);
+  if ((governing.value() & caller.policies_) == 0) {
+    return false;
+  }
+
+  if (required_audience.empty()) {
+    return true;
+  }
+
+  // Only a token carries an audience, so a caller admitted by anything else is
+  // unaffected by a requirement it could never have satisfied or broken. The
+  // signature is already established, so this is one more claim read from a
+  // token that has been verified rather than a second verification
+  const auto token{sourcemeta::core::JWT::from(caller.bearer_)};
+  return !token.has_value() || token.value().has_audience(required_audience);
 }
 
 auto Authentication::view_count() const -> std::size_t {

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -1179,6 +1179,7 @@ struct Authentication::Impl {
   // cookie from a defence against a forged callback into the way to mount one
   [[nodiscard]] auto transaction(const std::string_view policy_name,
                                  const std::string_view state,
+                                 const std::string_view redirect_uri,
                                  const Credentials &credentials) const
       -> std::optional<sourcemeta::core::JSON> {
     if (state.empty()) {
@@ -1205,12 +1206,15 @@ struct Authentication::Impl {
 
       const auto *sealed_policy{document.value().try_at("policy")};
       const auto *sealed_state{document.value().try_at("state")};
+      const auto *sealed_redirect{document.value().try_at("redirect_uri")};
       const auto *nonce{document.value().try_at("nonce")};
       const auto *verifier{document.value().try_at("verifier")};
       if (sealed_policy == nullptr || !sealed_policy->is_string() ||
           sealed_policy->to_string() != policy_name ||
           sealed_state == nullptr || !sealed_state->is_string() ||
-          sealed_state->to_string() != state || nonce == nullptr ||
+          sealed_state->to_string() != state || sealed_redirect == nullptr ||
+          !sealed_redirect->is_string() ||
+          sealed_redirect->to_string() != redirect_uri || nonce == nullptr ||
           !nonce->is_string() || nonce->to_string().empty() ||
           verifier == nullptr || !verifier->is_string() ||
           verifier->to_string().empty()) {
@@ -2556,6 +2560,11 @@ auto Authentication::login(const std::string_view policy_name,
   payload.assign_assume_new("state", sourcemeta::core::JSON{state});
   payload.assign_assume_new("nonce", sourcemeta::core::JSON{nonce});
   payload.assign_assume_new("verifier", sourcemeta::core::JSON{verifier});
+  // Sealed so that a callback completing this login has to name the same place
+  // the provider was told to come back to. The provider checks it too, and this
+  // is what lets the check hold before a code is ever redeemed
+  payload.assign_assume_new("redirect_uri",
+                            sourcemeta::core::JSON{std::string{redirect_uri}});
 
   // Where the browser goes once this completes. What the request asked for
   // wins, and what the policy governs stands in where it asked for nothing
@@ -2690,8 +2699,8 @@ auto Authentication::callback(const std::string_view policy_name,
   // provider echoes back. This runs before either the success or the decline is
   // honoured, so a cross-site callback cannot even trigger an error on a
   // person's behalf, per RFC 6749 Section 4.1.2.1
-  const auto transaction{
-      this->impl_->transaction(policy_name, incoming.state, credentials)};
+  const auto transaction{this->impl_->transaction(policy_name, incoming.state,
+                                                  redirect_uri, credentials)};
   if (!transaction.has_value()) {
     return result;
   }

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -185,10 +185,10 @@ auto encode_jwt_metadata(
 
 namespace sourcemeta::one {
 
-auto Authentication::save(std::span<const Authentication::Policy> policies,
-                          const std::filesystem::path &configuration,
-                          const std::filesystem::path &destination,
-                          const Authentication::PathGuard &gateable) -> void {
+auto Authentication::compile(std::span<const Authentication::Policy> policies,
+                             const std::filesystem::path &configuration,
+                             const Authentication::PathGuard &gateable)
+    -> std::vector<std::byte> {
   assert(gateable);
   // Each policy occupies one bit of the node masks, so exceeding the ceiling
   // would shift past the width of a PolicySet
@@ -363,25 +363,35 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
   for (std::size_t index{0}; index < policies.size(); index += 1) {
     const auto &policy{policies[index]};
     std::vector<std::byte> policy_metadata;
-    if (policy.type == Authentication::Type::JWT) {
-      policy_metadata = encode_jwt_metadata(policy.issuer, policy.audience,
-                                            policy.jwks_uri, policy.algorithms,
-                                            policy.token_type, policy.claims);
-    } else if (policy.type == Authentication::Type::OIDC) {
+    auto algorithm{Authentication::Algorithm::Identity};
+    if (const auto *token{
+            std::get_if<Authentication::Policy::Token>(&policy.credential)}) {
+      policy_metadata = encode_jwt_metadata(token->issuer, token->audience,
+                                            token->jwks_uri, token->algorithms,
+                                            token->token_type, token->claims);
+    } else if (const auto *interactive{
+                   std::get_if<Authentication::Policy::Interactive>(
+                       &policy.credential)}) {
       // An interactive policy without a session secret could never mint or
       // verify one, so it fails loudly here rather than silently denying every
       // login at runtime
-      if (policy.session_secrets.empty()) {
+      if (interactive->session_secrets.empty()) {
         throw std::runtime_error(
             "Interactive authentication policies require a session secret");
       }
 
       policy_metadata = encode_oidc_metadata(
-          policy.issuer, policy.client_id, policy.claims, policy.email_domains,
-          policy.client_secret_variable, policy.name, policy.session_secrets,
+          interactive->issuer, interactive->client_id, interactive->claims,
+          interactive->email_domains, interactive->client_secret_variable,
+          policy.name, interactive->session_secrets,
           policy.paths.empty() ? std::string_view{} : policy.paths.front());
-    } else if (!policy.keys.empty()) {
-      policy_metadata = encode_apikey_metadata(policy.keys);
+    } else {
+      const auto &key{
+          std::get<Authentication::Policy::ApiKey>(policy.credential)};
+      algorithm = key.algorithm;
+      if (!key.keys.empty()) {
+        policy_metadata = encode_apikey_metadata(key.keys);
+      }
     }
 
     AuthenticationPolicyEntry entry{};
@@ -390,8 +400,8 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
     entry.metadata_length = static_cast<std::uint32_t>(policy_metadata.size());
     entry.name_offset = policy_names[index].first;
     entry.name_length = policy_names[index].second;
-    entry.algorithm = static_cast<std::uint8_t>(policy.algorithm);
-    entry.type = static_cast<std::uint8_t>(policy.type);
+    entry.algorithm = static_cast<std::uint8_t>(algorithm);
+    entry.type = static_cast<std::uint8_t>(policy.type());
     policy_table.push_back(entry);
     metadata.insert(metadata.end(), policy_metadata.begin(),
                     policy_metadata.end());
@@ -429,7 +439,12 @@ auto Authentication::save(std::span<const Authentication::Policy> policies,
                 metadata.size());
   }
 
-  sourcemeta::core::write_file(destination, buffer);
+  return buffer;
+}
+
+auto Authentication::write(const std::span<const std::byte> bytes,
+                           const std::filesystem::path &destination) -> void {
+  sourcemeta::core::write_file(destination, bytes);
 }
 
 } // namespace sourcemeta::one

--- a/enterprise/authentication/session.cc
+++ b/enterprise/authentication/session.cc
@@ -1,5 +1,9 @@
 #include <sourcemeta/one/authentication.h>
 
+#include "session.h"
+
+#include "session.h"
+
 #include <sourcemeta/core/crypto.h>
 
 #include <algorithm>   // std::max
@@ -92,12 +96,11 @@ auto parse_expiry(const std::string_view input)
 
 namespace sourcemeta::one {
 
-auto Authentication::seal_value(const std::string_view payload,
-                                const Purpose purpose,
-                                const std::string_view secret,
-                                const std::chrono::sys_seconds issued,
-                                const std::chrono::sys_seconds expiry)
-    -> std::string {
+auto seal_value(const std::string_view payload,
+                const Authentication::Purpose purpose,
+                const std::string_view secret,
+                const std::chrono::sys_seconds issued,
+                const std::chrono::sys_seconds expiry) -> std::string {
   const auto key{derive_key(secret, purpose)};
   std::string result{SESSION_VERSION};
   result += '.';
@@ -117,10 +120,10 @@ auto Authentication::seal_value(const std::string_view payload,
   return result;
 }
 
-auto Authentication::open_value(const std::string_view value,
-                                const Purpose purpose,
-                                const std::span<const std::string_view> secrets,
-                                const std::chrono::sys_seconds now)
+auto open_value(const std::string_view value,
+                const Authentication::Purpose purpose,
+                const std::span<const std::string_view> secrets,
+                const std::chrono::sys_seconds now)
     -> std::optional<std::string> {
   // Expiry comparisons are meaningless under a clock that reads before the
   // epoch, so such a clock validates nothing

--- a/enterprise/authentication/session.h
+++ b/enterprise/authentication/session.h
@@ -1,0 +1,41 @@
+#ifndef SOURCEMETA_ONE_ENTERPRISE_AUTHENTICATION_SESSION_H_
+#define SOURCEMETA_ONE_ENTERPRISE_AUTHENTICATION_SESSION_H_
+
+#include <sourcemeta/one/authentication.h>
+
+#include <chrono>      // std::chrono::sys_seconds
+#include <optional>    // std::optional
+#include <span>        // std::span
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+// The sealing primitive the sessions and login transactions of this module are
+// built out of. It sits beside the sources that use it rather than under the
+// installed headers, so nothing outside this directory can reach it, and the
+// interface next door stays what a consumer may call
+namespace sourcemeta::one {
+
+// Bind a payload and an expiry under a key derived from the secret and the
+// purpose, producing a value that is safe to transport as a cookie. Only a
+// holder of the secret can produce or alter such a value, though anyone can
+// read its contents
+[[nodiscard]] auto seal_value(std::string_view payload,
+                              Authentication::Purpose purpose,
+                              std::string_view secret,
+                              std::chrono::sys_seconds issued,
+                              std::chrono::sys_seconds expiry) -> std::string;
+
+// Recover the payload of a sealed value, returning nothing for a value that was
+// not produced for that purpose under one of the given secrets, was altered in
+// any way, or has expired. Accepting several secrets lets a newly introduced
+// secret coexist with the one it replaces until every value sealed under the
+// old secret has expired
+[[nodiscard]] auto open_value(std::string_view value,
+                              Authentication::Purpose purpose,
+                              std::span<const std::string_view> secrets,
+                              std::chrono::sys_seconds now)
+    -> std::optional<std::string>;
+
+} // namespace sourcemeta::one
+
+#endif

--- a/enterprise/e2e/auth-sso/playwright/callback.spec.js
+++ b/enterprise/e2e/auth-sso/playwright/callback.spec.js
@@ -16,6 +16,11 @@ const STATE = 'e2e-forged-state-value-for-callback-tests-1';
 const NONCE = 'e2e-forged-nonce-value-for-callback-tests-1';
 const VERIFIER = 'e2e-forged-verifier-value-for-callback-12';
 
+// Where the provider was told to come back to. A login seals this into the
+// transaction, so a forged one has to name the address this instance would
+// have sent, or it is refused for that before anything else about it is read
+const REDIRECT = 'http://localhost:8000/self/v1/auth/callback/keycloak';
+
 const CALLBACK = /\/self\/v1\/auth\/callback\//;
 
 function sealTransaction(payload) {
@@ -106,7 +111,8 @@ test.describe('Callback transaction validation', () => {
       policy: 'keycloak',
       state: STATE,
       nonce: NONCE,
-      verifier: VERIFIER
+      verifier: VERIFIER,
+      redirect_uri: REDIRECT
     });
     // A transaction that is rejected outright is refused as a bad request, so
     // getting past that to a server-side failure is what shows this one was
@@ -127,7 +133,8 @@ test.describe('Callback transaction validation', () => {
       policy: 'keycloak',
       state: STATE,
       nonce: NONCE,
-      verifier: ''
+      verifier: '',
+      redirect_uri: REDIRECT
     });
     expect(response.status()).toBe(400);
     expect(await response.json()).toEqual({
@@ -145,7 +152,8 @@ test.describe('Callback transaction validation', () => {
       policy: 'keycloak',
       state: STATE,
       nonce: '',
-      verifier: VERIFIER
+      verifier: VERIFIER,
+      redirect_uri: REDIRECT
     });
     expect(response.status()).toBe(400);
     expect(await response.json()).toEqual({
@@ -169,7 +177,8 @@ test.describe('Callback transaction validation', () => {
             policy: 'keycloak',
             state: '',
             nonce: NONCE,
-            verifier: VERIFIER
+            verifier: VERIFIER,
+            redirect_uri: REDIRECT
           })}`
         }
       }
@@ -195,13 +204,15 @@ test.describe('Callback transaction validation', () => {
       policy: 'keycloak',
       state: 'a-state-belonging-to-some-other-login-1',
       nonce: NONCE,
-      verifier: VERIFIER
+      verifier: VERIFIER,
+      redirect_uri: REDIRECT
     });
     const mine = sealTransaction({
       policy: 'keycloak',
       state: STATE,
       nonce: NONCE,
-      verifier: VERIFIER
+      verifier: VERIFIER,
+      redirect_uri: REDIRECT
     });
     const declined = {
       type: 'urn:sourcemeta:one:auth-login-declined',
@@ -311,6 +322,29 @@ test.describe('Callback identity validation against a real login', () => {
       title: 'Internal Server Error',
       status: 500,
       detail: 'The session could not be established'
+    });
+    expect(response.headers()['set-cookie']).toBeUndefined();
+  });
+
+  test('a code redeemed for a return address other than the one asked for is refused', async ({
+    page,
+    context
+  }) => {
+    // The authorization request named where the provider was to come back to,
+    // and the exchange has to name the same address for the code to be worth
+    // anything. Reading that from the transaction rather than from the request
+    // being answered is what keeps a callback reached some other way from
+    // redeeming a code against an address this instance never asked for
+    const { response } = await signInAlteringTheTransaction(page, context, {
+      redirect_uri: 'http://localhost:8000/self/v1/auth/callback/elsewhere'
+    });
+
+    expect(response.status()).toBe(400);
+    expect(await response.json()).toEqual({
+      type: 'urn:sourcemeta:one:auth-invalid-callback',
+      title: 'Bad Request',
+      status: 400,
+      detail: 'The login could not be completed'
     });
     expect(response.headers()['set-cookie']).toBeUndefined();
   });

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -76,8 +76,9 @@ public:
     return true;
   }
 
-  auto rest(const std::span<std::string_view> matches, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view> matches,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);
@@ -106,255 +107,72 @@ public:
           "This action requires a policy name match", this->error_schema_, "*");
       return;
     }
-    const auto policy_name{matches.front()};
-    const auto state{request.query("state")};
-
-    // The transaction cookie is the only proof that this response belongs to
-    // a login this instance started, and the state it carries must match the
-    // one the provider echoes back. This gate runs before either the success
-    // or the decline is honoured, so a cross-site callback cannot even
-    // trigger an error on a person's behalf, per RFC 6749 section 4.1.2.1
-    const auto &authentication{this->dispatcher().authentication()};
-    const auto transaction{
-        this->transaction(request, authentication, policy_name, state)};
-    if (!transaction.has_value()) {
-      this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
-                 "urn:sourcemeta:one:auth-invalid-callback",
-                 "The login could not be completed");
-      return;
-    }
-
-    // Nobody asked for a silent attempt, so from here on nothing it does is
-    // shown to them: every way this can end without a session puts the browser
-    // back where it started instead
-    const auto silent{transaction.value().try_at("silent") != nullptr};
-    const auto *nonce{transaction.value().try_at("nonce")};
-    const auto *verifier{transaction.value().try_at("verifier")};
-
-    // Which policy a callback belongs to is settled by opening its
-    // transaction, so nothing reaching here names one this instance does not
-    // serve. Answering as though the callback were unproven keeps that the
-    // only thing this URL ever says about a name
-    const auto policy{authentication.interactive(policy_name)};
-    if (!policy.has_value()) {
-      this->abandon(silent, transaction.value(), request, response,
-                    sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
-                    "urn:sourcemeta:one:auth-invalid-callback",
-                    "The login could not be completed");
-      return;
-    }
-
-    // RFC 9207 Section 2.4 has a client compare the issuer an answer names
-    // against the one it addressed the request to, which is what catches an
-    // answer relayed from somewhere else. A provider naming none cannot be
-    // checked that way, so this runs only when one arrives, and it runs ahead
-    // of the outcome so that no answer is acted on before it is placed
-    if (request.has_query("iss") && request.query("iss") != policy->issuer) {
-      this->abandon(silent, transaction.value(), request, response,
-                    sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
-                    "urn:sourcemeta:one:auth-invalid-callback",
-                    "The login could not be completed");
-      return;
-    }
-
-    // Only once the callback is proven to belong to a real login is the
-    // provider's outcome honoured: a decline returns an error instead of a
-    // code, and a success without a code is malformed. RFC 6749 Section
-    // 4.1.2.1 has a decline name itself with an error code, so one that names
-    // nothing is not a decision this can report as the provider's. It is no
-    // grant either, and a code arriving beside it is left unredeemed
-    if (request.has_query("error")) {
-      if (request.query("error").empty()) {
-        this->abandon(silent, transaction.value(), request, response,
-                      sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
-                      "urn:sourcemeta:one:auth-invalid-callback",
-                      "The login could not be completed");
-      } else {
-        this->abandon(silent, transaction.value(), request, response,
-                      sourcemeta::core::HTTP_STATUS_FORBIDDEN,
-                      "urn:sourcemeta:one:auth-login-declined",
-                      "The identity provider declined the login");
-      }
-
-      return;
-    }
-
-    const auto code{request.query("code")};
-    if (code.empty()) {
-      this->abandon(silent, transaction.value(), request, response,
-                    sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
-                    "urn:sourcemeta:one:auth-invalid-callback",
-                    "The login could not be completed");
-      return;
-    }
-
-    const auto client_secret{authentication.client_secret(policy_name)};
-    if (!client_secret.has_value()) {
-      sourcemeta::one::HTTP_LOG("No client secret is set for the policy",
-                                policy_name);
-      this->incomplete(silent, transaction.value(), request, response);
-      return;
-    }
-
-    const auto endpoints{authentication.endpoints(policy_name)};
-    if (!endpoints.has_value() || endpoints.value().token.empty()) {
-      sourcemeta::one::HTTP_LOG("The provider named no token endpoint, or "
-                                "could not be reached, for the policy",
-                                policy_name);
-      this->incomplete(silent, transaction.value(), request, response);
-      return;
-    }
-
+    // The redirect URI must be the one the login was started with, since the
+    // provider checks it and so does the exchange. It is composed here because
+    // which routes this instance serves is not something authentication knows
+    constexpr std::string_view CALLBACK_PATH{"/self/v1/auth/callback/"};
     std::string redirect_uri{this->server_uri()};
-    redirect_uri += "/self/v1/auth/callback/";
-    redirect_uri += policy_name;
+    redirect_uri += CALLBACK_PATH;
+    redirect_uri += matches.front();
 
-    const auto grant{this->exchange(
-        endpoints.value().token, policy->client_id, client_secret.value(),
-        redirect_uri, code, verifier->to_string(),
-        endpoints.value().token_endpoint_basic_auth)};
-    const auto id_token{grant.has_value()
-                            ? std::optional<std::string>{grant.value().id_token}
-                            : std::nullopt};
-    if (!id_token.has_value()) {
-      sourcemeta::one::HTTP_LOG(
-          "The authorization code could not be redeemed for the policy",
-          policy_name);
-      this->incomplete(silent, transaction.value(), request, response);
-      return;
+    const sourcemeta::one::RequestCookies cookies{request};
+    const auto outcome{this->dispatcher().authentication().callback(
+        matches.front(), this->server_uri(), redirect_uri,
+        {.state = request.query("state"),
+         .code = request.query("code"),
+         .has_error = request.has_query("error"),
+         .error = request.query("error"),
+         .has_issuer = request.has_query("iss"),
+         .issuer = request.query("iss")},
+        {.cookies = cookies})};
+    for (const auto &message : outcome.log) {
+      sourcemeta::one::HTTP_LOG("Callback", message);
     }
 
-    const auto token{sourcemeta::core::JWT::from(id_token.value())};
-    if (!token.has_value()) {
-      sourcemeta::one::HTTP_LOG(
-          "The provider returned an identity token that could not be read, "
-          "for the policy",
-          policy_name);
-      this->incomplete(silent, transaction.value(), request, response);
-      return;
-    }
-
-    auto provider{this->jwks_provider(endpoints.value().jwks_uri)};
-    sourcemeta::core::OIDCValidationOptions options;
-    options.nonce = nonce->to_string();
-    const auto identity{sourcemeta::core::oidc_validate_id_token(
-        provider, token.value(), ID_TOKEN_ALGORITHMS, policy->issuer,
-        policy->client_id, options)};
-    if (!identity.has_value()) {
-      sourcemeta::one::HTTP_LOG(
-          "The identity token did not validate for the policy", policy_name);
-      this->incomplete(silent, transaction.value(), request, response);
-      return;
-    }
-
-    // A policy's rules are answered here rather than at the gate, so that a
-    // session only ever exists for somebody the policy admits. Answering it
-    // afterwards would leave a valid session denied on every request, and a
-    // denial asks the provider again, which is a loop rather than an answer
-    std::optional<sourcemeta::core::JSON> combined;
-    auto admission{
-        authentication.admits_identity(policy_name, token.value().payload())};
-
-    // OpenID Connect Core Section 5.4 has a provider answer for the claims a
-    // scope requested at its UserInfo endpoint rather than in the token, by
-    // default, under the flow this is completing. So a rule naming a claim the
-    // token does not carry is asked there before it is refused, and only then,
-    // since a token carrying everything needed spares the round trip
-    if (admission == sourcemeta::one::Authentication::Admission::Incomplete &&
-        !endpoints.value().userinfo.empty()) {
-      const auto extra{this->userinfo(endpoints.value().userinfo,
-                                      grant.value().access_token,
-                                      identity.value().subject)};
-      if (extra.has_value()) {
-        combined = sourcemeta::one::Authentication::combine_claims(
-            token.value().payload(), extra.value());
-        admission =
-            authentication.admits_identity(policy_name, combined.value());
-      }
-    }
-
-    // Whatever the decision was actually made against, which is the pair taken
-    // together once a second answer arrived. Explaining a refusal against the
-    // token alone would miss a claim the UserInfo endpoint supplied, and that
-    // is where a scope's claims arrive by default under this flow
-    const auto &asserted{combined.has_value() ? combined.value()
-                                              : token.value().payload()};
-
-    if (admission != sourcemeta::one::Authentication::Admission::Admitted) {
-      sourcemeta::one::HTTP_LOG(
-          "The provider authenticated somebody the policy does not admit, "
-          "for the policy",
-          policy_name);
-      this->report_object_shaped_claims(authentication, policy_name, asserted);
-      this->not_admitted(silent, transaction.value(), request, response);
-      return;
-    }
-
-    const auto expiry{std::chrono::time_point_cast<std::chrono::seconds>(
-                          std::chrono::system_clock::now()) +
-                      SESSION_LIFETIME};
-    const auto secure{sourcemeta::core::URI{this->server_uri()}.is_https()};
-
-    // The identity token is kept so that logging out can prove whose session
-    // it is asking the provider to end, which is what spares the person a
-    // confirmation page there. A provider that mints a large one can push the
-    // cookie past what a browser will store, and a browser drops such a cookie
-    // without saying so, which would look like signing in and then not being
-    // signed in. So the whole cookie is measured, and the token is left out
-    // when it does not fit, which costs the confirmation page and nothing else
-    auto session_cookie{this->session_cookie(authentication, policy_name,
-                                             identity.value().subject,
-                                             id_token.value(), expiry, secure)};
-    if (session_cookie.has_value() &&
-        session_cookie.value().size() > MAXIMUM_COOKIE_LENGTH) {
-      session_cookie =
-          this->session_cookie(authentication, policy_name,
-                               identity.value().subject, "", expiry, secure);
-    }
-
-    // Without the token there is very little left, so exceeding the limit here
-    // takes something extraordinary, such as a provider that identifies people
-    // by something enormous. Answering plainly beats handing over a cookie the
-    // browser discards, which would look like signing in and then not being
-    // signed in, with nothing anywhere to explain it
-    if (session_cookie.has_value() &&
-        session_cookie.value().size() > MAXIMUM_COOKIE_LENGTH) {
-      sourcemeta::one::HTTP_LOG(
-          "The provider returned more than a session can hold, for the policy",
-          policy_name);
-      this->incomplete(silent, transaction.value(), request, response);
-      return;
-    }
-
-    if (!session_cookie.has_value()) {
-      this->incomplete(silent, transaction.value(), request, response);
-      return;
-    }
-
-    // The login may have sealed a page to return to. It came through this
-    // instance's own signature, yet it is re-checked as a same-origin local
-    // path before being trusted as a redirect target, defaulting to the
-    // instance root
-    std::string destination{"/"};
-    const auto *sealed_destination{transaction.value().try_at("to")};
-    if (sealed_destination != nullptr && sealed_destination->is_string()) {
-      const auto &candidate{sealed_destination->to_string()};
-      if (sourcemeta::one::is_local_path(candidate)) {
-        destination = candidate;
-      }
+    using Result = sourcemeta::one::Authentication::Outcome::Result;
+    switch (outcome.result) {
+      case Result::Redirect:
+        break;
+      // A failed login leaves its transaction cookie in place, sealed and
+      // bound to a state the provider would have to echo, expiring on its own
+      // within minutes, so no cookie is cleared here and the error response
+      // owns the status line uncontested
+      case Result::Declined:
+        this->fail(request, response, sourcemeta::core::HTTP_STATUS_FORBIDDEN,
+                   "urn:sourcemeta:one:auth-login-declined",
+                   "The identity provider declined the login");
+        return;
+      case Result::NotAdmitted:
+        this->fail(request, response, sourcemeta::core::HTTP_STATUS_FORBIDDEN,
+                   "urn:sourcemeta:one:auth-not-admitted",
+                   "This account is not admitted here");
+        return;
+      // Every reason a proven callback cannot end in a session answers
+      // identically. Anybody may start a login and bring back a code of their
+      // own invention, so reaching here proves nothing about who is asking,
+      // while telling a secret apart from an unanswering provider apart from a
+      // token that would not validate reports how this deployment and its
+      // provider are faring. The cause went to the log above
+      case Result::Incomplete:
+        this->fail(request, response,
+                   sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
+                   "urn:sourcemeta:one:auth-incomplete",
+                   "The session could not be established");
+        return;
+      default:
+        this->fail(request, response, sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
+                   "urn:sourcemeta:one:auth-invalid-callback",
+                   "The login could not be completed");
+        return;
     }
 
     response.write_status(sourcemeta::core::HTTP_STATUS_SEE_OTHER);
-    response.write_header("Set-Cookie", session_cookie.value());
-    // Signing in is what earns a browser a silent renewal later, and the
-    // marker outlives the session it accompanies because it is only of use
-    // once that session has expired
-    this->remember_renewal(response, policy_name, secure);
-    // The single-use transaction has served its purpose, so it is expired
-    // alongside minting the session
-    this->expire(response, sourcemeta::one::Authentication::TRANSACTION_COOKIE,
-                 secure);
-    response.write_header("Location", destination);
+    for (const auto &cookie : outcome.cookies) {
+      response.write_header("Set-Cookie", cookie);
+    }
+
+    response.write_header("Location",
+                          outcome.location.empty() ? "/" : outcome.location);
     response.write_header("Cache-Control", "no-store");
     sourcemeta::one::send_response(sourcemeta::core::HTTP_STATUS_SEE_OTHER,
                                    request, response);
@@ -362,408 +180,12 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 
 private:
-  // The signature algorithms an identity token may be signed with: every
-  // asymmetric one, since a provider picks from these and an instance that
-  // named a narrower set would refuse a provider it could otherwise serve,
-  // after the person had already signed in. The symmetric ones are left out
-  // deliberately. They sign with the client secret rather than a key from the
-  // provider's published set, so admitting them alongside the rest is the
-  // shape that lets one algorithm be verified as though it were another
-  static constexpr std::array<sourcemeta::core::JWSAlgorithm, 10>
-      ID_TOKEN_ALGORITHMS{{sourcemeta::core::JWSAlgorithm::RS256,
-                           sourcemeta::core::JWSAlgorithm::RS384,
-                           sourcemeta::core::JWSAlgorithm::RS512,
-                           sourcemeta::core::JWSAlgorithm::PS256,
-                           sourcemeta::core::JWSAlgorithm::PS384,
-                           sourcemeta::core::JWSAlgorithm::PS512,
-                           sourcemeta::core::JWSAlgorithm::ES256,
-                           sourcemeta::core::JWSAlgorithm::ES384,
-                           sourcemeta::core::JWSAlgorithm::ES512,
-                           sourcemeta::core::JWSAlgorithm::EdDSA}};
-
-  // The tolerance allowed on an identity token's time-based claims, matching
-  // what a presented access token is already given. A provider whose clock
-  // runs a little fast otherwise mints a token this refuses the instant it
-  // arrives, which ends a login that did everything right
-  static constexpr std::chrono::seconds ID_TOKEN_CLOCK_SKEW{60};
-
-  // The transaction a callback belongs to, if the request carries one. A
-  // request can present several cookies under one name, since a parent
-  // domain and the host itself can each set one and neither the header nor
-  // the order says which is which, so every value is tried. Letting whoever
-  // controls a neighbouring host decide which transaction this instance
-  // reads is what turns the cookie from a defence against a forged callback
-  // into the way to mount one
-  [[nodiscard]] auto
-  transaction(sourcemeta::one::HTTPRequest &request,
-              const sourcemeta::one::Authentication &authentication,
-              const std::string_view policy_name,
-              const std::string_view state) const
-      -> std::optional<sourcemeta::core::JSON> {
-    if (state.empty()) {
-      return std::nullopt;
-    }
-
-    std::vector<std::string_view> candidates;
-    request.header_values(
-        "cookie", [&candidates](const std::string_view field) -> void {
-          sourcemeta::core::http_cookie_values(
-              field, sourcemeta::one::Authentication::TRANSACTION_COOKIE,
-              candidates);
-        });
-    for (const auto sealed : candidates) {
-      auto opened{authentication.open(
-          policy_name, sourcemeta::one::Authentication::Purpose::Transaction,
-          sealed)};
-      if (!opened.has_value()) {
-        continue;
-      }
-
-      auto document{sourcemeta::core::try_parse_json(opened.value())};
-      if (!document.has_value() || !document.value().is_object()) {
-        continue;
-      }
-
-      const auto *sealed_policy{document.value().try_at("policy")};
-      const auto *sealed_state{document.value().try_at("state")};
-      const auto *nonce{document.value().try_at("nonce")};
-      const auto *verifier{document.value().try_at("verifier")};
-      if (sealed_policy == nullptr || !sealed_policy->is_string() ||
-          sealed_policy->to_string() != policy_name ||
-          sealed_state == nullptr || !sealed_state->is_string() ||
-          sealed_state->to_string() != state || nonce == nullptr ||
-          !nonce->is_string() || nonce->to_string().empty() ||
-          verifier == nullptr || !verifier->is_string() ||
-          verifier->to_string().empty()) {
-        continue;
-      }
-
-      return document;
-    }
-
-    return std::nullopt;
-  }
-
-  // The session cookie for a login, carrying the identity token when one is
-  // given. Building it is separated out so the caller can measure the result
-  // and ask for a smaller one
-  [[nodiscard]] auto session_cookie(
-      const sourcemeta::one::Authentication &authentication,
-      const std::string_view policy_name, const std::string_view subject,
-      const std::string_view id_token, const std::chrono::sys_seconds expiry,
-      const bool secure) const -> std::optional<std::string> {
-    auto payload{sourcemeta::core::JSON::make_object()};
-    payload.assign_assume_new("policy",
-                              sourcemeta::core::JSON{std::string{policy_name}});
-    payload.assign_assume_new("subject",
-                              sourcemeta::core::JSON{std::string{subject}});
-    if (!id_token.empty()) {
-      payload.assign_assume_new("id_token",
-                                sourcemeta::core::JSON{std::string{id_token}});
-    }
-
-    std::ostringstream payload_text;
-    sourcemeta::core::stringify(payload, payload_text);
-    const auto sealed{authentication.seal(
-        policy_name, sourcemeta::one::Authentication::Purpose::Session,
-        payload_text.str(), expiry)};
-    if (!sealed.has_value()) {
-      sourcemeta::one::HTTP_LOG("No session secret is set for the policy",
-                                policy_name);
-      return std::nullopt;
-    }
-
-    auto cookie{sourcemeta::core::http_serialize_cookie(
-        {.name = sourcemeta::one::Authentication::SESSION_COOKIE,
-         .value = sealed.value(),
-         .path = sourcemeta::one::Authentication::COOKIE_PATH,
-         .max_age = SESSION_LIFETIME,
-         .http_only = true,
-         .secure = secure,
-         .same_site = sourcemeta::core::HTTPCookieSameSite::Lax})};
-    if (!cookie.has_value()) {
-      sourcemeta::one::HTTP_LOG("The session could not be put in a cookie, "
-                                "for the policy",
-                                policy_name);
-    }
-
-    return cookie;
-  }
-
-  // Every way a callback that belongs to a real login can end without a
-  // session. A silent attempt is put back where it started rather than shown
-  // any of this, since an error page would be the first anybody knew a renewal
-  // had been tried at all. The marker goes with it whatever the reason, so an
-  // attempt that did not come back with a grant is not made again on the next
-  // navigation, and every navigation after that
-  auto abandon(const bool silent, const sourcemeta::core::JSON &transaction,
-               sourcemeta::one::HTTPRequest &request,
-               sourcemeta::one::HTTPResponse &response,
-               const sourcemeta::core::HTTPStatus &status,
-               const std::string_view type, const std::string_view detail) const
-      -> void {
-    if (silent) {
-      sourcemeta::one::HTTP_LOG("A silent renewal did not end in a session",
-                                detail);
-      this->forget_renewal_and_redirect_back(transaction, request, response);
-      return;
-    }
-
-    this->fail(request, response, status, type, detail);
-  }
-
-  auto remember_renewal(sourcemeta::one::HTTPResponse &response,
-                        const std::string_view policy_name,
-                        const bool secure) const -> void {
-    const auto cookie{sourcemeta::core::http_serialize_cookie(
-        {.name = sourcemeta::one::Authentication::RENEWAL_COOKIE,
-         .value = policy_name,
-         .path = sourcemeta::one::Authentication::COOKIE_PATH,
-         .max_age = RENEWAL_LIFETIME,
-         .http_only = true,
-         .secure = secure,
-         .same_site = sourcemeta::core::HTTPCookieSameSite::Lax})};
-    if (cookie.has_value()) {
-      response.write_header("Set-Cookie", cookie.value());
-    }
-  }
-
-  // Where a silent attempt leaves the browser when it did not come back with a
-  // grant: back where it was denied, carrying neither a session nor the marker
-  // that would send it here again
-  auto forget_renewal_and_redirect_back(
-      const sourcemeta::core::JSON &transaction,
-      sourcemeta::one::HTTPRequest &request,
-      sourcemeta::one::HTTPResponse &response) const -> void {
-    const auto secure{sourcemeta::core::URI{this->server_uri()}.is_https()};
-    std::string destination{"/"};
-    const auto *sealed_destination{transaction.try_at("to")};
-    if (sealed_destination != nullptr && sealed_destination->is_string() &&
-        sourcemeta::one::is_local_path(sealed_destination->to_string())) {
-      destination = sealed_destination->to_string();
-    }
-
-    response.write_status(sourcemeta::core::HTTP_STATUS_SEE_OTHER);
-    this->expire(response, sourcemeta::one::Authentication::RENEWAL_COOKIE,
-                 secure);
-    this->expire(response, sourcemeta::one::Authentication::TRANSACTION_COOKIE,
-                 secure);
-    response.write_header("Location", destination);
-    response.write_header("Cache-Control", "no-store");
-    sourcemeta::one::send_response(sourcemeta::core::HTTP_STATUS_SEE_OTHER,
-                                   request, response);
-  }
-
-  auto expire(sourcemeta::one::HTTPResponse &response,
-              const std::string_view name, const bool secure) const -> void {
-    const auto cookie{sourcemeta::core::http_serialize_cookie(
-        {.name = name,
-         .value = "",
-         .path = sourcemeta::one::Authentication::COOKIE_PATH,
-         .max_age = std::chrono::seconds{0},
-         .http_only = true,
-         .secure = secure,
-         .same_site = sourcemeta::core::HTTPCookieSameSite::Lax})};
-    if (cookie.has_value()) {
-      response.write_header("Set-Cookie", cookie.value());
-    }
-  }
-
-  // What redeeming an authorization code yields, of which only the identity
-  // token decides anything. The access token comes along solely so that a
-  // claim missing from that token can be asked for at the UserInfo endpoint
-  struct Grant {
-    std::string id_token;
-    std::string access_token;
-  };
-
-  // RFC 6749 Section 2.3.1 has every server accept the client secret in an
-  // authorization header, and asks that carrying it in the request body be
-  // limited to clients that cannot send one. A body is the part of a request
-  // that logging and proxies keep, while an authorization header is the part
-  // they already know to redact, so the header is used wherever the provider
-  // takes it
-  [[nodiscard]] auto exchange(
-      const std::string_view token_endpoint, const std::string_view client_id,
-      const std::string_view client_secret, const std::string_view redirect_uri,
-      const std::string_view code, const std::string_view code_verifier,
-      const bool basic_auth) const -> std::optional<Grant> {
-    try {
-      sourcemeta::core::HTTPSystemRequest fetch{
-          std::string{token_endpoint}, sourcemeta::core::HTTPMethod::POST};
-      fetch.connect_timeout(std::chrono::seconds{2});
-      fetch.timeout(std::chrono::seconds{5});
-      fetch.maximum_response_size(1024UL * 1024UL);
-      fetch.follow_redirects(false);
-      sourcemeta::core::SecureString body;
-      sourcemeta::core::oauth_build_token_request_code(code, redirect_uri,
-                                                       code_verifier, {}, body);
-      if (basic_auth) {
-        sourcemeta::core::SecureString authorization;
-        sourcemeta::core::oauth_client_secret_basic(client_id, client_secret,
-                                                    authorization);
-        fetch.header("authorization", std::move(authorization));
-      } else {
-        sourcemeta::core::oauth_client_secret_post(client_id, client_secret,
-                                                   body);
-      }
-
-      fetch.body(std::move(body), "application/x-www-form-urlencoded");
-      const auto result{fetch.send()};
-      if (result.status.code < 200 || result.status.code >= 300) {
-        return std::nullopt;
-      }
-
-      const auto document{sourcemeta::core::try_parse_json(result.body)};
-      if (!document.has_value()) {
-        return std::nullopt;
-      }
-
-      auto identity{sourcemeta::core::oidc_parse_id_token(document.value())};
-      if (!identity.has_value()) {
-        return std::nullopt;
-      }
-
-      // The access token is kept only so that the UserInfo endpoint can be
-      // asked for a claim the identity token did not carry. It is never
-      // stored, never logged, and never leaves this exchange
-      Grant grant;
-      grant.id_token = std::move(identity).value();
-      const sourcemeta::core::OAuthTokenResponse response{document.value()};
-      if (response.access_token().has_value()) {
-        grant.access_token = response.access_token().value();
-      }
-
-      return grant;
-    } catch (...) {
-      return std::nullopt;
-    }
-  }
-
-  // A rule compared against a claim carrying objects is compared on the
-  // `value` sub-attribute alone, so a rule naming what a person sees rather
-  // than what identifies them matches nothing. A denial cannot show that, and
-  // the token it concerns is sealed inside a cookie where an operator cannot
-  // look, so it is said here.
-  //
-  // Only a refusal reaches this, so a working policy stays quiet, and each
-  // claim is named once however often somebody signs in
-  static auto report_object_shaped_claims(
-      const sourcemeta::one::Authentication &authentication,
-      const std::string_view policy_name, const sourcemeta::core::JSON &claims)
-      -> void {
-    static std::mutex mutex;
-    static std::set<std::string, std::less<>> reported;
-    for (const auto claim :
-         authentication.object_shaped_claims(policy_name, claims)) {
-      std::string subject{claim};
-      subject += " of the policy ";
-      subject += policy_name;
-      const std::scoped_lock guard{mutex};
-      if (!reported.insert(subject).second) {
-        continue;
-      }
-
-      sourcemeta::one::HTTP_LOG(
-          "A rule names a claim the provider answers with objects, which are "
-          "compared on their identifier rather than on any name shown to a "
-          "person. The claim is",
-          subject);
-    }
-  }
-
-  // What a provider answers at its UserInfo endpoint, which under the
-  // authorization code flow is where the claims a scope requested arrive by
-  // default (OpenID Connect Core Section 5.4).
-  //
-  // OpenID Connect Core Section 5.3.2 requires the subject it returns to match
-  // the one the identity token asserted, and to be checked before anything it
-  // says is used. Without that a response about somebody else would be read as
-  // being about this person, which is the whole of what this is for.
-  //
-  // A signed or encrypted response is refused rather than half-checked, since
-  // reading one without verifying it would defeat the signature it carries
-  [[nodiscard]] auto userinfo(const std::string_view endpoint,
-                              const std::string_view access_token,
-                              const std::string_view subject) const
-      -> std::optional<sourcemeta::core::JSON> {
-    if (access_token.empty()) {
-      return std::nullopt;
-    }
-
-    try {
-      sourcemeta::core::HTTPSystemRequest fetch{std::string{endpoint}};
-      fetch.connect_timeout(std::chrono::seconds{2});
-      fetch.timeout(std::chrono::seconds{5});
-      fetch.maximum_response_size(1024UL * 1024UL);
-      fetch.follow_redirects(false);
-      std::string authorization;
-      if (!sourcemeta::core::oauth_bearer_header(access_token, authorization)) {
-        return std::nullopt;
-      }
-
-      fetch.header("authorization", std::move(authorization));
-      const auto result{fetch.send()};
-      if (result.status.code < 200 || result.status.code >= 300) {
-        return std::nullopt;
-      }
-
-      const auto document{sourcemeta::core::try_parse_json(result.body)};
-      if (!document.has_value() || !document.value().is_object()) {
-        return std::nullopt;
-      }
-
-      const auto *asserted{document.value().try_at("sub")};
-      if (asserted == nullptr || !asserted->is_string() ||
-          asserted->to_string() != subject) {
-        sourcemeta::one::HTTP_LOG(
-            "The UserInfo endpoint answered about a different subject than "
-            "the identity token did");
-        return std::nullopt;
-      }
-
-      return document;
-    } catch (...) {
-      return std::nullopt;
-    }
-  }
-
-  [[nodiscard]] static auto jwks_provider(std::string location)
-      -> sourcemeta::core::JWKSProvider {
-    return sourcemeta::core::JWKSProvider{
-        std::move(location),
-        [](const std::string_view url)
-            -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
-          try {
-            sourcemeta::core::HTTPSystemRequest fetch{std::string{url}};
-            fetch.connect_timeout(std::chrono::seconds{2});
-            fetch.timeout(std::chrono::seconds{5});
-            fetch.maximum_response_size(1024UL * 1024UL);
-            fetch.follow_redirects(false);
-            const auto result{fetch.send()};
-            if (result.status.code < 200 || result.status.code >= 300) {
-              return std::nullopt;
-            }
-
-            return sourcemeta::core::JWKSProvider::FetchResult{
-                .body = result.body, .max_age = std::nullopt};
-          } catch (...) {
-            return std::nullopt;
-          }
-        },
-        {.clock_skew = ID_TOKEN_CLOCK_SKEW}};
-  }
-
-  // A failed login leaves its transaction cookie in place, sealed and bound
-  // to a state the provider would have to echo, expiring on its own within
-  // minutes, so no cookie is cleared here and the error response owns the
-  // status line uncontested
   auto fail(sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response,
             const sourcemeta::core::HTTPStatus &status,
@@ -771,36 +193,6 @@ private:
       -> void {
     sourcemeta::one::json_error(request, response, status, type, detail,
                                 this->error_schema_, "*");
-  }
-
-  // Every reason a proven callback cannot end in a session answers
-  // identically. Anybody may start a login and bring back a code of their own
-  // invention, so reaching here proves nothing about who is asking, while
-  // telling a secret apart from an unanswering provider apart from a token
-  // that would not validate reports how this deployment and its provider are
-  // faring. The cause goes to the log, where an operator looks and a caller
-  // cannot
-  auto incomplete(const bool silent, const sourcemeta::core::JSON &transaction,
-                  sourcemeta::one::HTTPRequest &request,
-                  sourcemeta::one::HTTPResponse &response) const -> void {
-    this->abandon(silent, transaction, request, response,
-                  sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
-                  "urn:sourcemeta:one:auth-incomplete",
-                  "The session could not be established");
-  }
-
-  // Somebody the provider vouched for, who this policy does not admit. That is
-  // a different answer from being refused a login, and it is the end of the
-  // road rather than something to try again, so a silent attempt gives up its
-  // marker here exactly as any other failure does and stops asking
-  auto not_admitted(const bool silent,
-                    const sourcemeta::core::JSON &transaction,
-                    sourcemeta::one::HTTPRequest &request,
-                    sourcemeta::one::HTTPResponse &response) const -> void {
-    this->abandon(silent, transaction, request, response,
-                  sourcemeta::core::HTTP_STATUS_FORBIDDEN,
-                  "urn:sourcemeta:one:auth-not-admitted",
-                  "This account is not admitted here");
   }
 
   std::string_view error_schema_;

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_callback_v1.h
@@ -126,7 +126,7 @@ public:
          .issuer = request.query("iss")},
         {.cookies = cookies})};
     for (const auto &message : outcome.log) {
-      sourcemeta::one::HTTP_LOG("Callback", message);
+      sourcemeta::one::HTTP_LOG(message, matches.front());
     }
 
     using Result = sourcemeta::one::Authentication::Outcome::Result;

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_page_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_page_v1.h
@@ -55,8 +55,9 @@ public:
     return true;
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     // The data representation is cross-origin readable, so the preflight has to
     // grant what the request that follows it needs. A page is a navigation and
@@ -107,7 +108,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
@@ -61,8 +61,9 @@ public:
     return true;
   }
 
-  auto rest(const std::span<std::string_view> matches, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view> matches,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);
@@ -92,11 +93,44 @@ public:
       return;
     }
 
-    // An unknown or non-interactive policy name reveals nothing
-    const auto policy_name{matches.front()};
-    const auto &authentication{this->dispatcher().authentication()};
-    const auto policy{authentication.interactive(policy_name)};
-    if (!policy.has_value()) {
+    // Where the browser goes once this completes. An explicit `to` query wins,
+    // then the referring page, which for a login reached from a denied page is
+    // exactly that page. Only a same-origin local path is ever honoured, so
+    // this cannot be turned into an open redirect. What the policy governs
+    // stands in where neither says anything, and that is decided by whoever
+    // holds the policy rather than here
+    std::string return_to;
+    const auto destination{request.query("to")};
+    if (!destination.empty() && sourcemeta::one::is_local_path(destination)) {
+      return_to = destination;
+    } else if (const auto referer{request.header("referer")};
+               referer.starts_with(this->server_uri())) {
+      std::string candidate{referer.substr(this->server_uri().size())};
+      if (sourcemeta::one::is_local_path(candidate)) {
+        return_to = std::move(candidate);
+      }
+    }
+
+    // The callback URL is pinned from the configured public URL, never
+    // inferred from an incoming request, and it is composed here because which
+    // routes this instance serves is not something authentication knows
+    constexpr std::string_view CALLBACK_PATH{"/self/v1/auth/callback/"};
+    std::string redirect_uri;
+    redirect_uri.reserve(this->server_uri().size() + CALLBACK_PATH.size() +
+                         matches.front().size());
+    redirect_uri += this->server_uri();
+    redirect_uri += CALLBACK_PATH;
+    redirect_uri += matches.front();
+
+    const auto outcome{this->dispatcher().authentication().login(
+        matches.front(), this->server_uri(), redirect_uri,
+        !request.query("silent").empty(), return_to)};
+    for (const auto &message : outcome.log) {
+      sourcemeta::one::HTTP_LOG("Login", message);
+    }
+
+    if (outcome.result ==
+        sourcemeta::one::Authentication::Outcome::Result::Missing) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
           "urn:sourcemeta:one:not-found", "There is nothing at this URL",
@@ -104,173 +138,28 @@ public:
       return;
     }
 
-    // Starting a login that cannot be completed only strands the person at the
-    // provider, so the secret the exchange will need is required up front
-    if (!authentication.client_secret(policy_name).has_value()) {
-      sourcemeta::one::HTTP_LOG("No client secret is set for the policy",
-                                policy_name);
-      this->unavailable(request, response);
-      return;
-    }
-
-    const auto endpoints{authentication.endpoints(policy_name)};
-    if (!endpoints.has_value() || endpoints.value().authorization.empty()) {
-      sourcemeta::one::HTTP_LOG("The provider named no authorization endpoint, "
-                                "or could not be reached, for the policy",
-                                policy_name);
-      this->unavailable(request, response);
-      return;
-    }
-
-    const auto secrets{sourcemeta::core::oauth_transaction_mint()};
-    const std::string_view state{secrets.state.data(), secrets.state.size()};
-    const std::string_view verifier{secrets.code_verifier.data(),
-                                    secrets.code_verifier.size()};
-    const auto nonce_token{sourcemeta::core::oidc_nonce()};
-    const std::string_view nonce{nonce_token.data(), nonce_token.size()};
-
-    // A silent attempt asks the provider whether an existing sign-in still
-    // stands, and is answered either way without the person seeing anything.
-    // The callback has to know which kind it is completing, since a provider
-    // refusing to answer without interaction is an ordinary outcome here and a
-    // failure anywhere else
-    const auto silent{!request.query("silent").empty()};
-
-    auto payload{sourcemeta::core::JSON::make_object()};
-    payload.assign_assume_new("policy",
-                              sourcemeta::core::JSON{std::string{policy_name}});
-    if (silent) {
-      payload.assign_assume_new("silent", sourcemeta::core::JSON{true});
-    }
-    payload.assign_assume_new("state", sourcemeta::core::JSON{state});
-    payload.assign_assume_new("nonce", sourcemeta::core::JSON{nonce});
-    payload.assign_assume_new("verifier", sourcemeta::core::JSON{verifier});
-    // The return target lets the login send the browser back to the page it
-    // was denied. An explicit `to` query wins, then the referring page, which
-    // for a login served in place is exactly that denied page and so needs no
-    // query, then what the policy governs. Only a same-origin local path is
-    // ever honoured, so the login cannot be turned into an open redirect
-    std::optional<std::string> target;
-    const auto destination{request.query("to")};
-    if (!destination.empty() && sourcemeta::one::is_local_path(destination)) {
-      target = std::string{destination};
-    } else if (const auto referer{request.header("referer")};
-               referer.starts_with(this->server_uri())) {
-      std::string candidate{""};
-      candidate += referer.substr(this->server_uri().size());
-      if (sourcemeta::one::is_local_path(candidate)) {
-        target = std::move(candidate);
-      }
-    }
-    if (!target.has_value() && !policy->default_path.empty()) {
-      std::string fallback{""};
-      fallback += policy->default_path;
-      target = std::move(fallback);
-    }
-    if (target.has_value()) {
-      payload.assign_assume_new("to", sourcemeta::core::JSON{target.value()});
-    }
-    std::ostringstream payload_text;
-    sourcemeta::core::stringify(payload, payload_text);
-
-    const auto expiry{std::chrono::time_point_cast<std::chrono::seconds>(
-                          std::chrono::system_clock::now()) +
-                      TRANSACTION_LIFETIME};
-    const auto sealed{authentication.seal(
-        policy_name, sourcemeta::one::Authentication::Purpose::Transaction,
-        payload_text.str(), expiry)};
-    if (!sealed.has_value()) {
-      sourcemeta::one::HTTP_LOG("No session secret is set for the policy",
-                                policy_name);
-      this->unavailable(request, response);
-      return;
-    }
-
-    // The callback URL is pinned from the configured public URL, never
-    // inferred from the incoming request
-    constexpr std::string_view CALLBACK_PATH{"/self/v1/auth/callback/"};
-    std::string redirect_uri;
-    redirect_uri.reserve(this->server_uri().size() + CALLBACK_PATH.size() +
-                         policy_name.size());
-    redirect_uri += this->server_uri();
-    redirect_uri += CALLBACK_PATH;
-    redirect_uri += policy_name;
-
-    // A provider sends only the claims a request asks for, so a policy whose
-    // rules name any is asked for them here. The standard way is the claims
-    // request parameter, and where a provider does not honour that, the scopes
-    // that carry the standard claims are the fallback. A claim no standard
-    // scope carries is then arranged at the provider instead, since inventing
-    // a scope name risks a request refused outright
-    // The rules outlive every request built from them, since a claim request
-    // names its claim by pointing into them rather than copying
-    const auto rules{policy->claims.empty()
-                         ? std::optional<sourcemeta::core::JSON>{std::nullopt}
-                         : sourcemeta::core::try_parse_json(policy->claims)};
-    const auto wanted{this->wanted_claims(policy.value(), rules)};
-    std::string scope_request;
-    std::string claims_parameter;
-    if (endpoints.value().claims_parameter_supported && !wanted.empty()) {
-      std::ostringstream text;
-      sourcemeta::core::stringify(
-          sourcemeta::core::oidc_build_claims_parameter({}, wanted), text);
-      claims_parameter = text.str();
-    }
-
-    this->requested_scope(wanted, scope_request);
-    this->report_unadvertised_claims(wanted, endpoints.value(), policy_name);
-
-    const auto challenge{sourcemeta::core::oauth_pkce_challenge(verifier)};
-    sourcemeta::core::OIDCAuthenticationRequest authentication_request{};
-    authentication_request.client_id = policy->client_id;
-    authentication_request.redirect_uri = redirect_uri;
-    authentication_request.scope = scope_request;
-    authentication_request.claims = claims_parameter;
-    authentication_request.response_type = "code";
-    authentication_request.state = state;
-    authentication_request.code_challenge = {challenge.data(),
-                                             challenge.size()};
-    authentication_request.code_challenge_method = "S256";
-    authentication_request.nonce = nonce;
-    if (silent) {
-      authentication_request.prompt = "none";
-    }
-
-    std::string authorization_url;
-    const auto url{sourcemeta::core::oidc_build_authentication_url(
-                       endpoints.value().authorization, authentication_request,
-                       authorization_url)
-                       ? std::optional<std::string>{authorization_url}
-                       : std::nullopt};
-    if (!url.has_value()) {
-      sourcemeta::one::HTTP_LOG("The authorization endpoint is not a URL a "
-                                "request can be built against, for the policy",
-                                policy_name);
-      this->unavailable(request, response);
-      return;
-    }
-
-    const auto cookie{sourcemeta::core::http_serialize_cookie(
-        {.name = sourcemeta::one::Authentication::TRANSACTION_COOKIE,
-         .value = sealed.value(),
-         .path = sourcemeta::one::Authentication::COOKIE_PATH,
-         .max_age = TRANSACTION_LIFETIME,
-         .http_only = true,
-         .secure = sourcemeta::core::URI{this->server_uri()}.is_https(),
-         .same_site = sourcemeta::core::HTTPCookieSameSite::Lax})};
-    // A redirect without the transaction cookie could never complete at the
-    // callback, so it is not worth sending
-    if (!cookie.has_value()) {
-      sourcemeta::one::HTTP_LOG(
-          "The login transaction could not be put in a cookie, for the policy",
-          policy_name);
-      this->unavailable(request, response);
+    // Every reason a login cannot start answers identically. Which policies
+    // exist is published, but whether one is misconfigured and whether its
+    // provider is answering are neither, and telling those apart hands a
+    // caller who has authenticated to nothing a view of how this deployment is
+    // doing. The cause went to the log above, where an operator looks and a
+    // caller cannot
+    if (outcome.result !=
+        sourcemeta::one::Authentication::Outcome::Result::Redirect) {
+      sourcemeta::one::json_error(
+          request, response,
+          sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
+          "urn:sourcemeta:one:auth-unavailable", "This login cannot be started",
+          this->error_schema_, "*");
       return;
     }
 
     response.write_status(sourcemeta::core::HTTP_STATUS_SEE_OTHER);
-    response.write_header("Set-Cookie", cookie.value());
-    response.write_header("Location", url.value());
+    for (const auto &cookie : outcome.cookies) {
+      response.write_header("Set-Cookie", cookie);
+    }
+
+    response.write_header("Location", outcome.location);
     response.write_header("Cache-Control", "no-store");
     sourcemeta::one::send_response(sourcemeta::core::HTTP_STATUS_SEE_OTHER,
                                    request, response);
@@ -278,122 +167,12 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 
 private:
-  // The claims a policy's rules speak about, each asked for as essential, so
-  // that a provider is told what is actually needed rather than being left to
-  // guess from a scope. A domain rule reads an address, so it asks for the
-  // pair OpenID Connect Core Section 5.1 defines for one
-  [[nodiscard]] static auto wanted_claims(
-      const sourcemeta::one::Authentication::InteractivePolicy &policy,
-      const std::optional<sourcemeta::core::JSON> &rules)
-      -> std::vector<sourcemeta::core::OIDCClaimRequest> {
-    std::vector<sourcemeta::core::OIDCClaimRequest> result;
-    if (!policy.email_domains.empty()) {
-      result.push_back({.name = "email", .essential = true});
-      result.push_back({.name = "email_verified", .essential = true});
-    }
-
-    if (!rules.has_value() || !rules.value().is_object()) {
-      return result;
-    }
-
-    for (const auto &rule : rules.value().as_object()) {
-      result.push_back({.name = rule.first, .essential = true});
-    }
-
-    return result;
-  }
-
-  // The scope a login asks for. Every request carries `openid`, and a claim
-  // one of the standard scopes carries adds that scope, which is the only
-  // mapping a specification defines. A claim outside them adds nothing, since
-  // a scope this invented could be refused outright by the provider
-  static auto
-  requested_scope(const std::vector<sourcemeta::core::OIDCClaimRequest> &wanted,
-                  std::string &sink) -> void {
-    sink += "openid";
-    std::vector<std::string_view> scopes;
-    for (const auto &claim : wanted) {
-      const auto scope{sourcemeta::core::oidc_claim_to_scope(claim.name)};
-      if (scope.has_value() && scope.value() != "openid" &&
-          std::ranges::find(scopes, scope.value()) == scopes.cend()) {
-        scopes.push_back(scope.value());
-      }
-    }
-
-    std::ranges::sort(scopes);
-    for (const auto scope : scopes) {
-      sink += " ";
-      sink += scope;
-    }
-  }
-
-  // A rule naming a claim the provider never sends is one that can only ever
-  // deny, and nothing in the exchange would say so: the login succeeds, the
-  // token arrives, and admission fails for a reason nobody can see. So the
-  // provider's own account of what it may supply is compared against what the
-  // rules ask for, and a gap is named where an operator will find it.
-  //
-  // This reports and never refuses. OpenID Connect Discovery Section 3 says
-  // the list "might not be an exhaustive list", so a claim missing from it is
-  // a hint rather than a verdict, and a provider publishing no list at all is
-  // saying nothing rather than saying no
-  static auto report_unadvertised_claims(
-      const std::vector<sourcemeta::core::OIDCClaimRequest> &wanted,
-      const sourcemeta::one::Authentication::ProviderEndpoints &endpoints,
-      const std::string_view policy_name) -> void {
-    if (endpoints.claims_supported.empty()) {
-      return;
-    }
-
-    // Anybody at all may start a login, so saying this on every attempt would
-    // leave a stranger able to bury everything else in the log. What it says
-    // concerns a policy and its provider rather than the attempt that
-    // surfaced it, so saying it once says all of it
-    static std::mutex mutex;
-    static std::set<std::string, std::less<>> reported;
-
-    for (const auto &claim : wanted) {
-      if (std::ranges::find(endpoints.claims_supported, claim.name) !=
-          endpoints.claims_supported.cend()) {
-        continue;
-      }
-
-      std::string subject{claim.name};
-      subject += " of the policy ";
-      subject += policy_name;
-      const std::scoped_lock guard{mutex};
-      if (!reported.insert(subject).second) {
-        continue;
-      }
-
-      sourcemeta::one::HTTP_LOG(
-          "The provider does not advertise a claim a rule requires, so the "
-          "rule may never match. The claim is",
-          subject);
-    }
-  }
-
-  // Every reason a login cannot start answers identically. The login page names
-  // its policies to anybody who reaches a gated path, so which policies exist
-  // is published rather than secret, but whether one is misconfigured and
-  // whether its provider is answering are neither, and telling those apart
-  // hands a caller who has authenticated to nothing a view of how this
-  // deployment is doing. The cause goes to the log, where an operator looks and
-  // a caller cannot
-  auto unavailable(sourcemeta::one::HTTPRequest &request,
-                   sourcemeta::one::HTTPResponse &response) const -> void {
-    sourcemeta::one::json_error(
-        request, response, sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR,
-        "urn:sourcemeta:one:auth-unavailable", "This login cannot be started",
-        this->error_schema_, "*");
-  }
-
   std::string_view error_schema_;
 };
 

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_login_v1.h
@@ -126,7 +126,7 @@ public:
         matches.front(), this->server_uri(), redirect_uri,
         !request.query("silent").empty(), return_to)};
     for (const auto &message : outcome.log) {
-      sourcemeta::one::HTTP_LOG("Login", message);
+      sourcemeta::one::HTTP_LOG(message, matches.front());
     }
 
     if (outcome.result ==

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_logout_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_auth_logout_v1.h
@@ -44,8 +44,9 @@ public:
         });
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);
@@ -74,32 +75,18 @@ public:
       return;
     }
 
+    const sourcemeta::one::RequestCookies cookies{request};
+    // Signing out always returns to the instance root, which is named here
+    // rather than assumed there
+    const auto outcome{this->dispatcher().authentication().logout(
+        {.cookies = cookies}, this->server_uri(), "/")};
+
     response.write_status(sourcemeta::core::HTTP_STATUS_SEE_OTHER);
+    for (const auto &cookie : outcome.cookies) {
+      response.write_header("Set-Cookie", cookie);
+    }
 
-    const auto secure{sourcemeta::core::URI{this->server_uri()}.is_https()};
-
-    // Both cookies are expired whether or not the request carried them. A
-    // cookie is withheld on plenty of navigations while the browser still
-    // holds it, so clearing only what arrived leaves a session behind and
-    // tells the person they are signed out. This runs before anything that
-    // could fail, so no outcome below can end with the session surviving
-    this->expire(response, sourcemeta::one::Authentication::SESSION_COOKIE,
-                 secure);
-    this->expire(response, sourcemeta::one::Authentication::TRANSACTION_COOKIE,
-                 secure);
-    // Somebody who has signed out is asking not to be signed in, so the marker
-    // that would have renewed them silently goes too. Leaving it would undo
-    // this at the very next denial, without them doing anything
-    this->expire(response, sourcemeta::one::Authentication::RENEWAL_COOKIE,
-                 secure);
-
-    // Ending the session here leaves the provider's own untouched, so signing
-    // in again would not ask who you are. Where the session names a policy
-    // whose provider offers to end it, the browser is sent there to finish the
-    // job, carrying the identity token as the proof of whose session it is
-    const auto &authentication{this->dispatcher().authentication()};
-    const auto elsewhere{this->provider_logout(request, authentication)};
-    response.write_header("Location", elsewhere.value_or(std::string{"/"}));
+    response.write_header("Location", outcome.location);
     response.write_header("Cache-Control", "no-store");
     sourcemeta::one::send_response(sourcemeta::core::HTTP_STATUS_SEE_OTHER,
                                    request, response);
@@ -107,83 +94,12 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
 
 private:
-  auto expire(sourcemeta::one::HTTPResponse &response,
-              const std::string_view name, const bool secure) const -> void {
-    // The attributes mirror the ones the cookie is minted under, so the
-    // browser replaces the cookie rather than keeping it alongside a second
-    // one of the same name
-    const auto cookie{sourcemeta::core::http_serialize_cookie(
-        {.name = name,
-         .value = "",
-         .path = sourcemeta::one::Authentication::COOKIE_PATH,
-         .max_age = std::chrono::seconds{0},
-         .http_only = true,
-         .secure = secure,
-         .same_site = sourcemeta::core::HTTPCookieSameSite::Lax})};
-    if (cookie.has_value()) {
-      response.write_header("Set-Cookie", cookie.value());
-    }
-  }
-
-  // Where to send the browser so the provider ends its own session, if the
-  // request carried a session this instance minted and the provider offers to
-  // end it. Every step that cannot be completed simply yields nothing, since
-  // the local session is already gone by the time this runs
-  [[nodiscard]] auto
-  provider_logout(sourcemeta::one::HTTPRequest &request,
-                  const sourcemeta::one::Authentication &authentication) const
-      -> std::optional<std::string> {
-    std::vector<std::string_view> candidates;
-    request.header_values(
-        "cookie", [&candidates](const std::string_view field) -> void {
-          sourcemeta::core::http_cookie_values(
-              field, sourcemeta::one::Authentication::SESSION_COOKIE,
-              candidates);
-        });
-    for (const auto sealed : candidates) {
-      const auto payload{authentication.open_session(sealed)};
-      if (!payload.has_value()) {
-        continue;
-      }
-
-      const auto document{sourcemeta::core::try_parse_json(payload.value())};
-      if (!document.has_value() || !document.value().is_object()) {
-        continue;
-      }
-
-      const auto *policy{document.value().try_at("policy")};
-      const auto *token{document.value().try_at("id_token")};
-      if (policy == nullptr || !policy->is_string()) {
-        continue;
-      }
-
-      const auto endpoints{authentication.endpoints(policy->to_string())};
-      if (!endpoints.has_value() || endpoints.value().end_session.empty()) {
-        continue;
-      }
-
-      sourcemeta::core::OIDCLogoutRequest logout;
-      if (token != nullptr && token->is_string()) {
-        logout.id_token_hint = token->to_string();
-      }
-
-      // Where the provider sends the browser back to once it is done
-      logout.post_logout_redirect_uri = this->server_uri();
-      std::string url;
-      sourcemeta::core::oidc_build_logout_url(endpoints.value().end_session,
-                                              logout, url);
-      return url;
-    }
-
-    return std::nullopt;
-  }
-
   std::string_view error_schema_;
 };
 

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_jsonschema_rdf_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_jsonschema_rdf_v1.h
@@ -59,7 +59,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            const std::string_view credential, const std::string_view,
+            const sourcemeta::one::Authentication::Caller &caller,
             sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     const auto &path{matches.front()};
@@ -105,14 +105,10 @@ public:
     schema_uri.push_back('/');
     schema_uri.append(path);
     const sourcemeta::one::RequestCookies cookies{request};
-    const auto schema_present{
-        this->artifact_resolve_path(sourcemeta::one::VIEW_PUBLIC,
-                                    {.bearer = credential, .cookies = cookies},
-                                    schema_uri, Tree::Schemas, "schema")};
+    const auto schema_present{this->artifact_resolve_path(
+        caller, schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
-        sourcemeta::one::VIEW_PUBLIC,
-        {.bearer = credential, .cookies = cookies}, schema_uri, Tree::Schemas,
-        "blaze-exhaustive")};
+        caller, schema_uri, Tree::Schemas, "blaze-exhaustive")};
     if (!schema_present.path.has_value()) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
@@ -164,7 +160,8 @@ public:
         // handler
         // NOLINTNEXTLINE(bugprone-exception-escape)
         [this, schema_template, schema_uri = std::move(schema_uri),
-         bearer = std::string{credential},
+         bearer = std::string{sourcemeta::core::http_parse_bearer(
+             request.header("authorization"))},
          cookies = sourcemeta::one::owned_cookies(request)](
             sourcemeta::one::HTTPRequest &callback_request,
             sourcemeta::one::HTTPResponse &callback_response,
@@ -201,6 +198,10 @@ public:
           }
 
           const sourcemeta::one::RequestCookies fields{cookies};
+          // Placed again rather than captured, since the caller this action
+          // was handed points at a request that is gone by now
+          const auto deferred_caller{
+              this->caller_from({.bearer = bearer, .cookies = fields})};
           if (!this->structural_evaluate_fast(this->request_schema_,
                                               envelope)) {
             sourcemeta::one::json_error(
@@ -232,8 +233,7 @@ public:
                    .detail = "The instance does not conform to the schema"})};
               payload.assign(
                   "errors",
-                  this->schema_evaluate({.bearer = bearer, .cookies = fields},
-                                        schema_uri, instance,
+                  this->schema_evaluate(deferred_caller, schema_uri, instance,
                                         sourcemeta::blaze::Mode::Exhaustive)
                       .second.at("errors"));
               this->send_problem(
@@ -329,7 +329,7 @@ public:
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
            const sourcemeta::core::JSON &arguments,
-           const sourcemeta::one::Credentials &credentials)
+           const sourcemeta::one::Authentication::Caller &caller)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
         this->structural_evaluate(this->rpc_request_schema_, arguments,
@@ -341,12 +341,10 @@ public:
     }
 
     const auto &schema_uri{arguments.at("schema").to_string()};
-    const auto schema_present{
-        this->artifact_resolve_path(sourcemeta::one::VIEW_PUBLIC, credentials,
-                                    schema_uri, Tree::Schemas, "schema")};
+    const auto schema_present{this->artifact_resolve_path(
+        caller, schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
-        sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri, Tree::Schemas,
-        "blaze-exhaustive")};
+        caller, schema_uri, Tree::Schemas, "blaze-exhaustive")};
     if (!schema_present.path.has_value()) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");
@@ -396,7 +394,7 @@ public:
       auto payload{sourcemeta::core::JSON::make_object()};
       payload.assign("valid", sourcemeta::core::JSON{false});
       payload.assign("errors",
-                     this->schema_evaluate(credentials, schema_uri, instance,
+                     this->schema_evaluate(caller, schema_uri, instance,
                                            sourcemeta::blaze::Mode::Exhaustive)
                          .second.at("errors"));
       return sourcemeta::core::mcp_make_tool_success(version, request_id,

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_prm_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_prm_v1.h
@@ -64,8 +64,9 @@ public:
     return true;
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",
@@ -112,7 +113,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
@@ -126,8 +126,9 @@ public:
     return this->resource_identifier_;
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view credential,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     // MCP Streamable HTTP transport / Security Warning:
     // "Servers MUST validate the Origin header on all incoming connections
@@ -277,7 +278,9 @@ public:
     }
 
     request.body(
-        [this, credential = std::string{credential},
+        [this,
+         bearer = std::string{sourcemeta::core::http_parse_bearer(
+             request.header("authorization"))},
          cookies = sourcemeta::one::owned_cookies(request),
          version = negotiated_version.value()](
             sourcemeta::one::HTTPRequest &callback_request,
@@ -293,9 +296,12 @@ public:
             return;
           }
           const sourcemeta::one::RequestCookies fields{cookies};
+          // Placed again rather than captured, since the caller this action
+          // was handed points at a request that is gone by now
+          const auto deferred_caller{
+              this->caller_from({.bearer = bearer, .cookies = fields})};
           this->on_message(version, callback_request, callback_response,
-                           std::move(body),
-                           {.bearer = credential, .cookies = fields});
+                           std::move(body), deferred_caller);
         },
         [this, version = negotiated_version.value()](
             sourcemeta::one::HTTPRequest &callback_request,
@@ -314,7 +320,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }
@@ -462,8 +468,9 @@ private:
                                                   std::move(result));
   }
 
-  auto on_resources_read(const sourcemeta::core::JSON &request_json,
-                         const sourcemeta::one::Credentials &credentials) const
+  auto
+  on_resources_read(const sourcemeta::core::JSON &request_json,
+                    const sourcemeta::one::Authentication::Caller &caller) const
       -> sourcemeta::core::JSON {
     const auto &id{request_json.at("id")};
     const auto &uri{request_json.at("params").at("uri").to_string()};
@@ -512,8 +519,7 @@ private:
     }
 
     const auto resolution{this->artifact_resolve_path(
-        sourcemeta::one::VIEW_PUBLIC, credentials, uri, Tree::Schemas,
-        bundle ? "bundle" : "schema")};
+        caller, uri, Tree::Schemas, bundle ? "bundle" : "schema")};
     if (!resolution.path.has_value()) {
       return sourcemeta::core::jsonrpc_make_error(
           &id, sourcemeta::core::MCP_CODE_RESOURCE_NOT_FOUND,
@@ -539,8 +545,9 @@ private:
 
   auto on_tools_call(const sourcemeta::core::MCPProtocolVersion version,
                      const sourcemeta::core::JSON &request_json,
-                     const sourcemeta::one::Credentials &credentials,
-                     const std::string_view view) -> sourcemeta::core::JSON {
+                     const sourcemeta::one::Authentication::Caller &caller)
+      -> sourcemeta::core::JSON {
+    const auto view{caller.view()};
     const auto &id{request_json.at("id")};
     const auto &name{request_json.at("params").at("name").to_string()};
     const auto &tool_routes{this->metadata_for(view).at("toolRoutes")};
@@ -563,7 +570,7 @@ private:
     try {
       return instance->mcp(version, id,
                            arguments == nullptr ? empty_arguments : *arguments,
-                           credentials);
+                           caller);
     } catch (const std::exception &error) {
       return sourcemeta::core::mcp_make_tool_error(id, error.what());
     }
@@ -572,7 +579,8 @@ private:
   auto on_message(const sourcemeta::core::MCPProtocolVersion version,
                   sourcemeta::one::HTTPRequest &request,
                   sourcemeta::one::HTTPResponse &response, std::string &&body,
-                  const sourcemeta::one::Credentials &credentials) -> void {
+                  const sourcemeta::one::Authentication::Caller &caller)
+      -> void {
     sourcemeta::core::JSON request_json{nullptr};
     try {
       request_json = sourcemeta::core::parse_json(body);
@@ -616,7 +624,7 @@ private:
           sub_id = *parsed_id;
         }
         try {
-          auto envelope{this->process_one(version, sub, credentials)};
+          auto envelope{this->process_one(version, sub, caller)};
           if (envelope.has_value()) {
             responses.push_back(std::move(envelope).value());
           }
@@ -649,7 +657,7 @@ private:
       return;
     }
 
-    auto envelope{this->process_one(version, request_json, credentials)};
+    auto envelope{this->process_one(version, request_json, caller)};
     if (envelope.has_value()) {
       this->write_envelope(request, response, sourcemeta::core::HTTP_STATUS_OK,
                            envelope.value(), version);
@@ -669,7 +677,7 @@ private:
 
   auto process_one(const sourcemeta::core::MCPProtocolVersion version,
                    const sourcemeta::core::JSON &request_json,
-                   const sourcemeta::one::Credentials &credentials)
+                   const sourcemeta::one::Authentication::Caller &caller)
       -> std::optional<sourcemeta::core::JSON> {
     if (sourcemeta::core::jsonrpc_is_notification(request_json)) {
       return std::nullopt;
@@ -684,6 +692,7 @@ private:
     if (!sourcemeta::core::mcp_is_request_method(method)) {
       return sourcemeta::core::jsonrpc_make_error_method_not_found(*id);
     }
+    const auto view{caller.view()};
     // Schema validation enforces MCP's stricter rules on top of JSON-RPC 2.0.
     // Most notably, MCP requires `id` MUST NOT be null even though JSON-RPC
     // §4 only calls null-id "discouraged" (technically valid). Sourcemeta One
@@ -694,7 +703,6 @@ private:
     }
     // Resolved once here, since a request reaches one method and placing the
     // caller again inside each of them would repeat the reading
-    const auto view{this->dispatcher().authentication().view(credentials)};
     if (method == sourcemeta::core::MCP_METHOD_INITIALIZE) {
       return this->on_initialize(request_json, view);
     }
@@ -705,10 +713,10 @@ private:
       return this->on_resources_list(request_json, view);
     }
     if (method == sourcemeta::core::MCP_METHOD_RESOURCES_READ) {
-      return this->on_resources_read(request_json, credentials);
+      return this->on_resources_read(request_json, caller);
     }
     if (method == sourcemeta::core::MCP_METHOD_TOOLS_CALL) {
-      return this->on_tools_call(version, request_json, credentials, view);
+      return this->on_tools_call(version, request_json, caller);
     }
     if (this->metadata_for(view).defines(method)) {
       return sourcemeta::core::jsonrpc_make_success(

--- a/enterprise/unit/authentication/authentication_session_test.cc
+++ b/enterprise/unit/authentication/authentication_session_test.cc
@@ -2,21 +2,144 @@
 
 #include <sourcemeta/core/test.h>
 
-#include <array> // std::array
-#include <chrono>
-#include <cstddef>     // std::chrono::sys_seconds, std::chrono::seconds
+#include <array>       // std::array
+#include <cstddef>     // std::size_t
+#include <filesystem>  // std::filesystem::path
+#include <map>         // std::map
+#include <optional>    // std::optional
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
-static constexpr std::chrono::sys_seconds NOW{std::chrono::seconds{1000000}};
-static constexpr std::chrono::sys_seconds LATER{std::chrono::seconds{1000060}};
+// The sealed values this instance mints are its own workings rather than its
+// interface, so these reach them the only way anybody can: by starting a login
+// and handing what it produced back to the callback that reads it. That is also
+// the only way they are ever reached in service of a request.
+//
+// A value that opens carries the callback past the one gate that reads it, and
+// a value that does not is refused there. So the two answers below are what
+// every case here distinguishes, and the provider is deliberately given no
+// token endpoint, which stops the callback one step after that gate and keeps
+// every test off a network
 
-static const std::array<std::string_view, 1> SECRETS{{"session-secret"}};
+static const std::string_view INSTANCE{"https://registry.test"};
+static const std::string_view REDIRECT{
+    "https://registry.test/self/v1/auth/callback/okta"};
 
-// These cases exercise the sealed format itself, which is the same whatever a
-// value is for, so they name one purpose throughout
-static constexpr auto PURPOSE{
-    sourcemeta::one::Authentication::Purpose::Session};
+static auto test_path(const std::string &name) -> std::filesystem::path {
+  return std::filesystem::path{AUTHENTICATION_TEST_DIRECTORY} / name;
+}
+
+static auto anywhere(const std::string_view) -> bool { return true; }
+
+// A request carries cookie fields rather than bare values, so a test that
+// wants a value read has to present it the way a browser would
+static auto field(const std::string_view value) -> std::string {
+  std::string result{"sourcemeta_one_transaction="};
+  result += value;
+  return result;
+}
+
+// A provider complete enough to start a login against, which answers nothing
+// at its token endpoint. A callback that got past the seal stops there, and
+// one that did not is refused before it is ever consulted
+static auto provider() -> sourcemeta::one::Authentication::Fetcher {
+  return
+      [](sourcemeta::one::Authentication::ProviderRequest &&request)
+          -> std::optional<sourcemeta::one::Authentication::ProviderResponse> {
+        if (request.url !=
+            "https://acme.test/.well-known/openid-configuration") {
+          return std::nullopt;
+        }
+
+        return sourcemeta::one::Authentication::ProviderResponse{
+            .status = 200,
+            .body = R"JSON({
+          "issuer": "https://acme.test",
+          "authorization_endpoint": "https://acme.test/authorize",
+          "token_endpoint": "https://acme.test/token",
+          "jwks_uri": "https://acme.test/keys",
+          "response_types_supported": [ "code" ],
+          "subject_types_supported": [ "public" ],
+          "id_token_signing_alg_values_supported": [ "RS256" ]
+        })JSON",
+            .max_age = std::nullopt};
+      };
+}
+
+static const std::array<std::string_view, 1> SESSION_SECRETS{
+    {"ONE_TEST_SEAL_SECRET"}};
+static const std::array<std::string_view, 2> ROTATED_SECRETS{
+    {"ONE_TEST_SEAL_ROTATED", "ONE_TEST_SEAL_SECRET"}};
+
+static auto instance(const std::string &name,
+                     const std::span<const std::string_view> secrets)
+    -> sourcemeta::one::Authentication {
+  setenv("ONE_TEST_SEAL_SECRET", "session-secret", 1);
+  setenv("ONE_TEST_SEAL_ROTATED", "rotated-secret", 1);
+  setenv("ONE_TEST_SEAL_CLIENT", "confidential", 1);
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://acme.test",
+            .client_id = "dashboard",
+            .client_secret_variable = "ONE_TEST_SEAL_CLIENT",
+            .session_secrets = secrets}}}};
+  return sourcemeta::one::Authentication{
+      sourcemeta::one::Authentication::compile(policies, test_path(name),
+                                               anywhere),
+      provider()};
+}
+
+// What a login handed the browser: the sealed value it must bring back, and the
+// state the provider is expected to echo beside it
+struct Started {
+  std::string sealed;
+  std::string state;
+};
+
+static auto value_of(const std::string_view cookie) -> std::string {
+  const auto equals{cookie.find('=')};
+  const auto end{cookie.find(';', equals)};
+  return std::string{cookie.substr(equals + 1, end - equals - 1)};
+}
+
+static auto query_of(const std::string_view url, const std::string_view name)
+    -> std::string {
+  std::string needle{name};
+  needle += "=";
+  const auto start{url.find(needle) + needle.size()};
+  const auto end{url.find('&', start)};
+  return std::string{url.substr(start, end - start)};
+}
+
+static auto start(const sourcemeta::one::Authentication &authentication)
+    -> Started {
+  const auto outcome{
+      authentication.login("okta", INSTANCE, REDIRECT, false, "")};
+  EXPECT_EQ(outcome.result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  EXPECT_EQ(outcome.cookies.size(), 1);
+  return {.sealed = value_of(outcome.cookies.front()),
+          .state = query_of(outcome.location, "state")};
+}
+
+// Whether the callback read the value as the transaction it names. Anything it
+// cannot open is refused before the provider is consulted at all, and anything
+// it opens gets one step further, to a provider that named no token endpoint
+static auto opens(const sourcemeta::one::Authentication &authentication,
+                  const Started &started, const std::string_view sealed)
+    -> bool {
+  const auto carried{field(sealed)};
+  const std::array<std::string_view, 1> presented{{carried}};
+  const auto outcome{authentication.callback(
+      "okta", INSTANCE, REDIRECT,
+      {.state = started.state, .code = "an-authorization-code"},
+      {.cookies = presented})};
+  return outcome.result !=
+         sourcemeta::one::Authentication::Outcome::Result::Invalid;
+}
 
 // A sealed value is version.issued.expiry.payload.signature. Every field is
 // covered by the signature, so a test that disturbs the wrong one still passes
@@ -40,390 +163,226 @@ static auto field_start(const std::string_view value, const Field field)
   return position;
 }
 
-TEST(session_round_trips_a_payload) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  const auto payload{sourcemeta::one::Authentication::open_value(value, PURPOSE,
-                                                                 SECRETS, NOW)};
-  EXPECT_TRUE(payload.has_value());
-  EXPECT_EQ(payload.value(), "the-payload");
+// Change one character of one field, which is the smallest disturbance that
+// should cost a value its signature
+static auto disturb(const std::string_view value, const Field field)
+    -> std::string {
+  std::string result{value};
+  const auto position{field_start(value, field)};
+  result[position] = (result[position] == 'a' ? 'b' : 'a');
+  return result;
 }
 
-TEST(session_round_trips_an_empty_payload) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "", PURPOSE, "session-secret", NOW, LATER)};
-  const auto payload{sourcemeta::one::Authentication::open_value(value, PURPOSE,
-                                                                 SECRETS, NOW)};
-  EXPECT_TRUE(payload.has_value());
-  EXPECT_EQ(payload.value(), "");
-}
-
-TEST(session_round_trips_a_payload_containing_separators) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "left.right.{\"claims\":[1,2]}\n", PURPOSE, "session-secret", NOW,
-      LATER)};
-  const auto payload{sourcemeta::one::Authentication::open_value(value, PURPOSE,
-                                                                 SECRETS, NOW)};
-  EXPECT_TRUE(payload.has_value());
-  EXPECT_EQ(payload.value(), "left.right.{\"claims\":[1,2]}\n");
+TEST(session_round_trips_what_a_login_sealed) {
+  const auto authentication{instance("seal_roundtrip", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
 }
 
 TEST(session_value_is_cookie_safe) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "payload with spaces; and = signs", PURPOSE, "session-secret", NOW,
-      LATER)};
-  for (const auto character : value) {
-    const auto safe{(character >= 'a' && character <= 'z') ||
-                    (character >= 'A' && character <= 'Z') ||
-                    (character >= '0' && character <= '9') ||
-                    character == '.' || character == '-' || character == '_'};
-    EXPECT_TRUE(safe);
+  const auto authentication{instance("seal_cookie_safe", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  for (const auto character : started.sealed) {
+    EXPECT_TRUE(character > 0x20 && character < 0x7f && character != '"' &&
+                character != ',' && character != ';' && character != '\\');
   }
 }
 
-TEST(session_denies_at_and_after_the_expiry_instant) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  EXPECT_TRUE(
-      sourcemeta::one::Authentication::open_value(value, PURPOSE, SECRETS, NOW)
-          .has_value());
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(value, PURPOSE,
-                                                           SECRETS, LATER)
-                   .has_value());
-  const std::chrono::sys_seconds after{LATER + std::chrono::seconds{1}};
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(value, PURPOSE,
-                                                           SECRETS, after)
-                   .has_value());
-}
-
-TEST(session_denies_a_wrong_secret) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "other-secret", NOW, LATER)};
-  EXPECT_FALSE(
-      sourcemeta::one::Authentication::open_value(value, PURPOSE, SECRETS, NOW)
-          .has_value());
-}
-
-TEST(session_denies_with_no_secrets) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  const std::array<std::string_view, 0> no_secrets{};
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(value, PURPOSE,
-                                                           no_secrets, NOW)
-                   .has_value());
-}
-
-TEST(session_admits_a_value_sealed_under_an_older_secret) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "old-secret", NOW, LATER)};
-  const std::array<std::string_view, 2> rotated{{"new-secret", "old-secret"}};
-  const auto payload{sourcemeta::one::Authentication::open_value(value, PURPOSE,
-                                                                 rotated, NOW)};
-  EXPECT_TRUE(payload.has_value());
-  EXPECT_EQ(payload.value(), "the-payload");
-  const std::array<std::string_view, 1> retired{{"new-secret"}};
-  EXPECT_FALSE(
-      sourcemeta::one::Authentication::open_value(value, PURPOSE, retired, NOW)
-          .has_value());
-}
-
 TEST(session_value_has_the_shape_the_tests_below_assume) {
-  // Several tests locate a field by index, so a change to the grammar would
-  // silently move what they disturb while leaving them green. This pins the
-  // whole shape against known inputs, so such a change fails here first and
-  // names what moved
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  constexpr std::string_view prefix{"1.1000000.1000060.dGhlLXBheWxvYWQ."};
-  EXPECT_TRUE(value.starts_with(prefix));
-  // The signature is the unpadded encoding of a fixed-width digest
-  EXPECT_EQ(value.size(), prefix.size() + 43);
-}
-
-TEST(session_denies_a_tampered_payload) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  auto tampered{value};
-  const auto payload_start{field_start(tampered, Field::Payload)};
-  tampered[payload_start] = tampered[payload_start] == 'A' ? 'B' : 'A';
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(tampered, PURPOSE,
-                                                           SECRETS, NOW)
-                   .has_value());
-}
-
-TEST(session_denies_a_tampered_expiry) {
-  const auto expired{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, NOW)};
-  // Extending the lifetime of an expired value must break its signature
-  const auto expiry_start{field_start(expired, Field::Expiry)};
-  auto tampered{expired};
-  tampered.insert(expiry_start, "9");
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(tampered, PURPOSE,
-                                                           SECRETS, NOW)
-                   .has_value());
+  const auto authentication{instance("seal_shape", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  EXPECT_EQ(std::ranges::count(started.sealed, '.'), 4);
+  EXPECT_EQ(started.sealed.front(), '1');
 }
 
 TEST(session_denies_a_tampered_version) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  auto tampered{value};
-  tampered[0] = '2';
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(tampered, PURPOSE,
-                                                           SECRETS, NOW)
-                   .has_value());
-}
-
-TEST(session_denies_a_transplanted_signature) {
-  const auto first{sourcemeta::one::Authentication::seal_value(
-      "first-payload", PURPOSE, "session-secret", NOW, LATER)};
-  const auto second{sourcemeta::one::Authentication::seal_value(
-      "second-payload", PURPOSE, "session-secret", NOW, LATER)};
-  const auto first_body{first.substr(0, first.rfind('.'))};
-  const auto second_signature{second.substr(second.rfind('.') + 1)};
-  const auto spliced{first_body + "." + second_signature};
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(spliced, PURPOSE,
-                                                           SECRETS, NOW)
-                   .has_value());
-}
-
-TEST(session_denies_a_truncated_signature) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  const auto truncated{value.substr(0, value.size() - 2)};
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(truncated, PURPOSE,
-                                                           SECRETS, NOW)
-                   .has_value());
-}
-
-TEST(session_denies_a_lengthened_signature) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  const auto lengthened{value + "AA"};
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(lengthened, PURPOSE,
-                                                           SECRETS, NOW)
-                   .has_value());
-}
-
-TEST(session_denies_a_value_sealed_with_a_pre_epoch_expiry) {
-  const std::chrono::sys_seconds before_epoch{std::chrono::seconds{-1}};
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, before_epoch)};
+  const auto authentication{instance("seal_version", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  // The control is the value it was made from, which opens
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
   EXPECT_FALSE(
-      sourcemeta::one::Authentication::open_value(value, PURPOSE, SECRETS, NOW)
-          .has_value());
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   value, PURPOSE, SECRETS, before_epoch)
-                   .has_value());
-}
-
-TEST(session_denies_everything_under_a_pre_epoch_clock) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  const std::chrono::sys_seconds before_epoch{std::chrono::seconds{-1}};
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   value, PURPOSE, SECRETS, before_epoch)
-                   .has_value());
-}
-
-TEST(session_denies_malformed_values) {
-  EXPECT_FALSE(
-      sourcemeta::one::Authentication::open_value("", PURPOSE, SECRETS, NOW)
-          .has_value());
-  EXPECT_FALSE(
-      sourcemeta::one::Authentication::open_value(".", PURPOSE, SECRETS, NOW)
-          .has_value());
-  EXPECT_FALSE(
-      sourcemeta::one::Authentication::open_value("...", PURPOSE, SECRETS, NOW)
-          .has_value());
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   "no-dots-at-all", PURPOSE, SECRETS, NOW)
-                   .has_value());
-  // Too few fields to be a sealed value
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   "1.123.456.AA", PURPOSE, SECRETS, NOW)
-                   .has_value());
-  // One field too many, which lands in the signature, where a separator says
-  // the value was not produced by sealing anything
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   "1.123.456.AA.BB.CC", PURPOSE, SECRETS, NOW)
-                   .has_value());
+      opens(authentication, started, disturb(started.sealed, Field::Version)));
 }
 
 TEST(session_denies_a_tampered_issuance) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  // Moving the instant of minting backwards would stretch the lifetime a value
-  // is allowed to claim, so the signature has to cover it like everything else
-  const auto issued_start{field_start(value, Field::Issued)};
-  auto tampered{value};
-  tampered.insert(issued_start, "9");
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(tampered, PURPOSE,
-                                                           SECRETS, NOW)
-                   .has_value());
+  const auto authentication{instance("seal_issuance", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
+  EXPECT_FALSE(
+      opens(authentication, started, disturb(started.sealed, Field::Issued)));
 }
 
-TEST(session_denies_a_malformed_issuance) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  const auto issued_start{field_start(value, Field::Issued)};
-  const auto issued_end{value.find('.', issued_start)};
-
-  auto empty_issued{value};
-  empty_issued.erase(issued_start, issued_end - issued_start);
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   empty_issued, PURPOSE, SECRETS, NOW)
-                   .has_value());
-
-  auto negative_issued{value};
-  negative_issued.replace(issued_start, issued_end - issued_start, "-1");
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   negative_issued, PURPOSE, SECRETS, NOW)
-                   .has_value());
+TEST(session_denies_a_tampered_expiry) {
+  const auto authentication{instance("seal_expiry", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
+  EXPECT_FALSE(
+      opens(authentication, started, disturb(started.sealed, Field::Expiry)));
 }
 
-TEST(session_denies_a_malformed_expiry) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  const auto expiry_start{field_start(value, Field::Expiry)};
-  const auto expiry_end{value.find('.', expiry_start)};
+TEST(session_denies_a_tampered_payload) {
+  const auto authentication{instance("seal_payload", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
+  EXPECT_FALSE(
+      opens(authentication, started, disturb(started.sealed, Field::Payload)));
+}
 
-  auto empty_expiry{value};
-  empty_expiry.erase(expiry_start, expiry_end - expiry_start);
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   empty_expiry, PURPOSE, SECRETS, NOW)
-                   .has_value());
+TEST(session_denies_a_tampered_signature) {
+  const auto authentication{instance("seal_signature", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
+  EXPECT_FALSE(opens(authentication, started,
+                     disturb(started.sealed, Field::Signature)));
+}
 
-  auto textual_expiry{value};
-  textual_expiry.replace(expiry_start, expiry_end - expiry_start, "later");
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   textual_expiry, PURPOSE, SECRETS, NOW)
-                   .has_value());
+TEST(session_denies_a_truncated_signature) {
+  const auto authentication{instance("seal_truncated", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
+  EXPECT_FALSE(opens(authentication, started,
+                     started.sealed.substr(0, started.sealed.size() - 1)));
+}
 
-  auto negative_expiry{value};
-  negative_expiry.replace(expiry_start, expiry_end - expiry_start, "-1");
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   negative_expiry, PURPOSE, SECRETS, NOW)
-                   .has_value());
+TEST(session_denies_a_lengthened_signature) {
+  const auto authentication{instance("seal_lengthened", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
+  EXPECT_FALSE(opens(authentication, started, started.sealed + "a"));
+}
 
-  auto overflowing_expiry{value};
-  overflowing_expiry.replace(expiry_start, expiry_end - expiry_start,
-                             "99999999999999999999999999");
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   overflowing_expiry, PURPOSE, SECRETS, NOW)
-                   .has_value());
+TEST(session_denies_a_transplanted_signature) {
+  const auto authentication{instance("seal_transplant", SESSION_SECRETS)};
+  const auto first{start(authentication)};
+  const auto second{start(authentication)};
+
+  // Everything but the signature from one value, and the signature from
+  // another, which is what a signature covering every field has to refuse
+  std::string spliced{
+      first.sealed.substr(0, field_start(first.sealed, Field::Signature))};
+  spliced += second.sealed.substr(field_start(second.sealed, Field::Signature));
+  EXPECT_TRUE(opens(authentication, first, first.sealed));
+  EXPECT_FALSE(opens(authentication, first, spliced));
+}
+
+TEST(session_denies_malformed_values) {
+  const auto authentication{instance("seal_malformed", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
+  EXPECT_FALSE(opens(authentication, started, ""));
+  EXPECT_FALSE(opens(authentication, started, "1"));
+  EXPECT_FALSE(opens(authentication, started, "1.2.3.4"));
+  EXPECT_FALSE(opens(authentication, started, "not-a-sealed-value"));
+  EXPECT_FALSE(opens(authentication, started, "1....."));
 }
 
 TEST(session_denies_a_signature_that_is_not_base64url) {
-  const auto value{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW, LATER)};
-  const auto body{value.substr(0, value.rfind('.'))};
-  const auto invalid{body + ".!!!not-base64url!!!"};
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(invalid, PURPOSE,
-                                                           SECRETS, NOW)
-                   .has_value());
+  const auto authentication{instance("seal_base64url", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  std::string altered{
+      started.sealed.substr(0, field_start(started.sealed, Field::Signature))};
+  altered += "!!!!";
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
+  EXPECT_FALSE(opens(authentication, started, altered));
 }
 
-TEST(session_denies_a_lifetime_longer_than_any_this_system_mints) {
-  // Only the expiry used to be sealed, so a value could name any expiry it
-  // liked and be honoured until it. Sealing the instant of minting alongside
-  // it makes the lifetime a fact about the value, and one this long was not
-  // minted here whatever signature it carries
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW,
-      NOW + std::chrono::hours{25})};
-  EXPECT_FALSE(
-      sourcemeta::one::Authentication::open_value(sealed, PURPOSE, SECRETS, NOW)
-          .has_value());
+TEST(session_denies_a_wrong_secret) {
+  const auto minting{instance("seal_wrong_minting", SESSION_SECRETS)};
+  const auto started{start(minting)};
+
+  // The same policy under a different secret, so the value differs from one it
+  // would accept in exactly that
+  const auto reading{instance("seal_wrong_reading", ROTATED_SECRETS)};
+  const auto theirs{start(reading)};
+  EXPECT_TRUE(opens(reading, theirs, theirs.sealed));
+  EXPECT_FALSE(opens(reading, theirs, started.sealed));
 }
 
-TEST(session_admits_a_lifetime_at_the_bound) {
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW,
-      NOW + std::chrono::hours{24})};
-  const auto opened{sourcemeta::one::Authentication::open_value(sealed, PURPOSE,
-                                                                SECRETS, NOW)};
-  EXPECT_TRUE(opened.has_value());
-  EXPECT_EQ(opened.value(), "the-payload");
-}
+TEST(session_admits_a_value_sealed_under_an_older_secret) {
+  const auto minting{instance("seal_old", SESSION_SECRETS)};
+  const auto started{start(minting)};
 
-TEST(session_denies_a_value_issued_in_the_future) {
-  // A bounded lifetime measured from an instant that has not arrived would
-  // start whenever its holder chose, so the bound only means anything
-  // alongside this
-  const auto ahead{NOW + std::chrono::hours{12}};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", ahead,
-      ahead + std::chrono::hours{1})};
-  EXPECT_FALSE(
-      sourcemeta::one::Authentication::open_value(sealed, PURPOSE, SECRETS, NOW)
-          .has_value());
-}
-
-TEST(session_admits_a_value_issued_within_the_clock_skew) {
-  // Replicas seal for one another, so one reading slightly ahead must not mint
-  // values the rest refuse
-  const auto ahead{NOW + std::chrono::seconds{30}};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", ahead,
-      ahead + std::chrono::hours{1})};
-  EXPECT_TRUE(
-      sourcemeta::one::Authentication::open_value(sealed, PURPOSE, SECRETS, NOW)
-          .has_value());
-}
-
-TEST(session_denies_an_expiry_before_the_instant_it_was_issued) {
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      "the-payload", PURPOSE, "session-secret", NOW,
-      NOW - std::chrono::seconds{1})};
-  EXPECT_FALSE(
-      sourcemeta::one::Authentication::open_value(sealed, PURPOSE, SECRETS, NOW)
-          .has_value());
+  // The newest secret leads and the one that sealed this follows, which is what
+  // lets a secret be replaced without ending what it signed
+  const auto rotated{instance("seal_new", ROTATED_SECRETS)};
+  EXPECT_TRUE(opens(rotated, started, started.sealed));
 }
 
 TEST(session_denies_a_value_sealed_for_another_purpose) {
-  // A cookie name is chosen by whoever presents it and travels outside the
-  // signature, so the purpose picks the key instead. A login transaction
-  // presented as a session then cannot verify, whether or not anything
-  // inspects what the payload claims to be
-  const auto transaction{sourcemeta::one::Authentication::seal_value(
-      "the-payload", sourcemeta::one::Authentication::Purpose::Transaction,
-      "session-secret", NOW, LATER)};
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   transaction,
-                   sourcemeta::one::Authentication::Purpose::Session, SECRETS,
-                   NOW)
-                   .has_value());
+  const auto authentication{instance("seal_purpose", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+
+  // A session is sealed for a different purpose than a transaction, and only a
+  // transaction opens here. Anybody may obtain the value a login hands out
+  // without holding any credential, so reading one as the other is what would
+  // turn starting a login into being signed in
+  const auto carried{field(started.sealed)};
+  const std::array<std::string_view, 1> presented{{carried}};
+  const auto session{
+      authentication.logout({.cookies = presented}, INSTANCE, "/")};
+  EXPECT_EQ(session.cookies.size(), 3);
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
 }
 
-TEST(transaction_denies_a_value_sealed_as_a_session) {
-  const auto session{sourcemeta::one::Authentication::seal_value(
-      "the-payload", sourcemeta::one::Authentication::Purpose::Session,
-      "session-secret", NOW, LATER)};
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   session,
-                   sourcemeta::one::Authentication::Purpose::Transaction,
-                   SECRETS, NOW)
-                   .has_value());
+TEST(session_denies_a_value_sealed_under_another_policy_name) {
+  const auto authentication{instance("seal_policy", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
+
+  // The same value offered under a name it was not sealed for, which is what a
+  // key derived per policy has to refuse
+  const auto carried{field(started.sealed)};
+  const std::array<std::string_view, 1> presented{{carried}};
+  const auto outcome{authentication.callback(
+      "unknown", INSTANCE, REDIRECT,
+      {.state = started.state, .code = "an-authorization-code"},
+      {.cookies = presented})};
+  EXPECT_EQ(outcome.result,
+            sourcemeta::one::Authentication::Outcome::Result::Invalid);
 }
 
-TEST(each_purpose_opens_the_value_it_sealed) {
-  const auto transaction{sourcemeta::one::Authentication::seal_value(
-      "transaction-payload",
-      sourcemeta::one::Authentication::Purpose::Transaction, "session-secret",
-      NOW, LATER)};
-  const auto opened{sourcemeta::one::Authentication::open_value(
-      transaction, sourcemeta::one::Authentication::Purpose::Transaction,
-      SECRETS, NOW)};
-  EXPECT_TRUE(opened.has_value());
-  EXPECT_EQ(opened.value(), "transaction-payload");
+TEST(session_denies_a_state_the_provider_did_not_echo) {
+  const auto authentication{instance("seal_state", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
+
+  // The value opens, and is still refused, since what it sealed and what came
+  // back do not agree. That is what stops a callback assembled elsewhere
+  const auto carried{field(started.sealed)};
+  const std::array<std::string_view, 1> presented{{carried}};
+  const auto outcome{authentication.callback(
+      "okta", INSTANCE, REDIRECT,
+      {.state = "not-the-state-it-sealed", .code = "an-authorization-code"},
+      {.cookies = presented})};
+  EXPECT_EQ(outcome.result,
+            sourcemeta::one::Authentication::Outcome::Result::Invalid);
 }
 
-TEST(the_two_purposes_seal_one_payload_differently) {
-  const auto session{sourcemeta::one::Authentication::seal_value(
-      "the-payload", sourcemeta::one::Authentication::Purpose::Session,
-      "session-secret", NOW, LATER)};
-  const auto transaction{sourcemeta::one::Authentication::seal_value(
-      "the-payload", sourcemeta::one::Authentication::Purpose::Transaction,
-      "session-secret", NOW, LATER)};
-  EXPECT_FALSE(session == transaction);
+TEST(session_denies_a_callback_carrying_no_transaction) {
+  const auto authentication{instance("seal_absent", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  const auto outcome{authentication.callback(
+      "okta", INSTANCE, REDIRECT,
+      {.state = started.state, .code = "an-authorization-code"}, {})};
+  EXPECT_EQ(outcome.result,
+            sourcemeta::one::Authentication::Outcome::Result::Invalid);
+}
+
+TEST(session_reads_every_value_a_request_carried) {
+  const auto authentication{instance("seal_several", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+
+  // A parent domain and the host itself can each set one, and neither the
+  // header nor the order says which is which, so every value is tried rather
+  // than the first. Letting whoever set the other one decide would turn the
+  // cookie from a defence into the way past it
+  const auto carried{field(started.sealed)};
+  const std::array<std::string_view, 2> both{
+      {"sourcemeta_one_transaction=somebody-elses-value", carried}};
+  const auto outcome{authentication.callback(
+      "okta", INSTANCE, REDIRECT,
+      {.state = started.state, .code = "an-authorization-code"},
+      {.cookies = both})};
+  EXPECT_NE(outcome.result,
+            sourcemeta::one::Authentication::Outcome::Result::Invalid);
 }

--- a/enterprise/unit/authentication/authentication_session_test.cc
+++ b/enterprise/unit/authentication/authentication_session_test.cc
@@ -70,12 +70,17 @@ static const std::array<std::string_view, 1> SESSION_SECRETS{
     {"ONE_TEST_SEAL_SECRET"}};
 static const std::array<std::string_view, 2> ROTATED_SECRETS{
     {"ONE_TEST_SEAL_ROTATED", "ONE_TEST_SEAL_SECRET"}};
+// Shares nothing with the set a value is minted under, so a reader holding it
+// holds no secret that value was sealed with
+static const std::array<std::string_view, 1> FOREIGN_SECRETS{
+    {"ONE_TEST_SEAL_FOREIGN"}};
 
 static auto instance(const std::string &name,
                      const std::span<const std::string_view> secrets)
     -> sourcemeta::one::Authentication {
   setenv("ONE_TEST_SEAL_SECRET", "session-secret", 1);
   setenv("ONE_TEST_SEAL_ROTATED", "rotated-secret", 1);
+  setenv("ONE_TEST_SEAL_FOREIGN", "foreign-secret", 1);
   setenv("ONE_TEST_SEAL_CLIENT", "confidential", 1);
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
@@ -164,12 +169,23 @@ static auto field_start(const std::string_view value, const Field field)
 }
 
 // Change one character of one field, which is the smallest disturbance that
-// should cost a value its signature
+// should cost a value its signature.
+//
+// A digit is changed to another digit rather than to a letter, because the
+// instants are read as numbers before anything is verified: a field that
+// stopped being a number is refused for that alone, which would leave the
+// signature covering it untested and the case passing without meaning anything
 static auto disturb(const std::string_view value, const Field field)
     -> std::string {
   std::string result{value};
   const auto position{field_start(value, field)};
-  result[position] = (result[position] == 'a' ? 'b' : 'a');
+  auto &character{result[position]};
+  if (character >= '0' && character <= '9') {
+    character = (character == '9' ? '8' : static_cast<char>(character + 1));
+  } else {
+    character = (character == 'a' ? 'b' : 'a');
+  }
+
   return result;
 }
 
@@ -290,12 +306,20 @@ TEST(session_denies_a_wrong_secret) {
   const auto minting{instance("seal_wrong_minting", SESSION_SECRETS)};
   const auto started{start(minting)};
 
-  // The same policy under a different secret, so the value differs from one it
-  // would accept in exactly that
-  const auto reading{instance("seal_wrong_reading", ROTATED_SECRETS)};
+  // A reader holding no secret the value was sealed under, which is the one
+  // thing that differs. Its secret set shares nothing with the minting one, so
+  // that accepting the value could only ever mean the signature went unchecked
+  const auto reading{instance("seal_wrong_reading", FOREIGN_SECRETS)};
+
+  // Both are read against the state the reader's own login sealed, so the
+  // control and the case differ in the secret and in nothing else
   const auto theirs{start(reading)};
   EXPECT_TRUE(opens(reading, theirs, theirs.sealed));
   EXPECT_FALSE(opens(reading, theirs, started.sealed));
+
+  // And the same value opens where the secret is held, which is what shows the
+  // refusal above came from the secret rather than from anything else about it
+  EXPECT_TRUE(opens(minting, started, started.sealed));
 }
 
 TEST(session_admits_a_value_sealed_under_an_older_secret) {
@@ -306,22 +330,6 @@ TEST(session_admits_a_value_sealed_under_an_older_secret) {
   // lets a secret be replaced without ending what it signed
   const auto rotated{instance("seal_new", ROTATED_SECRETS)};
   EXPECT_TRUE(opens(rotated, started, started.sealed));
-}
-
-TEST(session_denies_a_value_sealed_for_another_purpose) {
-  const auto authentication{instance("seal_purpose", SESSION_SECRETS)};
-  const auto started{start(authentication)};
-
-  // A session is sealed for a different purpose than a transaction, and only a
-  // transaction opens here. Anybody may obtain the value a login hands out
-  // without holding any credential, so reading one as the other is what would
-  // turn starting a login into being signed in
-  const auto carried{field(started.sealed)};
-  const std::array<std::string_view, 1> presented{{carried}};
-  const auto session{
-      authentication.logout({.cookies = presented}, INSTANCE, "/")};
-  EXPECT_EQ(session.cookies.size(), 3);
-  EXPECT_TRUE(opens(authentication, started, started.sealed));
 }
 
 TEST(session_denies_a_value_sealed_under_another_policy_name) {
@@ -385,4 +393,25 @@ TEST(session_reads_every_value_a_request_carried) {
       {.cookies = both})};
   EXPECT_NE(outcome.result,
             sourcemeta::one::Authentication::Outcome::Result::Invalid);
+}
+
+// A login tells the provider where to come back to, and the transaction it
+// seals carries that. A callback naming somewhere else is completing a
+// different login, so it is refused before a code is redeemed rather than left
+// for the provider to catch on the exchange
+TEST(session_denies_a_callback_naming_another_return_address) {
+  const auto authentication{instance("seal_redirect", SESSION_SECRETS)};
+  const auto started{start(authentication)};
+  const auto carried{field(started.sealed)};
+  const std::array<std::string_view, 1> presented{{carried}};
+
+  const auto elsewhere{authentication.callback(
+      "okta", INSTANCE, "https://registry.test/somewhere/else",
+      {.state = started.state, .code = "an-authorization-code"},
+      {.cookies = presented})};
+  EXPECT_EQ(elsewhere.result,
+            sourcemeta::one::Authentication::Outcome::Result::Invalid);
+
+  // The control differs in that alone
+  EXPECT_TRUE(opens(authentication, started, started.sealed));
 }

--- a/enterprise/unit/authentication/authentication_session_test.cc
+++ b/enterprise/unit/authentication/authentication_session_test.cc
@@ -5,8 +5,8 @@
 #include <array>       // std::array
 #include <cstddef>     // std::size_t
 #include <filesystem>  // std::filesystem::path
-#include <map>         // std::map
 #include <optional>    // std::optional
+#include <span>        // std::span
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -168,18 +168,29 @@ static auto field_start(const std::string_view value, const Field field)
   return position;
 }
 
+static auto field_end(const std::string_view value, const Field field)
+    -> std::size_t {
+  const auto end{value.find('.', field_start(value, field))};
+  return end == std::string_view::npos ? value.size() : end;
+}
+
 // Change one character of one field, which is the smallest disturbance that
 // should cost a value its signature.
 //
-// A digit is changed to another digit rather than to a letter, because the
-// instants are read as numbers before anything is verified: a field that
-// stopped being a number is refused for that alone, which would leave the
-// signature covering it untested and the case passing without meaning anything
+// The two instants are read as numbers, and the interval they name is bounded
+// against the clock, before any signature is verified. So a disturbance that
+// leaves one of them unreadable, or moves one of them by the decades that its
+// leading digit is worth, is refused for naming an interval nothing could have
+// minted, and the signature covering that field goes untested while the case
+// still passes. Their last digit is the one that leaves the value as readable
+// and as temporally sound as it was, so that the signature is all that is left
+// to refuse it
 static auto disturb(const std::string_view value, const Field field)
     -> std::string {
+  const auto instant{field == Field::Issued || field == Field::Expiry};
   std::string result{value};
-  const auto position{field_start(value, field)};
-  auto &character{result[position]};
+  auto &character{result[instant ? field_end(value, field) - 1
+                                 : field_start(value, field)]};
   if (character >= '0' && character <= '9') {
     character = (character == '9' ? '8' : static_cast<char>(character + 1));
   } else {

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -5,14 +5,15 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/test.h>
 
-#include <array>       // std::array
-#include <chrono>      // std::chrono::sys_seconds, std::chrono::seconds
-#include <cstddef>     // std::byte, std::size_t
-#include <cstdint>     // std::uint32_t
-#include <cstdlib>     // setenv
-#include <cstring>     // std::memcpy
-#include <filesystem>  // std::filesystem::path
-#include <fstream>     // std::ofstream, std::fstream, std::ifstream
+#include <array>      // std::array
+#include <chrono>     // std::chrono::sys_seconds, std::chrono::seconds
+#include <cstddef>    // std::byte, std::size_t
+#include <cstdint>    // std::uint32_t
+#include <cstdlib>    // setenv
+#include <cstring>    // std::memcpy
+#include <filesystem> // std::filesystem::path
+#include <fstream>    // std::ofstream, std::fstream, std::ifstream
+#include <iostream>
 #include <iterator>    // std::istreambuf_iterator
 #include <map>         // std::map
 #include <memory>      // std::shared_ptr, std::make_shared
@@ -41,6 +42,19 @@ static auto anywhere(const std::string_view) -> bool { return true; }
 static auto fields(const std::string_view value)
     -> std::array<std::string_view, 1> {
   return {{value}};
+}
+
+// The artifact is compiled and then persisted, which the tests below do
+// together because they read it back through a file
+static auto
+save(const std::span<const sourcemeta::one::Authentication::Policy> policies,
+     const std::filesystem::path &configuration,
+     const std::filesystem::path &destination,
+     const sourcemeta::one::Authentication::PathGuard &gateable) -> void {
+  sourcemeta::one::Authentication::write(
+      sourcemeta::one::Authentication::compile(policies, configuration,
+                                               gateable),
+      destination);
 }
 
 static auto test_path(const std::string &name) -> std::filesystem::path {
@@ -200,25 +214,311 @@ static auto token_with(const std::string_view claims) -> std::string {
   return sourcemeta::core::jwt_sign(header, payload, key.value()).value();
 }
 
-// A sealed value carries the instant it was minted, and is only honoured for
-// a bounded interval after it, so these are read from the clock rather than
-// named as constants
-static auto minted_now() -> std::chrono::sys_seconds {
-  return std::chrono::time_point_cast<std::chrono::seconds>(
-      std::chrono::system_clock::now());
+// What a Set-Cookie carries, and what a URL said, which these read back out of
+// what an operation produced
+static auto cookie_value(const std::string_view cookie) -> std::string {
+  const auto equals{cookie.find('=')};
+  const auto end{cookie.find(';', equals)};
+  return std::string{cookie.substr(equals + 1, end - equals - 1)};
 }
 
-// An expiry far enough ahead to outlive any test run, and near enough to the
-// instant of minting for the value to be one this system would produce
-static auto session_expiry() -> std::chrono::sys_seconds {
-  return minted_now() + std::chrono::hours{1};
+static auto query_of(const std::string_view url, const std::string_view name)
+    -> std::string {
+  std::string needle{name};
+  needle += "=";
+  const auto start{url.find(needle) + needle.size()};
+  const auto end{url.find('&', start)};
+  return std::string{url.substr(start, end - start)};
+}
+
+// What a policy needs depends entirely on what it authenticates, and these say
+// that the ones it does not need cannot be written down. A key policy carrying
+// a key set location, or a machine policy carrying a client secret, was a
+// configuration that meant nothing and is now one that does not compile
+template <typename T>
+concept names_a_key_set = requires(T value) { value.jwks_uri; };
+template <typename T>
+concept names_an_issuer = requires(T value) { value.issuer; };
+template <typename T>
+concept names_a_client_secret =
+    requires(T value) { value.client_secret_variable; };
+template <typename T>
+concept names_keys = requires(T value) { value.keys; };
+template <typename T>
+concept names_session_secrets = requires(T value) { value.session_secrets; };
+template <typename T>
+concept names_an_audience = requires(T value) { value.audience; };
+template <typename T>
+concept names_algorithms = requires(T value) { value.algorithms; };
+
+using ApiKeyPolicy = sourcemeta::one::Authentication::Policy::ApiKey;
+using TokenPolicy = sourcemeta::one::Authentication::Policy::Token;
+using InteractivePolicy = sourcemeta::one::Authentication::Policy::Interactive;
+
+// A credential compared verbatim discovers nothing and signs nobody in
+static_assert(!names_a_key_set<ApiKeyPolicy>);
+static_assert(!names_an_issuer<ApiKeyPolicy>);
+static_assert(!names_a_client_secret<ApiKeyPolicy>);
+static_assert(!names_session_secrets<ApiKeyPolicy>);
+
+// A token is validated rather than obtained here, so nothing about obtaining
+// one belongs to it
+static_assert(!names_keys<TokenPolicy>);
+static_assert(!names_a_client_secret<TokenPolicy>);
+static_assert(!names_session_secrets<TokenPolicy>);
+
+// A person signs in, which is neither a key nor an audience this validates
+static_assert(!names_keys<InteractivePolicy>);
+static_assert(!names_an_audience<InteractivePolicy>);
+static_assert(!names_algorithms<InteractivePolicy>);
+
+// And what each does need is still there to be written
+static_assert(names_keys<ApiKeyPolicy>);
+static_assert(names_a_key_set<TokenPolicy>);
+static_assert(names_an_audience<TokenPolicy>);
+static_assert(names_session_secrets<InteractivePolicy>);
+static_assert(names_a_client_secret<InteractivePolicy>);
+
+// A provider a case has control of, and what it says. Everything this module
+// reaches goes through one function, so a case configures what the provider
+// advertises and answers with, and then reads what was made of it. Nothing
+// here reaches a network
+struct Provider {
+  std::string_view issuer{"https://provider.test"};
+  // Members spliced into the discovery document, beyond the ones every valid
+  // one carries
+  std::string advertises{};
+  // What the UserInfo endpoint answers, empty where the provider offers none
+  std::string userinfo{};
+  // The identity token the exchange returns, put here once a login has said
+  // what nonce it must carry
+  std::shared_ptr<std::string> identity{std::make_shared<std::string>()};
+  // Whether the token request carried the client secret in a header, which is
+  // how a case reads the way it travelled
+  std::shared_ptr<bool> secret_in_header{std::make_shared<bool>(false)};
+  std::shared_ptr<int> discoveries{std::make_shared<int>(0)};
+  // A provider that answers nothing at all, which is one that cannot be reached
+  bool reachable{true};
+
+  [[nodiscard]] auto fetcher() const
+      -> sourcemeta::one::Authentication::Fetcher {
+    return [issuer = std::string{this->issuer}, advertises = this->advertises,
+            userinfo = this->userinfo, identity = this->identity,
+            secret_in_header = this->secret_in_header,
+            discoveries = this->discoveries, reachable = this->reachable](
+               sourcemeta::one::Authentication::ProviderRequest &&request)
+               -> std::optional<
+                   sourcemeta::one::Authentication::ProviderResponse> {
+      if (!reachable) {
+        return std::nullopt;
+      }
+
+      if (request.url == issuer + "/.well-known/openid-configuration") {
+        *discoveries += 1;
+        std::string document{"{"};
+        document += R"("issuer": ")" + issuer + R"(",)";
+        document +=
+            R"("authorization_endpoint": ")" + issuer + R"(/authorize",)";
+        document += R"("token_endpoint": ")" + issuer + R"(/token",)";
+        document += R"("jwks_uri": ")" + issuer + R"(/keys",)";
+        if (!userinfo.empty()) {
+          document += R"("userinfo_endpoint": ")" + issuer + R"(/userinfo",)";
+        }
+
+        if (!advertises.empty()) {
+          document += advertises;
+          document += ",";
+        }
+
+        document += R"("response_types_supported": [ "code" ],)";
+        document += R"("subject_types_supported": [ "public" ],)";
+        document +=
+            R"("id_token_signing_alg_values_supported": [ "RS256", "ES256" ])";
+        document += "}";
+        return sourcemeta::one::Authentication::ProviderResponse{
+            .status = 200, .body = document};
+      }
+
+      if (request.url == issuer + "/keys") {
+        return sourcemeta::one::Authentication::ProviderResponse{
+            .status = 200, .body = std::string{CLAIMS_KEYS}};
+      }
+
+      if (request.url == issuer + "/token") {
+        *secret_in_header = !request.authorization.empty();
+        auto body{sourcemeta::core::JSON::make_object()};
+        body.assign("id_token", sourcemeta::core::JSON{*identity});
+        body.assign("access_token", sourcemeta::core::JSON{"an-access-token"});
+        body.assign("token_type", sourcemeta::core::JSON{"Bearer"});
+        std::ostringstream serialized;
+        sourcemeta::core::stringify(body, serialized);
+        return sourcemeta::one::Authentication::ProviderResponse{
+            .status = 200, .body = serialized.str()};
+      }
+
+      if (request.url == issuer + "/userinfo" && !userinfo.empty()) {
+        return sourcemeta::one::Authentication::ProviderResponse{
+            .status = 200, .body = userinfo};
+      }
+
+      return std::nullopt;
+    };
+  }
+};
+
+static constexpr std::string_view INSTANCE_URL{"https://registry.test"};
+static constexpr std::string_view REDIRECT_URI{
+    "https://registry.test/self/v1/auth/callback/okta"};
+
+// Start a login and complete it, with the identity token carrying whatever a
+// case says the provider asserted about the person. A login that does not get
+// as far as a redirect is returned as it is, since that is the answer a case
+// asking about one wants
+static auto sign_in(const sourcemeta::one::Authentication &authentication,
+                    const Provider &provider, const std::string_view policy,
+                    const std::string_view client_id,
+                    const std::string_view asserted)
+    -> sourcemeta::one::Authentication::Outcome {
+  auto started{
+      authentication.login(policy, INSTANCE_URL, REDIRECT_URI, false, "")};
+  if (started.result !=
+      sourcemeta::one::Authentication::Outcome::Result::Redirect) {
+    return started;
+  }
+
+  auto payload{sourcemeta::core::parse_json(asserted)};
+  payload.assign("iss", sourcemeta::core::JSON{std::string{provider.issuer}});
+  payload.assign("aud", sourcemeta::core::JSON{std::string{client_id}});
+  payload.assign("exp", sourcemeta::core::JSON{2000000000});
+  payload.assign("iat", sourcemeta::core::JSON{1700000000});
+  payload.assign("nonce",
+                 sourcemeta::core::JSON{query_of(started.location, "nonce")});
+  const auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(CLAIMS_PRIVATE_KEY))};
+  auto header{sourcemeta::core::JSON::make_object()};
+  header.assign("alg", sourcemeta::core::JSON{"ES256"});
+  *provider.identity =
+      sourcemeta::core::jwt_sign(header, payload, key.value()).value();
+
+  const auto carried{"sourcemeta_one_transaction=" +
+                     cookie_value(started.cookies.front())};
+  const std::array<std::string_view, 1> presented{{carried}};
+  return authentication.callback(
+      policy, INSTANCE_URL, REDIRECT_URI,
+      {.state = query_of(started.location, "state"), .code = "a-code"},
+      {.cookies = presented});
+}
+
+// Whether any of what an operation reported names this, which is how a case
+// reads a reason that never reaches a response
+static auto reported(const sourcemeta::one::Authentication::Outcome &outcome,
+                     const std::string_view fragment) -> bool {
+  return std::ranges::any_of(
+      outcome.log, [fragment](const std::string &message) -> bool {
+        return message.find(fragment) != std::string::npos;
+      });
+}
+
+// A session obtained the only way anybody obtains one: by starting a login and
+// completing it against a provider that answers. The gate cases below are about
+// what a session opens rather than about how one is got, so they take it from
+// here and go on to say what they mean.
+//
+// The provider is a stub and the identity token is signed with the key its key
+// set publishes, so nothing here reaches a network
+static auto session_for(const std::string_view policy_name,
+                        const std::span<const std::string_view> secrets,
+                        const std::string_view subject) -> std::string {
+  setenv("ONE_TEST_SIGN_IN_CLIENT", "confidential", 1);
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = policy_name,
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://signin.test",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_SIGN_IN_CLIENT",
+            .session_secrets = secrets}}}};
+
+  // The identity token has to name the nonce the login just minted, so it is
+  // signed once that is known and left here for the exchange to answer with
+  const auto identity{std::make_shared<std::string>()};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(policies, test_path("sign_in"),
+                                               anywhere),
+      [identity](sourcemeta::one::Authentication::ProviderRequest &&request)
+          -> std::optional<sourcemeta::one::Authentication::ProviderResponse> {
+        if (request.url ==
+            "https://signin.test/.well-known/openid-configuration") {
+          return sourcemeta::one::Authentication::ProviderResponse{
+              .status = 200, .body = R"JSON({
+                "issuer": "https://signin.test",
+                "authorization_endpoint": "https://signin.test/authorize",
+                "token_endpoint": "https://signin.test/token",
+                "jwks_uri": "https://signin.test/keys",
+                "response_types_supported": [ "code" ],
+                "subject_types_supported": [ "public" ],
+                "id_token_signing_alg_values_supported": [ "RS256", "ES256" ]
+              })JSON"};
+        }
+
+        if (request.url == "https://signin.test/keys") {
+          return sourcemeta::one::Authentication::ProviderResponse{
+              .status = 200, .body = std::string{CLAIMS_KEYS}};
+        }
+
+        if (request.url == "https://signin.test/token") {
+          auto body{sourcemeta::core::JSON::make_object()};
+          body.assign("id_token", sourcemeta::core::JSON{*identity});
+          body.assign("access_token",
+                      sourcemeta::core::JSON{"an-access-token"});
+          body.assign("token_type", sourcemeta::core::JSON{"Bearer"});
+          std::ostringstream text;
+          sourcemeta::core::stringify(body, text);
+          return sourcemeta::one::Authentication::ProviderResponse{
+              .status = 200, .body = text.str()};
+        }
+
+        return std::nullopt;
+      }};
+
+  const std::string_view instance_url{"https://registry.test"};
+  const std::string_view redirect{"https://registry.test/callback"};
+  const auto started{
+      authentication.login(policy_name, instance_url, redirect, false, "")};
+  EXPECT_EQ(started.result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+
+  auto payload{sourcemeta::core::JSON::make_object()};
+  payload.assign("iss", sourcemeta::core::JSON{"https://signin.test"});
+  payload.assign("aud", sourcemeta::core::JSON{"client"});
+  payload.assign("sub", sourcemeta::core::JSON{std::string{subject}});
+  payload.assign("exp", sourcemeta::core::JSON{2000000000});
+  payload.assign("iat", sourcemeta::core::JSON{1700000000});
+  payload.assign("nonce",
+                 sourcemeta::core::JSON{query_of(started.location, "nonce")});
+  const auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(CLAIMS_PRIVATE_KEY))};
+  auto header{sourcemeta::core::JSON::make_object()};
+  header.assign("alg", sourcemeta::core::JSON{"ES256"});
+  *identity = sourcemeta::core::jwt_sign(header, payload, key.value()).value();
+
+  const auto carried{"sourcemeta_one_transaction=" +
+                     cookie_value(started.cookies.front())};
+  const std::array<std::string_view, 1> presented{{carried}};
+  const auto completed{authentication.callback(
+      policy_name, instance_url, redirect,
+      {.state = query_of(started.location, "state"), .code = "a-code"},
+      {.cookies = presented})};
+  EXPECT_EQ(completed.result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  return cookie_value(completed.cookies.front());
 }
 
 // An interactive policy names the environment variable holding the secret
 // that signs its session and transaction cookies, so the tests set that
 // variable and mint cookies under its value
 static constexpr const char *SESSION_SECRET_VARIABLE{"ONE_TEST_SESSION_SECRET"};
-static constexpr std::string_view SESSION_SECRET{"session-secret"};
 
 // An interactive policy names one variable per secret it accepts, newest
 // first, so each set of policies points at the variables it needs
@@ -228,44 +528,44 @@ static constexpr std::array<std::string_view, 1> SESSION_SECRETS_UNUSED{
     {"ONE_TEST_OIDC_SESSION_UNUSED"}};
 static constexpr std::array<std::string_view, 1> SESSION_SECRETS_BLANK{
     {"ONE_TEST_OIDC_BLANK_SECRET"}};
-static constexpr std::array<std::string_view, 1> SESSION_SECRETS_OPEN{
-    {"ONE_TEST_OIDC_OPEN_SECRET"}};
 static constexpr std::array<std::string_view, 2> SESSION_SECRETS_ROTATED{
     {"ONE_TEST_OIDC_ROTATED_SECRET", "ONE_TEST_OIDC_ROTATED_SECRET_OLD"}};
-static constexpr std::array<std::string_view, 1> SESSION_SECRETS_SEAL_NONE{
-    {"ONE_TEST_OIDC_SEAL_NONE_SECRET"}};
-static constexpr std::array<std::string_view, 1> SESSION_SECRETS_SEAL_OTHER{
-    {"ONE_TEST_OIDC_SEAL_OTHER"}};
 static constexpr std::array<std::string_view, 1> SESSION_SECRETS_UNSET{
     {"ONE_TEST_OIDC_UNSET_SECRET"}};
 
+// Every outbound call this module makes goes through one function, so a test
+// answers them all from a map and nothing here reaches a network
 static auto stub_fetcher(std::map<std::string, std::string> responses,
                          std::shared_ptr<int> calls)
-    -> sourcemeta::core::JWKSProvider::Fetcher {
-  return [responses = std::move(responses),
-          calls = std::move(calls)](const std::string_view url)
-             -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
-    if (calls != nullptr) {
-      *calls += 1;
-    }
+    -> sourcemeta::one::Authentication::Fetcher {
+  return
+      [responses = std::move(responses), calls = std::move(calls)](
+          sourcemeta::one::Authentication::ProviderRequest &&request)
+          -> std::optional<sourcemeta::one::Authentication::ProviderResponse> {
+        if (calls != nullptr) {
+          *calls += 1;
+        }
 
-    const auto match{responses.find(std::string{url})};
-    if (match == responses.cend()) {
-      return std::nullopt;
-    }
+        const auto match{responses.find(std::string{request.url})};
+        if (match == responses.cend()) {
+          return std::nullopt;
+        }
 
-    return sourcemeta::core::JWKSProvider::FetchResult{.body = match->second,
-                                                       .max_age = std::nullopt};
-  };
+        return sourcemeta::one::Authentication::ProviderResponse{
+            .status = 200, .body = match->second, .max_age = std::nullopt};
+      };
 }
 
 TEST(missing_artifact_denies_everything) {
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"},
       stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits(at("/"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(authentication.admits(at("/acme/foo"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(authentication.admits(at(""), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.permits(at("/"), authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/acme/foo"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(
+      authentication.permits(at(""), authentication.caller({.bearer = ""})));
 }
 
 TEST(malformed_artifact_denies_everything) {
@@ -277,8 +577,10 @@ TEST(malformed_artifact_denies_everything) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits(at("/"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(authentication.admits(at("/acme/foo"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.permits(at("/"), authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/acme/foo"),
+                                      authentication.caller({.bearer = ""})));
 }
 
 TEST(structurally_corrupt_artifact_denies_everything) {
@@ -296,9 +598,10 @@ TEST(structurally_corrupt_artifact_denies_everything) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits(at("/"), {.bearer = ""}).allowed);
   EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
+      authentication.permits(at("/"), authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/internal/foo"),
+                                      authentication.caller({.bearer = ""})));
 }
 
 TEST(artifact_exceeding_the_policy_ceiling_denies_everything) {
@@ -319,17 +622,22 @@ TEST(artifact_exceeding_the_policy_ceiling_denies_everything) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits(at("/"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(authentication.admits(at("/acme/foo"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.permits(at("/"), authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/acme/foo"),
+                                      authentication.caller({.bearer = ""})));
 }
 
 TEST(corrupted_section_offset_denies_everything) {
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_OFFSET"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("corrupted_offset.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   // Overwrite the node section offset with a value that aliases the header
   std::fstream stream{path, std::ios::binary | std::ios::in | std::ios::out};
@@ -340,22 +648,25 @@ TEST(corrupted_section_offset_denies_everything) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
+  EXPECT_FALSE(authentication.permits(at("/internal/foo"),
+                                      authentication.caller({.bearer = ""})));
   EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(authentication.admits(at("/"), {.bearer = ""}).allowed);
+      authentication.permits(at("/"), authentication.caller({.bearer = ""})));
 }
 
 TEST(zero_policies_admits_every_path) {
   const std::array<sourcemeta::one::Authentication::Policy, 0> policies{};
   const auto path{test_path("zero_policies.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(authentication.admits(at("/"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication.admits(at(""), {.bearer = ""}).allowed);
   EXPECT_TRUE(
-      authentication.admits(at("/acme/foo/bar"), {.bearer = ""}).allowed);
+      authentication.permits(at("/"), authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(
+      authentication.permits(at(""), authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(at("/acme/foo/bar"),
+                                     authentication.caller({.bearer = ""})));
   EXPECT_EQ(authentication.governing(at("/")), (std::vector<std::size_t>{}));
   EXPECT_EQ(authentication.governing(at("/acme")),
             (std::vector<std::size_t>{}));
@@ -366,46 +677,57 @@ TEST(uncovered_paths_are_public_around_a_gated_scope) {
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_SCOPE"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("uncovered_public.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The covered subtree is gated
-  EXPECT_FALSE(authentication.admits(at("/internal"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication.admits(at("/internal"), {.bearer = "scope-secret"})
-                  .allowed);
-  EXPECT_TRUE(
-      authentication.admits(at("/internal/foo"), {.bearer = "scope-secret"})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(at("/internal"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/internal/foo"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(
+      at("/internal"), authentication.caller({.bearer = "scope-secret"})));
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "scope-secret"})));
   // Everything outside it is public
-  EXPECT_TRUE(authentication.admits(at("/"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication.admits(at("/vendor"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication.admits(at("/vendor/foo"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(
+      authentication.permits(at("/"), authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(at("/vendor"),
+                                     authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(at("/vendor/foo"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(scope_matches_whole_segments_only) {
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_SEGMENT"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("segment_boundary.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The scope gates its own segment
-  EXPECT_FALSE(authentication.admits(at("/internal"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(at("/internal"),
+                                      authentication.caller({.bearer = ""})));
   // A textual prefix that is not a whole segment is a different path, so it is
   // uncovered and public
-  EXPECT_TRUE(
-      authentication.admits(at("/internalish"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication.admits(at("/int"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(
-      authentication.admits(at("/internal-team"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/internalish"),
+                                     authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(at("/int"),
+                                     authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(at("/internal-team"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(distinct_policies_each_gate_their_scope) {
@@ -416,20 +738,33 @@ TEST(distinct_policies_each_gate_their_scope) {
   const std::array<std::string_view, 1> beta_keys{{"ONE_TEST_KEY_DB"}};
   const std::array<std::string_view, 1> gamma_keys{{"ONE_TEST_KEY_DG"}};
   const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
-      {{.paths = alpha, .keys = alpha_keys, .name = "alpha"},
-       {.paths = beta, .keys = beta_keys, .name = "beta"},
-       {.paths = gamma, .keys = gamma_keys, .name = "gamma"}}};
+      {{.paths = alpha,
+        .name = "alpha",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys =
+                                                                alpha_keys}},
+       {.paths = beta,
+        .name = "beta",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = beta_keys}},
+       {.paths = gamma,
+        .name = "gamma",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = gamma_keys}}}};
   const auto path{test_path("distinct_policies.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits(at("/alpha/one"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(authentication.admits(at("/beta/two"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/gamma/three"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(at("/alpha/one"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/beta/two"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/gamma/three"),
+                                      authentication.caller({.bearer = ""})));
   // Between the scopes the registry is public
-  EXPECT_TRUE(authentication.admits(at("/delta"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/delta"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(nested_prefixes_gate_their_subtrees) {
@@ -438,23 +773,32 @@ TEST(nested_prefixes_gate_their_subtrees) {
   const std::array<std::string_view, 1> internal_keys{{"ONE_TEST_KEY_NI"}};
   const std::array<std::string_view, 1> secret_keys{{"ONE_TEST_KEY_NS"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = internal, .keys = internal_keys, .name = "internal"},
-       {.paths = secret, .keys = secret_keys, .name = "secret"}}};
+      {{.paths = internal,
+        .name = "internal",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys =
+                                                                internal_keys}},
+       {.paths = secret,
+        .name = "secret",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = secret_keys}}}};
   const auto path{test_path("nested_prefixes.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits(at("/internal"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/other"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/secret"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/secret/deep"), {.bearer = ""})
-          .allowed);
-  EXPECT_TRUE(authentication.admits(at("/"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication.admits(at("/public"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(at("/internal"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/internal/other"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/internal/secret"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/internal/secret/deep"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(
+      authentication.permits(at("/"), authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(at("/public"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(nested_inner_key_widens_access) {
@@ -465,44 +809,51 @@ TEST(nested_inner_key_widens_access) {
   const std::array<std::string_view, 1> outer_keys{{"ONE_TEST_KEY_WO"}};
   const std::array<std::string_view, 1> inner_keys{{"ONE_TEST_KEY_WI"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = outer, .keys = outer_keys, .name = "outer"},
-       {.paths = inner, .keys = inner_keys, .name = "inner"}}};
+      {{.paths = outer,
+        .name = "outer",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys =
+                                                                outer_keys}},
+       {.paths = inner,
+        .name = "inner",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = inner_keys}}}};
   const auto path{test_path("nested_widen.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The inner path is covered by both, so either key admits it
-  EXPECT_TRUE(
-      authentication.admits(at("/internal/secret"), {.bearer = "wo-secret"})
-          .allowed);
-  EXPECT_TRUE(
-      authentication.admits(at("/internal/secret"), {.bearer = "wi-secret"})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/secret"), authentication.caller({.bearer = "wo-secret"})));
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/secret"), authentication.caller({.bearer = "wi-secret"})));
   // The outer path is covered only by the outer policy
-  EXPECT_TRUE(
-      authentication.admits(at("/internal/other"), {.bearer = "wo-secret"})
-          .allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/other"), {.bearer = "wi-secret"})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/other"), authentication.caller({.bearer = "wo-secret"})));
+  EXPECT_FALSE(authentication.permits(
+      at("/internal/other"), authentication.caller({.bearer = "wi-secret"})));
 }
 
 TEST(single_policy_with_multiple_prefixes) {
   const std::array<std::string_view, 2> paths{{"/internal", "/vendor"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_MP"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("multiple_prefixes.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/vendor/bar"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication.admits(at("/public"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(at("/internal/foo"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/vendor/bar"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(at("/public"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(extensionless_policy_gates_every_representation) {
@@ -510,42 +861,41 @@ TEST(extensionless_policy_gates_every_representation) {
   const std::array<std::string_view, 1> paths{{"/secret/data"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_REPRESENTATION"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("representation_agnostic.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The resource, every representation of it, and its subtree are all governed
-  EXPECT_FALSE(
-      authentication.admits(at("/secret/data"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/secret/data.json"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/secret/data.xml"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/secret/data/nested"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/secret/data"), {.bearer = "representation-secret"})
-          .allowed);
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/secret/data.json"), {.bearer = "representation-secret"})
-          .allowed);
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/secret/data.xml"), {.bearer = "representation-secret"})
-          .allowed);
-  EXPECT_TRUE(authentication
-                  .admits(at("/secret/data/nested"),
-                          {.bearer = "representation-secret"})
-                  .allowed);
+  EXPECT_FALSE(authentication.permits(at("/secret/data"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/secret/data.json"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/secret/data.xml"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/secret/data/nested"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(
+      at("/secret/data"),
+      authentication.caller({.bearer = "representation-secret"})));
+  EXPECT_TRUE(authentication.permits(
+      at("/secret/data.json"),
+      authentication.caller({.bearer = "representation-secret"})));
+  EXPECT_TRUE(authentication.permits(
+      at("/secret/data.xml"),
+      authentication.caller({.bearer = "representation-secret"})));
+  EXPECT_TRUE(authentication.permits(
+      at("/secret/data/nested"),
+      authentication.caller({.bearer = "representation-secret"})));
   // A sibling sharing a textual prefix is covered by no policy, so it is public
-  EXPECT_TRUE(
-      authentication.admits(at("/secret/database"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(
-      authentication.admits(at("/secret/data2.json"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/secret/database"),
+                                     authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(at("/secret/data2.json"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(extension_specific_policy_gates_only_that_representation) {
@@ -553,50 +903,57 @@ TEST(extension_specific_policy_gates_only_that_representation) {
   const std::array<std::string_view, 1> paths{{"/secret/data.json"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_SPECIFIC"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("representation_specific.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // Only the named representation is gated
-  EXPECT_FALSE(
-      authentication.admits(at("/secret/data.json"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/secret/data.json"), {.bearer = "specific-secret"})
-          .allowed);
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/secret/data.json/nested"), {.bearer = "specific-secret"})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(at("/secret/data.json"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(
+      at("/secret/data.json"),
+      authentication.caller({.bearer = "specific-secret"})));
+  EXPECT_TRUE(authentication.permits(
+      at("/secret/data.json/nested"),
+      authentication.caller({.bearer = "specific-secret"})));
   // The bare resource and other representations are uncovered, so public
-  EXPECT_TRUE(
-      authentication.admits(at("/secret/data"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(
-      authentication.admits(at("/secret/data.xml"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/secret/data"),
+                                     authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(at("/secret/data.xml"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(extension_handling_is_confined_to_the_terminal_segment) {
   const std::array<std::string_view, 1> paths{{"/v1"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_V1"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("intermediate_dot.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The policy on /v1 gates its own subtree
-  EXPECT_FALSE(authentication.admits(at("/v1"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(authentication.admits(at("/v1/secret"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(
+      authentication.permits(at("/v1"), authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/v1/secret"),
+                                      authentication.caller({.bearer = ""})));
   // As a terminal segment, /v1.0 is a representation of /v1 under the
   // content-negotiation rule, the same way /person.json represents /person
-  EXPECT_FALSE(authentication.admits(at("/v1.0"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(at("/v1.0"),
+                                      authentication.caller({.bearer = ""})));
   // But as an intermediate segment it is a distinct directory that does not
   // descend into the /v1 subtree, so its children are uncovered and public
-  EXPECT_TRUE(
-      authentication.admits(at("/v1.0/secret"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/v1.0/secret"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(an_explicit_route_is_gated_on_the_target_as_it_arrived) {
@@ -604,30 +961,30 @@ TEST(an_explicit_route_is_gated_on_the_target_as_it_arrived) {
   const std::array<std::string_view, 1> apikey_paths{{"/private"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_ROUTE"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = apikey_paths, .keys = keys, .name = "policy"}}};
+      {{.paths = apikey_paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("explicit_route.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication
-          .admits_route("/private/secret", {.bearer = "", .cookies = {}})
-          .allowed);
-  EXPECT_TRUE(authentication
-                  .admits_route("/private/secret",
-                                {.bearer = "route-secret", .cookies = {}})
-                  .allowed);
+  EXPECT_FALSE(authentication.permits(
+      sourcemeta::one::RouteTarget{"/private/secret"},
+      authentication.caller({.bearer = "", .cookies = {}})));
+  EXPECT_TRUE(authentication.permits(
+      sourcemeta::one::RouteTarget{"/private/secret"},
+      authentication.caller({.bearer = "route-secret", .cookies = {}})));
 
   // A target covered by no policy is admitted, including one whose spelling
   // only resembles a governed prefix
-  EXPECT_TRUE(authentication
-                  .admits_route("/public/string", {.bearer = "", .cookies = {}})
-                  .allowed);
-  EXPECT_TRUE(
-      authentication
-          .admits_route("/privateextra/secret", {.bearer = "", .cookies = {}})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      sourcemeta::one::RouteTarget{"/public/string"},
+      authentication.caller({.bearer = "", .cookies = {}})));
+  EXPECT_TRUE(authentication.permits(
+      sourcemeta::one::RouteTarget{"/privateextra/secret"},
+      authentication.caller({.bearer = "", .cookies = {}})));
 }
 
 TEST(apikey_admits_matching_credential) {
@@ -635,19 +992,21 @@ TEST(apikey_admits_matching_credential) {
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_MATCH"}};
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("apikey_match.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(
-      authentication.admits(at("/internal/foo"), {.bearer = "secret-match"})
-          .allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = "wrong"}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "secret-match"})));
+  EXPECT_FALSE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "wrong"})));
+  EXPECT_FALSE(authentication.permits(at("/internal/foo"),
+                                      authentication.caller({.bearer = ""})));
 }
 
 TEST(apikey_with_multiple_keys_admits_any) {
@@ -657,35 +1016,40 @@ TEST(apikey_with_multiple_keys_admits_any) {
       {"ONE_TEST_KEY_MULTI_A", "ONE_TEST_KEY_MULTI_B"}};
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("apikey_multi.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(
-      authentication.admits(at("/internal/foo"), {.bearer = "key-a"}).allowed);
-  EXPECT_TRUE(
-      authentication.admits(at("/internal/foo"), {.bearer = "key-b"}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = "key-c"}).allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "key-a"})));
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "key-b"})));
+  EXPECT_FALSE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "key-c"})));
 }
 
 TEST(apikey_with_unset_variable_denies) {
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_UNSET"}};
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("apikey_unset.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = "anything"})
-          .allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "anything"})));
+  EXPECT_FALSE(authentication.permits(at("/internal/foo"),
+                                      authentication.caller({.bearer = ""})));
 }
 
 TEST(apikey_with_an_empty_variable_denies) {
@@ -693,19 +1057,21 @@ TEST(apikey_with_an_empty_variable_denies) {
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_EMPTY"}};
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("apikey_empty.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // A variable an operator meant to hold a key but left blank gates the path
   // exactly as an unset one does, rather than opening it to everyone
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = "anything"})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(at("/internal/foo"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "anything"})));
 }
 
 TEST(apikey_ignores_an_empty_variable_beside_a_real_one) {
@@ -715,21 +1081,23 @@ TEST(apikey_ignores_an_empty_variable_beside_a_real_one) {
       {"ONE_TEST_KEY_PAIR_BLANK", "ONE_TEST_KEY_PAIR_REAL"}};
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("apikey_pair.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The blank one neither admits anybody nor keeps the key beside it from
   // working
-  EXPECT_TRUE(
-      authentication.admits(at("/internal/foo"), {.bearer = "pair-secret"})
-          .allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/internal/foo"), {.bearer = "wrong"}).allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "pair-secret"})));
+  EXPECT_FALSE(authentication.permits(at("/internal/foo"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "wrong"})));
 }
 
 TEST(sha256_policy_with_an_empty_variable_denies) {
@@ -738,23 +1106,23 @@ TEST(sha256_policy_with_an_empty_variable_denies) {
   const std::array<std::string_view, 1> paths{{"/secret"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .keys = keys,
-        .algorithm = sourcemeta::one::Authentication::Algorithm::Sha256,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = keys,
+            .algorithm = sourcemeta::one::Authentication::Algorithm::Sha256}}}};
   const auto path{test_path("sha256_empty.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/secret/foo"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/secret/foo"), {.bearer = "anything"}).allowed);
+  EXPECT_FALSE(authentication.permits(at("/secret/foo"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(
+      at("/secret/foo"), authentication.caller({.bearer = "anything"})));
   // Nor does the digest of nothing, which is what an empty credential hashes to
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/secret/foo"), {.bearer = sourcemeta::core::sha256("")})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secret/foo"),
+      authentication.caller({.bearer = sourcemeta::core::sha256("")})));
 }
 
 TEST(sha256_policy_admits_the_matching_credential) {
@@ -764,25 +1132,25 @@ TEST(sha256_policy_admits_the_matching_credential) {
   const std::array<std::string_view, 1> paths{{"/secret"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .keys = keys,
-        .algorithm = sourcemeta::one::Authentication::Algorithm::Sha256,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = keys,
+            .algorithm = sourcemeta::one::Authentication::Algorithm::Sha256}}}};
   const auto path{test_path("sha256_match.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(
-      authentication.admits(at("/secret/foo"), {.bearer = raw}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/secret/foo"), {.bearer = "wrong"}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/secret/foo"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/secret/foo"),
+                                     authentication.caller({.bearer = raw})));
+  EXPECT_FALSE(authentication.permits(
+      at("/secret/foo"), authentication.caller({.bearer = "wrong"})));
+  EXPECT_FALSE(authentication.permits(at("/secret/foo"),
+                                      authentication.caller({.bearer = ""})));
   // Presenting the stored hash itself does not authenticate
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/secret/foo"), {.bearer = sourcemeta::core::sha256(raw)})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secret/foo"),
+      authentication.caller({.bearer = sourcemeta::core::sha256(raw)})));
 }
 
 TEST(mixed_algorithms_admit_either_key_with_identity_first) {
@@ -794,25 +1162,30 @@ TEST(mixed_algorithms_admit_either_key_with_identity_first) {
   const std::array<std::string_view, 1> sha256_keys{{"ONE_TEST_KEY_MIXA_SHA"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = paths,
-        .keys = identity_keys,
-        .algorithm = sourcemeta::one::Authentication::Algorithm::Identity,
-        .name = "identity"},
+        .name = "identity",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{
+                .keys = identity_keys,
+                .algorithm =
+                    sourcemeta::one::Authentication::Algorithm::Identity}},
        {.paths = paths,
-        .keys = sha256_keys,
-        .algorithm = sourcemeta::one::Authentication::Algorithm::Sha256,
-        .name = "hashed"}}};
+        .name = "hashed",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = sha256_keys,
+            .algorithm = sourcemeta::one::Authentication::Algorithm::Sha256}}}};
   const auto path{test_path("mixed_identity_first.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // Either key type opens the path regardless of declaration order. The sha256
   // key must work even though the identity policy is checked first and fails
-  EXPECT_TRUE(
-      authentication.admits(at("/mixed/x"), {.bearer = "plain-a"}).allowed);
-  EXPECT_TRUE(authentication.admits(at("/mixed/x"), {.bearer = raw}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/mixed/x"), {.bearer = "neither"}).allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/mixed/x"), authentication.caller({.bearer = "plain-a"})));
+  EXPECT_TRUE(authentication.permits(at("/mixed/x"),
+                                     authentication.caller({.bearer = raw})));
+  EXPECT_FALSE(authentication.permits(
+      at("/mixed/x"), authentication.caller({.bearer = "neither"})));
 }
 
 TEST(mixed_algorithms_admit_either_key_with_sha256_first) {
@@ -824,24 +1197,30 @@ TEST(mixed_algorithms_admit_either_key_with_sha256_first) {
   const std::array<std::string_view, 1> sha256_keys{{"ONE_TEST_KEY_MIXB_SHA"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = paths,
-        .keys = sha256_keys,
-        .algorithm = sourcemeta::one::Authentication::Algorithm::Sha256,
-        .name = "hashed"},
+        .name = "hashed",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{
+                .keys = sha256_keys,
+                .algorithm =
+                    sourcemeta::one::Authentication::Algorithm::Sha256}},
        {.paths = paths,
-        .keys = identity_keys,
-        .algorithm = sourcemeta::one::Authentication::Algorithm::Identity,
-        .name = "identity"}}};
+        .name = "identity",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = identity_keys,
+            .algorithm =
+                sourcemeta::one::Authentication::Algorithm::Identity}}}};
   const auto path{test_path("mixed_sha256_first.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The identity key must work even though the sha256 policy is checked first
-  EXPECT_TRUE(authentication.admits(at("/mixed/x"), {.bearer = raw}).allowed);
-  EXPECT_TRUE(
-      authentication.admits(at("/mixed/x"), {.bearer = "plain-b"}).allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/mixed/x"), {.bearer = "neither"}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/mixed/x"),
+                                     authentication.caller({.bearer = raw})));
+  EXPECT_TRUE(authentication.permits(
+      at("/mixed/x"), authentication.caller({.bearer = "plain-b"})));
+  EXPECT_FALSE(authentication.permits(
+      at("/mixed/x"), authentication.caller({.bearer = "neither"})));
 }
 
 TEST(supports_the_maximum_number_of_policies) {
@@ -869,19 +1248,23 @@ TEST(supports_the_maximum_number_of_policies) {
   for (std::size_t index{0}; index < maximum; index += 1) {
     policies.push_back(
         {.paths = std::span<const std::string_view>{&path_views[index], 1},
-         .name = name_storage[index]});
+         .name = name_storage[index],
+         .credential = sourcemeta::one::Authentication::Policy::ApiKey{}});
   }
 
   const auto path{test_path("maximum_policies.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // The keyless policies gate their scope with no key that can open it
-  EXPECT_FALSE(authentication.admits(at("/p0/foo"), {.bearer = ""}).allowed);
-  EXPECT_FALSE(authentication.admits(at("/p63/foo"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(at("/p0/foo"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_FALSE(authentication.permits(at("/p63/foo"),
+                                      authentication.caller({.bearer = ""})));
   // An uncovered path is public
-  EXPECT_TRUE(authentication.admits(at("/missing"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/missing"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(governing_returns_policy_indices_in_declaration_order) {
@@ -890,10 +1273,16 @@ TEST(governing_returns_policy_indices_in_declaration_order) {
   const std::array<std::string_view, 1> root_keys{{"ONE_TEST_KEY_GR"}};
   const std::array<std::string_view, 1> internal_keys{{"ONE_TEST_KEY_GI"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = root_paths, .keys = root_keys, .name = "root"},
-       {.paths = internal_paths, .keys = internal_keys, .name = "internal"}}};
+      {{.paths = root_paths,
+        .name = "root",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = root_keys}},
+       {.paths = internal_paths,
+        .name = "internal",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = internal_keys}}}};
   const auto path{test_path("governing.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -910,9 +1299,12 @@ TEST(governing_of_an_ungoverned_path_is_empty) {
   const std::array<std::string_view, 1> internal_paths{{"/internal"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_GE"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = internal_paths, .keys = keys, .name = "policy"}}};
+      {{.paths = internal_paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("governing_empty.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -938,9 +1330,12 @@ TEST(reference_to_a_public_schema_is_permitted) {
   const std::array<std::string_view, 1> secret_paths{{"/secret"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_REF_PUBLIC"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = secret_paths, .keys = keys, .name = "policy"}}};
+      {{.paths = secret_paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("ref_to_public.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -954,9 +1349,12 @@ TEST(public_schema_referencing_an_apikey_schema_is_rejected) {
   const std::array<std::string_view, 1> secret_paths{{"/secret"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_REF_LEAK"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = secret_paths, .keys = keys, .name = "policy"}}};
+      {{.paths = secret_paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("ref_public_to_apikey.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -968,9 +1366,12 @@ TEST(reference_within_the_same_policy_is_permitted) {
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_REF_SAME"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("ref_same_policy.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -986,10 +1387,17 @@ TEST(reference_across_disjoint_policies_is_rejected) {
   const std::array<std::string_view, 1> alpha_keys{{"ONE_TEST_REF_ALPHA"}};
   const std::array<std::string_view, 1> beta_keys{{"ONE_TEST_REF_BETA"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = alpha_paths, .keys = alpha_keys, .name = "alpha"},
-       {.paths = beta_paths, .keys = beta_keys, .name = "beta"}}};
+      {{.paths = alpha_paths,
+        .name = "alpha",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys =
+                                                                alpha_keys}},
+       {.paths = beta_paths,
+        .name = "beta",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = beta_keys}}}};
   const auto path{test_path("ref_disjoint.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -1005,10 +1413,17 @@ TEST(reference_from_a_narrower_to_a_wider_audience_is_permitted) {
   const std::array<std::string_view, 1> broad_keys{{"ONE_TEST_REF_BROAD"}};
   const std::array<std::string_view, 1> nested_keys{{"ONE_TEST_REF_NESTED"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = broad_paths, .keys = broad_keys, .name = "broad"},
-       {.paths = nested_paths, .keys = nested_keys, .name = "nested"}}};
+      {{.paths = broad_paths,
+        .name = "broad",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys =
+                                                                broad_keys}},
+       {.paths = nested_paths,
+        .name = "nested",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = nested_keys}}}};
   const auto path{test_path("ref_narrow_to_wide.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -1024,27 +1439,28 @@ TEST(jwt_admits_a_valid_token_and_caches_the_key_set) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_valid.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const auto calls{std::make_shared<int>(0)};
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          calls)};
-  EXPECT_TRUE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
-  EXPECT_FALSE(authentication.admits(at("/secure/x"), {.bearer = "not-a-token"})
-                   .allowed);
-  EXPECT_FALSE(authentication.admits(at("/secure/x"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = "not-a-token"})));
+  EXPECT_FALSE(authentication.permits(at("/secure/x"),
+                                      authentication.caller({.bearer = ""})));
   // A second valid request reuses the cached key set rather than refetching
-  EXPECT_TRUE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
   EXPECT_EQ(*calls, 1);
 }
 
@@ -1054,21 +1470,21 @@ TEST(jwt_admits_a_token_whose_type_the_policy_requires) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .token_type = "at+jwt",
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .token_type = "at+jwt"}}}};
   const auto path{test_path("jwt_type_match.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
-  EXPECT_TRUE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
 
 TEST(jwt_denies_a_token_whose_type_is_not_the_required_one) {
@@ -1080,21 +1496,21 @@ TEST(jwt_denies_a_token_whose_type_is_not_the_required_one) {
   // that audience the type is the only thing telling the two apart
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .token_type = "JWT",
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .token_type = "JWT"}}}};
   const auto path{test_path("jwt_type_mismatch.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
 
 TEST(jwt_without_a_required_type_admits_any_type) {
@@ -1105,20 +1521,20 @@ TEST(jwt_without_a_required_type_admits_any_type) {
   // so a policy that names no type keeps working against one
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_type_absent.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
-  EXPECT_TRUE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
 
 TEST(jwt_denies_a_token_for_the_wrong_audience) {
@@ -1127,20 +1543,20 @@ TEST(jwt_denies_a_token_for_the_wrong_audience) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "different",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "different",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_audience.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
 
 TEST(jwt_denies_a_token_from_the_wrong_issuer) {
@@ -1149,20 +1565,20 @@ TEST(jwt_denies_a_token_from_the_wrong_issuer) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "different",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "different",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_issuer.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
 
 TEST(jwt_denies_a_disallowed_algorithm) {
@@ -1171,20 +1587,20 @@ TEST(jwt_denies_a_disallowed_algorithm) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_algorithm.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
 
 TEST(jwt_denies_when_the_signing_key_is_absent) {
@@ -1193,21 +1609,21 @@ TEST(jwt_denies_when_the_signing_key_is_absent) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_unknown_key.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path,
       stub_fetcher({{"https://idp.test/jwks", std::string{UNRELATED_KEYS}}},
                    nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
 
 TEST(jwt_denies_when_the_key_set_cannot_be_fetched) {
@@ -1216,19 +1632,19 @@ TEST(jwt_denies_when_the_key_set_cannot_be_fetched) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_fetch_fails.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
 
 TEST(an_apikey_credential_never_triggers_a_jwt_fetch) {
@@ -1237,23 +1653,23 @@ TEST(an_apikey_credential_never_triggers_a_jwt_fetch) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_no_fetch.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const auto calls{std::make_shared<int>(0)};
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          calls)};
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = "static-api-key"})
-          .allowed);
-  EXPECT_FALSE(authentication.admits(at("/secure/x"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = "static-api-key"})));
+  EXPECT_FALSE(authentication.permits(at("/secure/x"),
+                                      authentication.caller({.bearer = ""})));
   EXPECT_EQ(*calls, 0);
 }
 
@@ -1264,13 +1680,13 @@ TEST(jwt_resolves_the_key_set_through_discovery) {
   // No key set location is pinned, so it is discovered from the issuer
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://acme.test",
-        .audience = "client",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://acme.test",
+            .audience = "client",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_discovery.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const auto calls{std::make_shared<int>(0)};
   const sourcemeta::one::Authentication authentication{
@@ -1287,8 +1703,8 @@ TEST(jwt_resolves_the_key_set_through_discovery) {
   // Both the provider metadata and the key set it names are retrieved, and
   // the token then fails only on its issuer claim, which names a different
   // issuer than the policy trusts
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
   EXPECT_EQ(*calls, 2);
 }
 
@@ -1300,13 +1716,13 @@ TEST(jwt_without_a_discoverable_issuer_fails_closed) {
   // pinned key set location there is nowhere trustworthy to discover one
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_discovery_issuer.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
   const auto calls{std::make_shared<int>(0)};
   const sourcemeta::one::Authentication authentication{
       path,
@@ -1315,8 +1731,8 @@ TEST(jwt_without_a_discoverable_issuer_fails_closed) {
             R"JSON({ "issuer": "acme", "jwks_uri": "https://acme.test/keys" })JSON"},
            {"https://acme.test/keys", std::string{SIGNED_KEYS}}},
           calls)};
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
   EXPECT_EQ(*calls, 0);
 }
 
@@ -1327,449 +1743,496 @@ TEST(mixed_apikey_and_jwt_policies_admit_either_credential) {
   const std::array<sourcemeta::core::JWSAlgorithm, 1> algorithms{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = paths, .keys = keys, .name = "policy-0"},
+      {{.paths = paths,
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}},
        {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_mixed.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
   // The static key opens the path
-  EXPECT_TRUE(authentication.admits(at("/both/x"), {.bearer = "static-secret"})
-                  .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/both/x"), authentication.caller({.bearer = "static-secret"})));
   // The token opens the path
-  EXPECT_TRUE(
-      authentication.admits(at("/both/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/both/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
   // Neither a wrong key nor a wrong token opens it
-  EXPECT_FALSE(
-      authentication.admits(at("/both/x"), {.bearer = "wrong"}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/both/x"), authentication.caller({.bearer = "wrong"})));
 }
 
-TEST(oidc_identity_without_rules_admits_whoever_signs_in) {
-  setenv("ONE_TEST_OIDC_ADMIT_OPEN", "confidential", 1);
+// A policy naming no rule admits whoever its provider vouched for, so signing
+// in is the whole of it
+TEST(a_policy_naming_no_rule_admits_whoever_signs_in) {
+  setenv("ONE_TEST_ADMIT_OPEN", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_ADMIT_OPEN",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_admit_open.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_ADMIT_OPEN",
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  const auto anybody{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2"
-  })JSON")};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_admit_open"), anywhere),
+      provider.fetcher()};
 
-  EXPECT_EQ(authentication.admits_identity("okta", anybody),
-            sourcemeta::one::Authentication::Admission::Admitted);
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2" })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "somebody-else" })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
 }
 
-TEST(oidc_identity_missing_a_claim_is_incomplete_rather_than_refused) {
-  setenv("ONE_TEST_OIDC_ADMIT_PARTIAL", "confidential", 1);
+// A claim that never arrived is a question the provider may still answer at its
+// UserInfo endpoint, which is where a scope's claims land by default under this
+// flow. A claim that arrived and fell short is an answer already given, so
+// asking anywhere else would only repeat it.
+//
+// Whether asking again could still change the answer is exactly what tells the
+// two apart, so that is what these say: the same provider answers the missing
+// claim at UserInfo, and only the one that had not been answered is admitted
+TEST(a_claim_that_never_arrived_is_asked_for_rather_than_refused) {
+  setenv("ONE_TEST_ADMIT_PARTIAL", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
+  provider.userinfo = R"JSON({ "sub": "a1b2", "groups": [ "platform" ] })JSON";
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .claims = CLAIMS_ONE_GROUP,
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_ADMIT_PARTIAL",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_admit_partial.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_ADMIT_PARTIAL",
+            .claims = CLAIMS_ONE_GROUP,
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  using Admission = sourcemeta::one::Authentication::Admission;
-  const auto no_group{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2"
-  })JSON")};
-  const auto another_group{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "groups": [ "support" ]
-  })JSON")};
-  const auto the_group{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "groups": [ "platform" ]
-  })JSON")};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_admit_partial"), anywhere),
+      provider.fetcher()};
 
-  // A claim that never arrived is a question the provider may still answer at
-  // its UserInfo endpoint, which is where a scope's claims land by default
-  EXPECT_EQ(authentication.admits_identity("okta", no_group),
-            Admission::Incomplete);
-  // A claim that arrived and fell short is an answer already given, so asking
-  // anywhere else would only repeat it
-  EXPECT_EQ(authentication.admits_identity("okta", another_group),
-            Admission::Refused);
-  EXPECT_EQ(authentication.admits_identity("okta", the_group),
-            Admission::Admitted);
+  // It never arrived, so UserInfo is asked and answers
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2" })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+
+  // It arrived and fell short, so nothing is asked and the answer stands, even
+  // though the very same UserInfo answer would have satisfied the rule
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "groups": [ "support" ] })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
+
+  // And what the token carried on its own is enough where it satisfies the rule
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "groups": [ "platform" ] })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
 }
 
-TEST(oidc_identity_refused_by_one_rule_is_refused_whatever_another_wants) {
-  setenv("ONE_TEST_OIDC_ADMIT_BOTH", "confidential", 1);
+// The same claim, with a provider that answers nothing at its UserInfo
+// endpoint, which is what shows the admission above came from asking
+TEST(a_claim_that_never_arrived_and_is_nowhere_to_ask_refuses) {
+  setenv("ONE_TEST_ADMIT_NO_USERINFO", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
   const std::array<std::string_view, 1> paths{{"/portal"}};
-  const std::array<std::string_view, 1> domains{{"acme.test"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .claims = CLAIMS_ONE_GROUP,
-        .email_domains = domains,
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_ADMIT_BOTH",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_admit_both.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_ADMIT_NO_USERINFO",
+            .claims = CLAIMS_ONE_GROUP,
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  using Admission = sourcemeta::one::Authentication::Admission;
-  const auto foreign_address{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@other.test",
-    "email_verified": true
-  })JSON")};
-  const auto unvouched_address{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@acme.test",
-    "email_verified": false,
-    "groups": [ "platform" ]
-  })JSON")};
-  const auto neither_half{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2"
-  })JSON")};
-  const auto both_halves{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@acme.test",
-    "email_verified": true,
-    "groups": [ "platform" ]
-  })JSON")};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_admit_no_userinfo"), anywhere),
+      provider.fetcher()};
 
-  // The address settles it, so the absent group changes nothing
-  EXPECT_EQ(authentication.admits_identity("okta", foreign_address),
-            Admission::Refused);
-  // An address the provider will not vouch for is an answer, not a gap
-  EXPECT_EQ(authentication.admits_identity("okta", unvouched_address),
-            Admission::Refused);
-  // Neither half having arrived leaves both worth asking about
-  EXPECT_EQ(authentication.admits_identity("okta", neither_half),
-            Admission::Incomplete);
-  EXPECT_EQ(authentication.admits_identity("okta", both_halves),
-            Admission::Admitted);
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2" })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "groups": [ "platform" ] })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
 }
 
-TEST(oidc_identity_refuses_an_unvouched_address_whose_companion_is_absent) {
-  setenv("ONE_TEST_OIDC_ADMIT_UNVOUCHED", "confidential", 1);
+// Rules are cumulative, so one that refuses settles it whatever another would
+// have allowed
+TEST(a_rule_that_refuses_settles_it_whatever_another_wants) {
+  setenv("ONE_TEST_ADMIT_BOTH", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
+  provider.userinfo =
+      R"JSON({ "sub": "a1b2", "groups": [ "platform" ], "email": "jane@acme.test", "email_verified": true })JSON";
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<std::string_view, 1> domains{{"acme.test"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .email_domains = domains,
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_ADMIT_UNVOUCHED",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_admit_unvouched.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_ADMIT_BOTH",
+            .claims = CLAIMS_ONE_GROUP,
+            .email_domains = domains,
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  using Admission = sourcemeta::one::Authentication::Admission;
-  const auto declined_to_vouch{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email_verified": false
-  })JSON")};
-  const auto not_an_address{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": 42
-  })JSON")};
-  const auto nothing_at_all{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2"
-  })JSON")};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_admit_both"), anywhere),
+      provider.fetcher()};
 
-  // The provider saying it will not vouch is an answer, so the address that
-  // never arrived cannot turn it into a question worth asking again
-  EXPECT_EQ(authentication.admits_identity("okta", declined_to_vouch),
-            Admission::Refused);
+  // Both hold, which is the control
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "groups": [ "platform" ],
+                       "email": "jane@acme.test", "email_verified": true })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+
+  // The group falls short, and no address can make up for it
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "groups": [ "support" ],
+                       "email": "jane@acme.test", "email_verified": true })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
+
+  // The address is somewhere else, and no group can make up for that
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "groups": [ "platform" ],
+                       "email": "jane@elsewhere.test", "email_verified": true })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
+}
+
+// A domain rule reads an address and the assertion that it was verified, which
+// OpenID Connect Core Section 5.1 has speak for the address delivered with it
+// and no other. A provider saying it will not vouch is an answer, so it settles
+// the matter, while absence alone is what leaves the question open
+TEST(an_address_the_provider_will_not_vouch_for_is_refused) {
+  setenv("ONE_TEST_ADMIT_UNVOUCHED", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
+  provider.userinfo =
+      R"JSON({ "sub": "a1b2", "email": "jane@acme.test", "email_verified": true })JSON";
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<std::string_view, 1> domains{{"acme.test"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_ADMIT_UNVOUCHED",
+            .email_domains = domains,
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_admit_unvouched"), anywhere),
+      provider.fetcher()};
+
+  // The provider declined to vouch, which is an answer, so asking again cannot
+  // change it even though UserInfo would have vouched
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "email": "jane@acme.test",
+                             "email_verified": false })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
+
   // An address that is not one settles it the same way
-  EXPECT_EQ(authentication.admits_identity("okta", not_an_address),
-            Admission::Refused);
-  // Absence alone is what leaves the question open
-  EXPECT_EQ(authentication.admits_identity("okta", nothing_at_all),
-            Admission::Incomplete);
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "email": 42 })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
+
+  // Absence alone leaves the question open, so it is asked and answered
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2" })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
 }
 
-TEST(combining_two_answers_fills_gaps_without_overruling_the_token) {
-  const auto token{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "groups": [ "platform" ],
-    "department": "engineering"
-  })JSON")};
-  const auto extra{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "department": "sales",
-    "cost_centre": "R&D"
-  })JSON")};
+// The token wins wherever both answers speak, since it arrives signed and
+// verified while a UserInfo response is protected only by the transport that
+// carried it. So the second fills gaps rather than overruling a signature
+TEST(a_second_answer_fills_gaps_without_overruling_the_token) {
+  setenv("ONE_TEST_COMBINE_TOKEN", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
+  provider.userinfo = R"JSON({ "sub": "a1b2", "groups": [ "platform" ] })JSON";
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_COMBINE_TOKEN",
+            .claims = CLAIMS_ONE_GROUP,
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_combine_token"), anywhere),
+      provider.fetcher()};
 
-  const auto expected{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "groups": [ "platform" ],
-    "department": "engineering",
-    "cost_centre": "R&D"
-  })JSON")};
+  // The token said something else about the very claim UserInfo would satisfy,
+  // and the token is what stands
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "groups": [ "support" ] })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
 
-  // What only the second answer carried is added, and what the signed one
-  // already said stands
-  EXPECT_EQ(sourcemeta::one::Authentication::combine_claims(token, extra),
-            expected);
+  // Where the token said nothing, the gap is filled
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2" })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
 }
 
-TEST(combining_two_answers_keeps_an_address_with_its_own_assertion) {
-  // A token vouching for an address it never carried says nothing about the
-  // one a second answer supplies
-  const auto orphan{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email_verified": true
-  })JSON")};
-  const auto supplied{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@acme.test"
-  })JSON")};
-  const auto without_the_assertion{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@acme.test"
-  })JSON")};
+// An address and the assertion that it was verified travel as a pair, from
+// whichever answer carried the address. OpenID Connect Core Section 5.1 has
+// `email_verified` speak for the `email` delivered alongside it and no other,
+// so letting one answer's assertion vouch for the other answer's address would
+// admit an address the provider never verified
+// An address and the assertion that it was verified travel as a pair, from
+// whichever answer carried the address. OpenID Connect Core Section 5.1 has
+// `email_verified` speak for the `email` delivered alongside it and no other,
+// so letting one answer's assertion vouch for the other answer's address would
+// admit an address the provider never verified
+TEST(an_address_arrives_with_its_own_assertion_or_not_at_all) {
+  setenv("ONE_TEST_COMBINE_PAIR", "confidential", 1);
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<std::string_view, 1> domains{{"acme.test"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://provider.test",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_COMBINE_PAIR",
+            .email_domains = domains,
+            .session_secrets = SESSION_SECRETS}}}};
 
-  EXPECT_EQ(sourcemeta::one::Authentication::combine_claims(orphan, supplied),
-            without_the_assertion);
+  // The token vouches for an address it never carried, and the second answer
+  // supplies one without an assertion. Neither half may vouch for the other
+  Provider orphaned;
+  orphaned.userinfo = R"JSON({ "sub": "a1b2", "email": "jane@acme.test" })JSON";
+  const sourcemeta::one::Authentication unvouched{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("combine_pair"), anywhere),
+      orphaned.fetcher()};
+  EXPECT_EQ(sign_in(unvouched, orphaned, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "email_verified": true })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
 
-  // The pair arrives whole from the answer that carried the address
-  const auto pair{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@acme.test",
-    "email_verified": true
-  })JSON")};
-  const auto with_the_pair{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@acme.test",
-    "email_verified": true
-  })JSON")};
-
-  EXPECT_EQ(sourcemeta::one::Authentication::combine_claims(orphan, pair),
-            with_the_pair);
-
-  // A token carrying the address keeps its own assertion, so a second answer
-  // cannot vouch for it either
-  const auto unverified{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@acme.test"
-  })JSON")};
-  const auto vouching{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "someone@acme.test",
-    "email_verified": true
-  })JSON")};
-  const auto keeping_its_own{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@acme.test"
-  })JSON")};
-
-  EXPECT_EQ(
-      sourcemeta::one::Authentication::combine_claims(unverified, vouching),
-      keeping_its_own);
-
-  // An assertion arriving on its own from the second answer is dropped for
-  // the same reason as one left behind by the first
-  const auto nothing_to_vouch_for{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email_verified": true
-  })JSON")};
-  const auto neither_half{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2"
-  })JSON")};
-
-  EXPECT_EQ(sourcemeta::one::Authentication::combine_claims(
-                neither_half, nothing_to_vouch_for),
-            neither_half);
-
-  // An address without an assertion still arrives, since it claims nothing
-  const auto address_alone{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@acme.test"
-  })JSON")};
-  const auto carried_over{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@acme.test"
-  })JSON")};
-
-  EXPECT_EQ(sourcemeta::one::Authentication::combine_claims(neither_half,
-                                                            address_alone),
-            carried_over);
+  // The control differs in one thing: the pair arrives whole from the answer
+  // that carried the address
+  Provider whole;
+  whole.userinfo = R"JSON({ "sub": "a1b2", "email": "jane@acme.test",
+                            "email_verified": true })JSON";
+  const sourcemeta::one::Authentication vouched{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("combine_whole"), anywhere),
+      whole.fetcher()};
+  EXPECT_EQ(sign_in(vouched, whole, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "email_verified": true })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
 }
 
 TEST(admitting_reads_two_answers_only_once_they_are_combined) {
-  setenv("ONE_TEST_OIDC_ADMIT_SPLIT", "confidential", 1);
+  setenv("ONE_TEST_ADMIT_SPLIT", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
+  provider.userinfo =
+      R"JSON({ "sub": "a1b2", "email": "jane@acme.test", "email_verified": true })JSON";
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<std::string_view, 1> domains{{"acme.test"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .claims = CLAIMS_ONE_GROUP,
-        .email_domains = domains,
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_ADMIT_SPLIT",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_admit_split.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_ADMIT_SPLIT",
+            .claims = CLAIMS_ONE_GROUP,
+            .email_domains = domains,
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  using Admission = sourcemeta::one::Authentication::Admission;
-  const auto token{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "groups": [ "platform" ]
-  })JSON")};
-  const auto extra{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "email": "jane@acme.test",
-    "email_verified": true
-  })JSON")};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_admit_split"), anywhere),
+      provider.fetcher()};
 
-  // Either answer alone leaves a rule unanswered
-  EXPECT_EQ(authentication.admits_identity("okta", token),
-            Admission::Incomplete);
-  EXPECT_EQ(authentication.admits_identity("okta", extra),
-            Admission::Incomplete);
-  // Only what combining them produces admits, so a combine dropping either
-  // side is caught here rather than passing on a payload the test built
-  EXPECT_EQ(authentication.admits_identity(
-                "okta",
-                sourcemeta::one::Authentication::combine_claims(token, extra)),
-            Admission::Admitted);
+  // The token carries the group and UserInfo carries the address, so only the
+  // two together satisfy both rules
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "groups": [ "platform" ] })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+
+  // The same second answer cannot supply the group, so what the token carried
+  // is what decided that half
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2", "groups": [ "support" ] })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
 }
 
-TEST(oidc_identity_names_a_claim_the_provider_answers_with_objects) {
-  setenv("ONE_TEST_OIDC_SHAPE", "confidential", 1);
+// A rule compared against a claim carrying objects is compared on the `value`
+// sub-attribute alone, which RFC 9068 gives group, role and entitlement claims
+// by way of RFC 7643. So a rule naming what a person sees rather than what
+// identifies them matches nothing, and a refusal cannot show that: the token it
+// concerns is sealed inside a cookie where an operator cannot look. It is said
+// in the log instead, which is the only place it can be said
+TEST(a_claim_answered_with_objects_is_named_where_an_operator_looks) {
+  setenv("ONE_TEST_SHAPE_OBJECTS", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .claims = CLAIMS_ONE_GROUP,
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_SHAPE",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_shape.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .name = "shapes",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_SHAPE_OBJECTS",
+            .claims = CLAIMS_ONE_GROUP,
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  const auto objects{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "groups": [ { "value": "g-1", "display": "platform" } ]
-  })JSON")};
-  const auto strings{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "groups": [ "platform" ]
-  })JSON")};
-  const auto absent{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2"
-  })JSON")};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("shape_objects"), anywhere),
+      provider.fetcher()};
 
-  // The rule compares an identifier, so a rule naming what a person sees
-  // matches nothing, and that is what an operator has no other way to learn
-  EXPECT_EQ(authentication.object_shaped_claims("okta", objects),
-            (std::vector<std::string_view>{"groups"}));
-  // Nothing to say where a claim arrived in the shape a rule names
-  EXPECT_EQ(authentication.object_shaped_claims("okta", strings),
-            (std::vector<std::string_view>{}));
-  // Nor where it never arrived, which is a different problem with its own word
-  EXPECT_EQ(authentication.object_shaped_claims("okta", absent),
-            (std::vector<std::string_view>{}));
-  // A claim no rule names is nobody's business here
-  const auto elsewhere{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "groups": [ "platform" ],
-    "roles": [ { "value": "r-1" } ]
-  })JSON")};
-  EXPECT_EQ(authentication.object_shaped_claims("okta", elsewhere),
-            (std::vector<std::string_view>{}));
-  // And a policy that names no rule has nothing to report about
-  EXPECT_EQ(authentication.object_shaped_claims("nowhere", objects),
-            (std::vector<std::string_view>{}));
+  const auto objects{sign_in(authentication, provider, "shapes", "client",
+                             R"JSON({ "sub": "a1b2",
+               "groups": [ { "value": "g-1", "display": "platform" } ] })JSON")};
+  EXPECT_EQ(objects.result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
+  EXPECT_TRUE(reported(objects, "groups"));
+  // Nothing about it reaches the person
+  EXPECT_TRUE(objects.cookies.empty());
 }
 
-TEST(oidc_identity_says_nothing_about_the_shape_of_a_scope) {
-  setenv("ONE_TEST_OIDC_SHAPE_SCOPE", "confidential", 1);
+// The same rule, answered in the shape it names, says nothing at all. This
+// names a policy of its own because what is said is said once per claim and
+// policy however often somebody signs in
+TEST(a_claim_answered_in_the_shape_a_rule_names_says_nothing) {
+  setenv("ONE_TEST_SHAPE_STRINGS", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .claims = CLAIMS_SCOPE,
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_SHAPE_SCOPE",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_shape_scope.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .name = "strings",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_SHAPE_STRINGS",
+            .claims = CLAIMS_ONE_GROUP,
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  const auto objects{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2",
-    "scope": [ { "value": "registry:read" } ]
-  })JSON")};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("shape_strings"), anywhere),
+      provider.fetcher()};
 
-  // A scope is read whole rather than member by member, so one arriving as
-  // anything else is refused outright, and naming an identifier here would
-  // point an operator at a mistake they did not make
-  EXPECT_EQ(authentication.object_shaped_claims("okta", objects),
-            (std::vector<std::string_view>{}));
+  // It matched, so there is nothing to explain
+  const auto matched{sign_in(authentication, provider, "strings", "client",
+                             R"JSON({ "sub": "a1b2",
+                                      "groups": [ "platform" ] })JSON")};
+  EXPECT_EQ(matched.result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  EXPECT_FALSE(reported(matched, "groups"));
+
+  // It fell short in the shape the rule names, which is an ordinary refusal
+  // rather than a mistake worth naming
+  const auto fell_short{sign_in(authentication, provider, "strings", "client",
+                                R"JSON({ "sub": "a1b2",
+                                         "groups": [ "support" ] })JSON")};
+  EXPECT_EQ(fell_short.result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
+  EXPECT_FALSE(reported(fell_short, "objects"));
 }
 
-TEST(oidc_identity_under_an_unknown_policy_is_refused) {
-  setenv("ONE_TEST_OIDC_ADMIT_UNKNOWN", "confidential", 1);
+// A rule on `scope` is never named that way. That claim is read as one
+// space-delimited string rather than compared member by member, so one arriving
+// as anything else is refused outright, and calling it an identifier mismatch
+// would describe a mistake nobody made
+TEST(a_scope_arriving_as_objects_is_refused_without_being_named) {
+  setenv("ONE_TEST_SHAPE_SCOPE", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_ADMIT_UNKNOWN",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_admit_unknown.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .name = "scopes",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_SHAPE_SCOPE",
+            .claims = CLAIMS_SCOPE,
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  // A name no interactive policy answers to could never have minted a session
-  const auto somebody{sourcemeta::core::parse_json(R"JSON({
-    "sub": "a1b2"
-  })JSON")};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("shape_scope"), anywhere),
+      provider.fetcher()};
 
-  EXPECT_EQ(authentication.admits_identity("nowhere", somebody),
-            sourcemeta::one::Authentication::Admission::Refused);
+  const auto objects{sign_in(
+      authentication, provider, "scopes", "client",
+      R"JSON({ "sub": "a1b2", "scope": [ { "value": "registry:read" } ] })JSON")};
+  EXPECT_EQ(objects.result,
+            sourcemeta::one::Authentication::Outcome::Result::NotAdmitted);
+  EXPECT_FALSE(reported(objects, "scope"));
+}
+
+TEST(a_callback_under_a_name_this_instance_does_not_serve_is_refused) {
+  setenv("ONE_TEST_ADMIT_UNKNOWN", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_ADMIT_UNKNOWN",
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_admit_unknown"), anywhere),
+      provider.fetcher()};
+
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2" })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  EXPECT_EQ(sign_in(authentication, provider, "nowhere", "client",
+                    R"JSON({ "sub": "a1b2" })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Missing);
 }
 
 TEST(oidc_policy_admits_no_presented_credential) {
@@ -1777,14 +2240,14 @@ TEST(oidc_policy_admits_no_presented_credential) {
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_DENY",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_DENY",
+            .session_secrets = SESSION_SECRETS_UNUSED}}}};
   const auto path{test_path("oidc_deny.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   // The provider is reachable and would verify the token, yet no presented
   // credential opens the path, not even one the equivalent token policy
@@ -1797,20 +2260,17 @@ TEST(oidc_policy_admits_no_presented_credential) {
                     {"https://acme.test/keys", std::string{SIGNED_KEYS}}},
                    calls)};
 
-  const auto empty_verdict{
-      authentication.admits(at("/portal/x"), {.bearer = ""})};
-  EXPECT_FALSE(empty_verdict.allowed);
-  EXPECT_FALSE(empty_verdict.principal.has_value());
+  const auto empty_permitted{authentication.permits(
+      at("/portal/x"), authentication.caller({.bearer = ""}))};
+  EXPECT_FALSE(empty_permitted);
 
-  const auto secret_verdict{
-      authentication.admits(at("/portal/x"), {.bearer = "confidential"})};
-  EXPECT_FALSE(secret_verdict.allowed);
-  EXPECT_FALSE(secret_verdict.principal.has_value());
+  const auto secret_permitted{authentication.permits(
+      at("/portal/x"), authentication.caller({.bearer = "confidential"}))};
+  EXPECT_FALSE(secret_permitted);
 
-  const auto token_verdict{
-      authentication.admits(at("/portal/x"), {.bearer = SIGNED_TOKEN})};
-  EXPECT_FALSE(token_verdict.allowed);
-  EXPECT_FALSE(token_verdict.principal.has_value());
+  const auto token_permitted{authentication.permits(
+      at("/portal/x"), authentication.caller({.bearer = SIGNED_TOKEN}))};
+  EXPECT_FALSE(token_permitted);
 
   EXPECT_EQ(*calls, 0);
 }
@@ -1820,32 +2280,30 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_only_the_key) {
   const std::array<std::string_view, 1> paths{{"/both"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_OIDC_UNION"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = paths, .keys = keys, .name = "policy-0"},
+      {{.paths = paths,
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}},
        {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_KEY_OIDC_UNION",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_KEY_OIDC_UNION",
+            .session_secrets = SESSION_SECRETS_UNUSED}}}};
   const auto path{test_path("oidc_union.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
 
-  const auto key_verdict{
-      authentication.admits(at("/both/x"), {.bearer = "union-secret"})};
-  EXPECT_TRUE(key_verdict.allowed);
-  EXPECT_TRUE(key_verdict.principal.has_value());
-  EXPECT_EQ(key_verdict.principal.value().type,
-            sourcemeta::one::Authentication::Type::ApiKey);
-  EXPECT_EQ(key_verdict.principal.value().policy, std::size_t{0});
+  const auto key_permitted{authentication.permits(
+      at("/both/x"), authentication.caller({.bearer = "union-secret"}))};
+  EXPECT_TRUE(key_permitted);
 
-  const auto token_verdict{
-      authentication.admits(at("/both/x"), {.bearer = SIGNED_TOKEN})};
-  EXPECT_FALSE(token_verdict.allowed);
-  EXPECT_FALSE(token_verdict.principal.has_value());
+  const auto token_permitted{authentication.permits(
+      at("/both/x"), authentication.caller({.bearer = SIGNED_TOKEN}))};
+  EXPECT_FALSE(token_permitted);
 }
 
 TEST(oidc_policy_admits_its_session_cookie) {
@@ -1853,38 +2311,31 @@ TEST(oidc_policy_admits_its_session_cookie) {
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SESSION",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_SESSION",
+            .session_secrets = SESSION_SECRETS}}}};
   const auto path{test_path("oidc_session.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const auto calls{std::make_shared<int>(0)};
   const sourcemeta::one::Authentication authentication{path,
                                                        stub_fetcher({}, calls)};
 
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta", "subject": "jane@acme.test" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "jane@acme.test")};
   const std::string cookies{"theme=dark; sourcemeta_one_session=" + sealed};
 
-  const auto verdict{authentication.admits(
-      at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})};
-  EXPECT_TRUE(verdict.allowed);
-  EXPECT_TRUE(verdict.principal.has_value());
-  EXPECT_EQ(verdict.principal.value().type,
-            sourcemeta::one::Authentication::Type::OIDC);
-  EXPECT_EQ(verdict.principal.value().policy, std::size_t{0});
+  const auto permitted{authentication.permits(
+      at("/portal/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)}))};
+  EXPECT_TRUE(permitted);
   EXPECT_EQ(*calls, 0);
 
-  const auto anonymous_verdict{
-      authentication.admits(at("/portal/x"), {.bearer = ""})};
-  EXPECT_FALSE(anonymous_verdict.allowed);
-  EXPECT_FALSE(anonymous_verdict.principal.has_value());
+  const auto anonymous_permitted{authentication.permits(
+      at("/portal/x"), authentication.caller({.bearer = ""}))};
+  EXPECT_FALSE(anonymous_permitted);
 }
 
 TEST(session_cookie_is_bound_to_the_policy_it_was_minted_for) {
@@ -1893,155 +2344,90 @@ TEST(session_cookie_is_bound_to_the_policy_it_was_minted_for) {
   const std::array<std::string_view, 1> beta_paths{{"/beta"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_BIND_A",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS},
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "acme",
+                .client_id = "client",
+                .client_secret_variable = "ONE_TEST_OIDC_BIND_A",
+                .session_secrets = SESSION_SECRETS}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_BIND_B",
         .name = "google",
-        .session_secrets = SESSION_SECRETS}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_BIND_B",
+            .session_secrets = SESSION_SECRETS}}}};
   const auto path{test_path("oidc_session_bound.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
 
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "")};
 
   // The session opens the path its policy governs
   const std::string okta_cookies{"sourcemeta_one_session=" + sealed};
-  EXPECT_TRUE(authentication
-                  .admits(at("/alpha/x"),
-                          {.bearer = "", .cookies = fields(okta_cookies)})
-                  .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/alpha/x"),
+      authentication.caller({.bearer = "", .cookies = fields(okta_cookies)})));
 
   // And not a path governed by another policy. Both policies here read the
   // same session secret, so the value verifies under either and the payload is
   // the only thing that tells them apart. There is no cookie name left to
   // separate them, which makes this the control rather than a second opinion
-  EXPECT_FALSE(authentication
-                   .admits(at("/beta/x"),
-                           {.bearer = "", .cookies = fields(okta_cookies)})
-                   .allowed);
-}
-
-TEST(expired_session_cookie_is_denied) {
-  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
-  const std::array<std::string_view, 1> paths{{"/portal"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_EXPIRED",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_session_expired.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-
-  const auto past{minted_now() - std::chrono::hours{2}};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET, past,
-      past + std::chrono::hours{1})};
-  const std::string cookies{"sourcemeta_one_session=" + sealed};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/beta/x"),
+      authentication.caller({.bearer = "", .cookies = fields(okta_cookies)})));
 }
 
 TEST(forged_session_cookie_is_denied) {
   setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  setenv("ONE_TEST_FOREIGN_SECRET", "other-secret", 1);
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_FORGED",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_session_forged.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_FORGED",
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("oidc_session_forged"), anywhere),
+      stub_fetcher({}, nullptr)};
 
-  // A value sealed under a secret this policy does not hold
-  const auto foreign{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, "other-secret",
-      minted_now(), session_expiry())};
-  const std::string foreign_cookies{"sourcemeta_one_session=" + foreign};
-  EXPECT_FALSE(authentication
-                   .admits(at("/portal/x"),
-                           {.bearer = "", .cookies = fields(foreign_cookies)})
-                   .allowed);
+  // The control, which is a session this policy did mint
+  const auto genuine{session_for("okta", SESSION_SECRETS, "")};
+  EXPECT_TRUE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller(
+          {.cookies = fields("sourcemeta_one_session=" + genuine)})));
+
+  // A session minted under a secret this policy does not hold, which differs
+  // from the one above in that alone
+  const std::array<std::string_view, 1> foreign_secrets{
+      {"ONE_TEST_FOREIGN_SECRET"}};
+  const auto foreign{session_for("okta", foreign_secrets, "")};
+  EXPECT_FALSE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller(
+          {.cookies = fields("sourcemeta_one_session=" + foreign)})));
 
   // A value whose signature no longer matches its contents
-  auto tampered{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  auto tampered{genuine};
   tampered.back() = tampered.back() == 'A' ? 'B' : 'A';
-  const std::string tampered_cookies{"sourcemeta_one_session=" + tampered};
-  EXPECT_FALSE(authentication
-                   .admits(at("/portal/x"),
-                           {.bearer = "", .cookies = fields(tampered_cookies)})
-                   .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller(
+          {.cookies = fields("sourcemeta_one_session=" + tampered)})));
 
   // A value that is not a sealed session at all
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/portal/x"),
-                  {.bearer = "",
-                   .cookies = fields("sourcemeta_one_session=garbage")})
-          .allowed);
-}
-
-TEST(session_payload_must_declare_its_policy) {
-  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
-  const std::array<std::string_view, 1> paths{{"/portal"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_PAYLOAD",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_session_payload.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-
-  const std::array<std::string_view, 4> payloads{
-      {"not json", "[ 1, 2 ]", R"JSON({ "subject": "jane" })JSON",
-       R"JSON({ "policy": "google" })JSON"}};
-  for (const auto payload : payloads) {
-    const auto sealed{sourcemeta::one::Authentication::seal_value(
-        payload, sourcemeta::one::Authentication::Purpose::Session,
-        SESSION_SECRET, minted_now(), session_expiry())};
-    const std::string cookies{"sourcemeta_one_session=" + sealed};
-    EXPECT_FALSE(
-        authentication
-            .admits(at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})
-            .allowed);
-  }
+  EXPECT_FALSE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller(
+          {.cookies = fields("sourcemeta_one_session=garbage")})));
 }
 
 TEST(session_is_admitted_when_a_shadowing_cookie_precedes_it) {
@@ -2049,21 +2435,18 @@ TEST(session_is_admitted_when_a_shadowing_cookie_precedes_it) {
   const std::array<std::string_view, 1> paths{{"/alpha"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SHADOW_A",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_SHADOW_A",
+            .session_secrets = SESSION_SECRETS}}}};
   const auto path{test_path("oidc_shadow_before.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "")};
 
   // A parent domain can set a cookie the host also sets, and the header says
   // nothing about which is which, so the genuine one is honoured wherever it
@@ -2071,10 +2454,9 @@ TEST(session_is_admitted_when_a_shadowing_cookie_precedes_it) {
   const std::string cookies{"sourcemeta_one_session=not-a-session; "
                             "sourcemeta_one_session=" +
                             sealed};
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/alpha/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)})));
 }
 
 TEST(session_is_admitted_when_a_shadowing_cookie_follows_it) {
@@ -2082,30 +2464,26 @@ TEST(session_is_admitted_when_a_shadowing_cookie_follows_it) {
   const std::array<std::string_view, 1> paths{{"/alpha"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SHADOW_B",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_SHADOW_B",
+            .session_secrets = SESSION_SECRETS}}}};
   const auto path{test_path("oidc_shadow_after.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "")};
 
   // Taking the last match would deny here, which is the shape that lets a
   // neighbouring host lock somebody out of an instance it does not control
   const std::string cookies{"sourcemeta_one_session=" + sealed +
                             "; sourcemeta_one_session=not-a-session"};
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/alpha/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)})));
 }
 
 TEST(session_is_admitted_when_it_arrives_in_a_later_cookie_field) {
@@ -2113,30 +2491,27 @@ TEST(session_is_admitted_when_it_arrives_in_a_later_cookie_field) {
   const std::array<std::string_view, 1> paths{{"/alpha"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_FIELD_LATER",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_FIELD_LATER",
+            .session_secrets = SESSION_SECRETS}}}};
   const auto path{test_path("oidc_field_later.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "")};
 
   // A request may carry its cookies across several fields rather than one, so
   // reading only the first would deny a session that did arrive
   const std::string second{"sourcemeta_one_session=" + sealed};
   const std::array<std::string_view, 2> carried{
       {"sourcemeta_one_session=not-a-session", second}};
-  EXPECT_TRUE(
-      authentication.admits(at("/alpha/x"), {.bearer = "", .cookies = carried})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/alpha/x"),
+      authentication.caller({.bearer = "", .cookies = carried})));
 }
 
 TEST(session_is_admitted_when_it_arrives_in_an_earlier_cookie_field) {
@@ -2144,30 +2519,27 @@ TEST(session_is_admitted_when_it_arrives_in_an_earlier_cookie_field) {
   const std::array<std::string_view, 1> paths{{"/alpha"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_FIELD_EARLIER",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_FIELD_EARLIER",
+            .session_secrets = SESSION_SECRETS}}}};
   const auto path{test_path("oidc_field_earlier.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "")};
 
   // And neither field is the one that decides, so a later one carrying nothing
   // does not undo an earlier one that does
   const std::string first{"sourcemeta_one_session=" + sealed};
   const std::array<std::string_view, 2> carried{
       {first, "sourcemeta_one_session=not-a-session"}};
-  EXPECT_TRUE(
-      authentication.admits(at("/alpha/x"), {.bearer = "", .cookies = carried})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/alpha/x"),
+      authentication.caller({.bearer = "", .cookies = carried})));
 }
 
 TEST(a_session_for_another_policy_does_not_end_the_search) {
@@ -2178,48 +2550,41 @@ TEST(a_session_for_another_policy_does_not_end_the_search) {
   // opens under the other and is only told apart by the payload
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SEARCH_A",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS},
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "acme",
+                .client_id = "client",
+                .client_secret_variable = "ONE_TEST_OIDC_SEARCH_A",
+                .session_secrets = SESSION_SECRETS}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SEARCH_B",
         .name = "google",
-        .session_secrets = SESSION_SECRETS}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_SEARCH_B",
+            .session_secrets = SESSION_SECRETS}}}};
   const auto path{test_path("oidc_search.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  const auto other{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "google" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
-  const auto mine{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto other{session_for("google", SESSION_SECRETS, "")};
+  const auto mine{session_for("okta", SESSION_SECRETS, "")};
 
   // The first value opens but was minted elsewhere, so stopping there would
   // deny a caller who did present a session for this policy
   const std::string cookies{"sourcemeta_one_session=" + other +
                             "; sourcemeta_one_session=" + mine};
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/alpha/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)})));
 
   // And a value minted elsewhere still opens nothing on its own
   const std::string alone{"sourcemeta_one_session=" + other};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(alone)})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/alpha/x"),
+      authentication.caller({.bearer = "", .cookies = fields(alone)})));
 }
 
 TEST(a_shadowing_cookie_alone_never_admits) {
@@ -2227,14 +2592,14 @@ TEST(a_shadowing_cookie_alone_never_admits) {
   const std::array<std::string_view, 1> paths{{"/alpha"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SHADOW_C",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_SHADOW_C",
+            .session_secrets = SESSION_SECRETS}}}};
   const auto path{test_path("oidc_shadow_only.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -2242,10 +2607,9 @@ TEST(a_shadowing_cookie_alone_never_admits) {
   // several did not
   const std::string cookies{"sourcemeta_one_session=not-a-session; "
                             "sourcemeta_one_session=nor-is-this"};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/alpha/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)})));
 }
 
 TEST(a_session_never_admits_under_a_policy_sharing_its_secret) {
@@ -2257,185 +2621,145 @@ TEST(a_session_never_admits_under_a_policy_sharing_its_secret) {
   // distinguishes them
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SHARED_A",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS},
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "acme",
+                .client_id = "client",
+                .client_secret_variable = "ONE_TEST_OIDC_SHARED_A",
+                .session_secrets = SESSION_SECRETS}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SHARED_B",
         .name = "google",
-        .session_secrets = SESSION_SECRETS}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_SHARED_B",
+            .session_secrets = SESSION_SECRETS}}}};
   const auto path{test_path("oidc_shared_secret.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
 
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/alpha/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/beta/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/alpha/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)})));
+  EXPECT_FALSE(authentication.permits(
+      at("/beta/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)})));
 }
 
-TEST(a_session_naming_no_policy_never_admits) {
+// Signing out asks the provider to end its own session, carrying the identity
+// token as proof of whose it is asking about. Reaching that at all means the
+// session opened and named the policy that minted it
+TEST(signing_out_asks_the_provider_that_established_the_session) {
+  setenv("ONE_TEST_LOGOUT_A", "confidential", 1);
   setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
-  const std::array<std::string_view, 1> paths{{"/alpha"}};
+  Provider provider;
+  provider.advertises =
+      R"JSON("end_session_endpoint": "https://provider.test/logout")JSON";
+  const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_NAMELESS_PAYLOAD",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_nameless_payload.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_LOGOUT_A",
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("logout_known"), anywhere),
+      provider.fetcher()};
 
-  // Correctly sealed, and says nothing about which policy it is for
-  const auto empty{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "subject": "somebody" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/alpha/x"),
-                  {.bearer = "",
-                   .cookies = fields("sourcemeta_one_session=" + empty)})
-          .allowed);
-
-  // Names a policy that does not exist
-  const auto unknown{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "nowhere" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/alpha/x"),
-                  {.bearer = "",
-                   .cookies = fields("sourcemeta_one_session=" + unknown)})
-          .allowed);
-
-  // Names a policy but not as a string
-  const auto typed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": 42 })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/alpha/x"),
-                  {.bearer = "",
-                   .cookies = fields("sourcemeta_one_session=" + typed)})
-          .allowed);
+  const auto established{session_for("okta", SESSION_SECRETS, "jane")};
+  const auto carried{"sourcemeta_one_session=" + established};
+  const auto outcome{
+      authentication.logout({.cookies = fields(carried)}, INSTANCE_URL, "/")};
+  EXPECT_TRUE(outcome.location.starts_with("https://provider.test/logout"));
+  EXPECT_TRUE(outcome.location.find("id_token_hint=") != std::string::npos);
+  // Both cookies expire whatever happened
+  EXPECT_EQ(outcome.cookies.size(), 3);
 }
 
-TEST(open_session_recovers_the_payload_of_whichever_policy_minted_it) {
+// A session naming a policy this instance does not serve opens nothing, so
+// there is nobody to ask and the browser is simply forgotten here
+TEST(signing_out_with_a_session_naming_no_policy_here_asks_nobody) {
+  setenv("ONE_TEST_LOGOUT_B", "confidential", 1);
   setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
-  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
-  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_OPEN_A",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS},
-       {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_OPEN_B",
-        .name = "google",
-        .session_secrets = SESSION_SECRETS_OPEN}}};
-  setenv("ONE_TEST_OIDC_OPEN_SECRET", "another-secret", 1);
-  const auto path{test_path("oidc_open_session.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta", "subject": "jane" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
-
-  const auto payload{authentication.open_session(sealed)};
-  EXPECT_TRUE(payload.has_value());
-  EXPECT_EQ(payload.value(),
-            R"JSON({ "policy": "okta", "subject": "jane" })JSON");
-}
-
-TEST(open_session_refuses_a_value_whose_payload_names_another_policy) {
-  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
-  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
-  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
-  // Sharing the secret again, so the value verifies under both and only the
-  // payload decides. A caller must not be able to learn a policy the value was
-  // never minted for
-  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_OPENX_A",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS},
-       {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_OPENX_B",
-        .name = "google",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_open_session_cross.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "nowhere" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
-  EXPECT_FALSE(authentication.open_session(sealed).has_value());
-}
-
-TEST(open_session_refuses_a_transaction) {
-  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
-  const std::array<std::string_view, 1> paths{{"/alpha"}};
+  Provider provider;
+  provider.advertises =
+      R"JSON("end_session_endpoint": "https://provider.test/logout")JSON";
+  const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_OPEN_PURPOSE",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_open_session_purpose.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_LOGOUT_B",
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  const auto transaction{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Transaction, SESSION_SECRET,
-      minted_now(), session_expiry())};
-  EXPECT_FALSE(authentication.open_session(transaction).has_value());
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("logout_unknown"), anywhere),
+      provider.fetcher()};
+
+  // A session another instance minted under a name this one never declared
+  const auto elsewhere{session_for("nowhere", SESSION_SECRETS, "jane")};
+  const auto carried{"sourcemeta_one_session=" + elsewhere};
+  const auto outcome{
+      authentication.logout({.cookies = fields(carried)}, INSTANCE_URL, "/")};
+  EXPECT_EQ(outcome.location, "/");
+  // The instance still forgets, which is the secure outcome either way
+  EXPECT_EQ(outcome.cookies.size(), 3);
+}
+
+TEST(a_transaction_never_admits_as_a_session) {
+  setenv("ONE_TEST_PURPOSE_CLIENT", "confidential", 1);
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://acme.test",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_PURPOSE_CLIENT",
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("oidc_open_session_purpose"), anywhere),
+      stub_fetcher({{"https://acme.test/.well-known/openid-configuration",
+                     R"JSON({
+              "issuer": "https://acme.test",
+              "authorization_endpoint": "https://acme.test/authorize",
+              "token_endpoint": "https://acme.test/token",
+              "jwks_uri": "https://acme.test/keys",
+              "response_types_supported": [ "code" ],
+              "subject_types_supported": [ "public" ],
+              "id_token_signing_alg_values_supported": [ "RS256", "ES256" ]
+            })JSON"}},
+                   nullptr)};
+
+  const auto started{authentication.login("okta", "https://registry.test",
+                                          "https://registry.test/callback",
+                                          false, "")};
+  EXPECT_EQ(started.result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  const auto transaction{cookie_value(started.cookies.front())};
+
+  // The control is a session, which does admit
+  const auto session{session_for("okta", SESSION_SECRETS, "")};
+  EXPECT_TRUE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller(
+          {.cookies = fields("sourcemeta_one_session=" + session)})));
+
+  EXPECT_FALSE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller(
+          {.cookies = fields("sourcemeta_one_session=" + transaction)})));
 }
 
 TEST(session_cookie_without_a_configured_secret_is_denied) {
@@ -2443,93 +2767,64 @@ TEST(session_cookie_without_a_configured_secret_is_denied) {
   // The session secret variable is deliberately never set in the environment
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_NO_SECRETS",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNSET}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_NO_SECRETS",
+            .session_secrets = SESSION_SECRETS_UNSET}}}};
   const auto path{test_path("oidc_session_no_secrets.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
 
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)})));
 }
 
 TEST(session_admitted_under_a_rotated_secret) {
   // The policy names the newest secret first, then the one it replaces, so a
-  // cookie signed under the old secret still verifies
+  // session established under the old secret still verifies
   setenv("ONE_TEST_OIDC_ROTATED_SECRET", "new-secret", 1);
   setenv("ONE_TEST_OIDC_ROTATED_SECRET_OLD", "old-secret", 1);
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_ROTATED",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS_ROTATED}}};
-  const auto path{test_path("oidc_session_rotated.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_ROTATED",
+            .session_secrets = SESSION_SECRETS_ROTATED}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("oidc_session_rotated"), anywhere),
+      stub_fetcher({}, nullptr)};
 
-  // A cookie signed under the older secret is still admitted
-  const auto old_sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, "old-secret",
-      minted_now(), session_expiry())};
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/portal/x"),
-                  {.bearer = "",
-                   .cookies = fields("sourcemeta_one_session=" + old_sealed)})
-          .allowed);
+  // A session established when the old secret was the only one is still
+  // admitted, which is what lets a secret be replaced without ending it
+  const std::array<std::string_view, 1> old_only{
+      {"ONE_TEST_OIDC_ROTATED_SECRET_OLD"}};
+  const auto established{session_for("okta", old_only, "")};
+  EXPECT_TRUE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller(
+          {.cookies = fields("sourcemeta_one_session=" + established)})));
 
-  // A fresh login mints under the newest secret alone, so the minted value
-  // verifies under a new-only secret set and not under an old-only one
-  const auto minted{authentication.seal(
-      "okta", sourcemeta::one::Authentication::Purpose::Session,
-      R"JSON({ "policy": "okta" })JSON", session_expiry())};
-  EXPECT_TRUE(minted.has_value());
-  // The value was minted from the clock, so it is read against the same one
-  const auto now{minted_now()};
-  const std::array<std::string_view, 1> new_only{{"new-secret"}};
-  EXPECT_TRUE(sourcemeta::one::Authentication::open_value(
-                  minted.value(),
-                  sourcemeta::one::Authentication::Purpose::Session, new_only,
-                  now)
-                  .has_value());
-  const std::array<std::string_view, 1> old_only{{"old-secret"}};
-  EXPECT_FALSE(sourcemeta::one::Authentication::open_value(
-                   minted.value(),
-                   sourcemeta::one::Authentication::Purpose::Session, old_only,
-                   now)
-                   .has_value());
-
-  // A secret no longer in the set is rejected
-  const auto retired{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, "retired-secret",
-      minted_now(), session_expiry())};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/portal/x"),
-                  {.bearer = "",
-                   .cookies = fields("sourcemeta_one_session=" + retired)})
-          .allowed);
+  // A secret no longer in the set is refused, which differs from the one above
+  // in exactly that
+  setenv("ONE_TEST_OIDC_RETIRED_SECRET", "retired-secret", 1);
+  const std::array<std::string_view, 1> retired_only{
+      {"ONE_TEST_OIDC_RETIRED_SECRET"}};
+  const auto retired{session_for("okta", retired_only, "")};
+  EXPECT_FALSE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller(
+          {.cookies = fields("sourcemeta_one_session=" + retired)})));
 }
 
 TEST(session_with_a_blank_configured_secret_is_denied) {
@@ -2537,28 +2832,24 @@ TEST(session_with_a_blank_configured_secret_is_denied) {
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_BLANK",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS_BLANK}}};
-  const auto path{test_path("oidc_session_blank.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_BLANK",
+            .session_secrets = SESSION_SECRETS_BLANK}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("oidc_session_blank"), anywhere),
+      stub_fetcher({}, nullptr)};
 
-  // A blank secret would let anyone forge sessions, so it never verifies one
-  const auto forged{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, "", minted_now(),
-      session_expiry())};
-  const std::string cookies{"sourcemeta_one_session=" + forged};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
+  // A blank secret would let anybody forge a session, so nothing verifies one,
+  // not even a session this system established under a real secret
+  const auto established{session_for("okta", SESSION_SECRETS, "")};
+  EXPECT_FALSE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller(
+          {.cookies = fields("sourcemeta_one_session=" + established)})));
 }
 
 TEST(save_creates_the_directory_it_writes_into) {
@@ -2566,30 +2857,32 @@ TEST(save_creates_the_directory_it_writes_into) {
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_NESTED"}};
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("nested") / "deeper" / "authentication.bin"};
   std::filesystem::remove_all(test_path("nested"));
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   EXPECT_TRUE(std::filesystem::exists(path));
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(
-      authentication.admits(at("/internal/foo"), {.bearer = "nested-secret"})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "nested-secret"})));
 }
 
 TEST(save_rejects_a_nameless_policy) {
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_NAMELESS"}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_NAMELESS"}}}};
   const auto path{test_path("oidc_nameless.bin")};
   try {
-    sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+    save(policies, path, path, anywhere);
     FAIL();
   } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
     EXPECT_STREQ(error.what(),
@@ -2602,9 +2895,12 @@ TEST(an_artifact_whose_table_omits_the_anonymous_view_is_refused) {
   const std::array<std::string_view, 1> paths{{"/machine"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_TABLE_ANONYMOUS"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "machine"}}};
+      {{.paths = paths,
+        .name = "machine",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("table_anonymous.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   // The anonymous view is the entry naming no policy, so giving the entry that
   // holds it a policy is what a table naming nobody anonymous looks like. Where
@@ -2624,20 +2920,22 @@ TEST(an_artifact_whose_table_omits_the_anonymous_view_is_refused) {
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // A refused artifact denies rather than serving anybody a tree it guessed at
-  EXPECT_FALSE(
-      authentication.admits(at("/machine/x"), {.bearer = "table-secret"})
-          .allowed);
-  EXPECT_FALSE(authentication.admits(at("/anywhere"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/machine/x"), authentication.caller({.bearer = "table-secret"})));
+  EXPECT_FALSE(authentication.permits(at("/anywhere"),
+                                      authentication.caller({.bearer = ""})));
 }
 
 TEST(save_rejects_a_nameless_key_policy) {
   const std::array<std::string_view, 1> paths{{"/machine"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_NAMELESS"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys}}};
+      {{.paths = paths,
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("key_nameless.bin")};
   try {
-    sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+    save(policies, path, path, anywhere);
     FAIL();
   } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
     EXPECT_STREQ(error.what(),
@@ -2651,11 +2949,18 @@ TEST(save_rejects_two_policies_sharing_a_name) {
   const std::array<std::string_view, 1> alpha_keys{{"ONE_TEST_KEY_SAME_A"}};
   const std::array<std::string_view, 1> beta_keys{{"ONE_TEST_KEY_SAME_B"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = alpha_paths, .keys = alpha_keys, .name = "shared"},
-       {.paths = beta_paths, .keys = beta_keys, .name = "shared"}}};
+      {{.paths = alpha_paths,
+        .name = "shared",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys =
+                                                                alpha_keys}},
+       {.paths = beta_paths,
+        .name = "shared",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = beta_keys}}}};
   const auto path{test_path("name_shared.bin")};
   try {
-    sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+    save(policies, path, path, anywhere);
     FAIL();
   } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
     EXPECT_STREQ(error.what(),
@@ -2705,47 +3010,55 @@ TEST(save_writes_the_largest_table_a_configuration_can_declare) {
   for (std::size_t index{0}; index < total; index += 1) {
     policies.push_back(
         {.paths = std::span<const std::string_view>{&path_views[index], 1},
-         .type = sourcemeta::one::Authentication::Type::JWT,
-         .issuer = issuer_storage[index],
-         .audience = "client",
-         .jwks_uri = "https://idp.test/jwks",
-         .algorithms = algorithms,
-         .claims = claims_storage[index],
-         .name = name_storage[index]});
+         .name = name_storage[index],
+         .credential = sourcemeta::one::Authentication::Policy::Token{
+             .issuer = issuer_storage[index],
+             .audience = "client",
+             .jwks_uri = "https://idp.test/jwks",
+             .algorithms = algorithms,
+             .claims = claims_storage[index]}});
   }
 
   // Each group contributes every combination over it, which is the most views a
   // configuration can ask for at the maximum number of policies
   const auto path{test_path("largest_table.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
-  EXPECT_EQ(authentication.view({.bearer = ""}), "public");
+  EXPECT_EQ(authentication.caller({.bearer = ""}).view(), "public");
   // A name read back out of a table this size, rather than the entry that sits
   // first in it whatever was written after
-  EXPECT_EQ(authentication.view(
-                {.bearer = token_with(R"JSON({ "groups": [ "g0" ] })JSON")}),
-            "p0");
-  EXPECT_EQ(authentication.view(
-                {.bearer = token_with(R"JSON({ "groups": [ "g15" ] })JSON")}),
-            "p15");
+  EXPECT_EQ(
+      authentication
+          .caller({.bearer = token_with(R"JSON({ "groups": [ "g0" ] })JSON")})
+          .view(),
+      "p0");
+  EXPECT_EQ(
+      authentication
+          .caller({.bearer = token_with(R"JSON({ "groups": [ "g15" ] })JSON")})
+          .view(),
+      "p15");
   // And a combination, spelled from its members sorted rather than from the
   // order the token happened to carry them in
-  EXPECT_EQ(
-      authentication.view(
-          {.bearer = token_with(R"JSON({ "groups": [ "g1", "g0" ] })JSON")}),
-      "p0+p1");
-  EXPECT_EQ(
-      authentication.view(
-          {.bearer = token_with(R"JSON({ "groups": [ "g2", "g15" ] })JSON")}),
-      "p15+p2");
+  EXPECT_EQ(authentication
+                .caller({.bearer = token_with(
+                             R"JSON({ "groups": [ "g1", "g0" ] })JSON")})
+                .view(),
+            "p0+p1");
+  EXPECT_EQ(authentication
+                .caller({.bearer = token_with(
+                             R"JSON({ "groups": [ "g2", "g15" ] })JSON")})
+                .view(),
+            "p15+p2");
   // A token no policy answers to is placed nowhere, which is the anonymous
   // view rather than a name the table happens to carry
-  EXPECT_EQ(authentication.view(
-                {.bearer = token_with(R"JSON({ "groups": [ "gx" ] })JSON")}),
-            "public");
+  EXPECT_EQ(
+      authentication
+          .caller({.bearer = token_with(R"JSON({ "groups": [ "gx" ] })JSON")})
+          .view(),
+      "public");
 }
 
 TEST(save_rejects_a_policy_named_as_a_combination_of_others) {
@@ -2761,23 +3074,28 @@ TEST(save_rejects_a_policy_named_as_a_combination_of_others) {
   // by joining them, which is the name the third policy also carries
   const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "alpha"},
+        .name = "alpha",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = algorithms}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "beta"},
-       {.paths = machine_paths, .keys = machine_keys, .name = "alpha+beta"}}};
+        .name = "beta",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = algorithms}},
+       {.paths = machine_paths,
+        .name = "alpha+beta",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = machine_keys}}}};
   const auto path{test_path("name_combination.bin")};
   try {
-    sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+    save(policies, path, path, anywhere);
     FAIL();
   } catch (const sourcemeta::one::AuthenticationViewNameCollisionError &error) {
     EXPECT_STREQ(
@@ -2792,24 +3110,31 @@ TEST(save_accepts_a_separator_that_spells_no_other_combination) {
   const std::array<std::string_view, 1> machine_keys{
       {"ONE_TEST_KEY_LONE_SEPARATOR"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = machine_paths, .keys = machine_keys, .name = "alpha+beta"}}};
+      {{.paths = machine_paths,
+        .name = "alpha+beta",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = machine_keys}}}};
   const auto path{test_path("name_separator.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_EQ(authentication.view({.bearer = "separator-secret"}), "alpha+beta");
-  EXPECT_EQ(authentication.view({.bearer = ""}), "public");
+  EXPECT_EQ(authentication.caller({.bearer = "separator-secret"}).view(),
+            "alpha+beta");
+  EXPECT_EQ(authentication.caller({.bearer = ""}).view(), "public");
 }
 
 TEST(save_rejects_a_policy_taking_the_anonymous_name) {
   const std::array<std::string_view, 1> paths{{"/machine"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_RESERVED"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "public"}}};
+      {{.paths = paths,
+        .name = "public",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("name_reserved.bin")};
   try {
-    sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+    save(policies, path, path, anywhere);
     FAIL();
   } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
     EXPECT_STREQ(error.what(),
@@ -2823,42 +3148,36 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_key_or_session) {
   const std::array<std::string_view, 1> paths{{"/both"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_SESSION_UNION"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = paths, .keys = keys, .name = "policy-0"},
+      {{.paths = paths,
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}},
        {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SESSION_UNION",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_SESSION_UNION",
+            .session_secrets = SESSION_SECRETS}}}};
   const auto path{test_path("oidc_session_union.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
 
-  const auto key_verdict{
-      authentication.admits(at("/both/x"), {.bearer = "union-key"})};
-  EXPECT_TRUE(key_verdict.allowed);
-  EXPECT_TRUE(key_verdict.principal.has_value());
-  EXPECT_EQ(key_verdict.principal.value().type,
-            sourcemeta::one::Authentication::Type::ApiKey);
-  EXPECT_EQ(key_verdict.principal.value().policy, std::size_t{0});
+  const auto key_permitted{authentication.permits(
+      at("/both/x"), authentication.caller({.bearer = "union-key"}))};
+  EXPECT_TRUE(key_permitted);
 
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
-  const auto session_verdict{authentication.admits(
-      at("/both/x"), {.bearer = "", .cookies = fields(cookies)})};
-  EXPECT_TRUE(session_verdict.allowed);
-  EXPECT_TRUE(session_verdict.principal.has_value());
-  EXPECT_EQ(session_verdict.principal.value().type,
-            sourcemeta::one::Authentication::Type::OIDC);
-  EXPECT_EQ(session_verdict.principal.value().policy, std::size_t{1});
+  const auto session_permitted{authentication.permits(
+      at("/both/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)}))};
+  EXPECT_TRUE(session_permitted);
 
-  EXPECT_FALSE(authentication.admits(at("/both/x"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(at("/both/x"),
+                                      authentication.caller({.bearer = ""})));
 }
 
 TEST(session_cookie_does_not_open_an_apikey_path) {
@@ -2867,462 +3186,429 @@ TEST(session_cookie_does_not_open_an_apikey_path) {
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_NO_SESSION"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("oidc_session_apikey.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
 
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/internal/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/internal/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)})));
 }
 
-TEST(interactive_returns_the_policy_by_name) {
-  setenv("ONE_TEST_KEY_INTERACTIVE", "key-value", 1);
-  setenv("ONE_TEST_OIDC_LOOKUP_A", "lookup-a-secret", 1);
-  setenv("ONE_TEST_OIDC_LOOKUP_B", "lookup-b-secret", 1);
-  const std::array<std::string_view, 1> key_paths{{"/internal"}};
-  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_INTERACTIVE"}};
-  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
-  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
-      {{.paths = key_paths, .keys = keys, .name = "machine"},
-       {.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_LOOKUP_A",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED},
-       {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://accounts.test",
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_LOOKUP_B",
-        .name = "google",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_lookup.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-
-  const auto okta{authentication.interactive("okta")};
-  EXPECT_TRUE(okta.has_value());
-  EXPECT_EQ(okta.value().issuer, "https://login.test");
-  EXPECT_EQ(okta.value().client_id, "registry");
-  EXPECT_EQ(okta.value().default_path, "/alpha");
-  EXPECT_EQ(authentication.client_secret("okta").value(), "lookup-a-secret");
-
-  const auto google{authentication.interactive("google")};
-  EXPECT_TRUE(google.has_value());
-  EXPECT_EQ(google.value().issuer, "https://accounts.test");
-  EXPECT_EQ(google.value().client_id, "dashboard");
-  EXPECT_EQ(google.value().default_path, "/beta");
-  EXPECT_EQ(authentication.client_secret("google").value(), "lookup-b-secret");
-
-  EXPECT_FALSE(authentication.interactive("github").has_value());
-  EXPECT_FALSE(authentication.interactive("").has_value());
-  EXPECT_FALSE(authentication.client_secret("github").has_value());
-  EXPECT_FALSE(authentication.client_secret("").has_value());
-}
-
-TEST(provider_endpoints_are_retrieved_once_and_reused) {
-  const auto calls{std::make_shared<int>(0)};
+// A login is offered under the name a policy was declared with, and nowhere
+// else. A name this instance does not serve is answered as missing, which is
+// the same answer a typo gets
+TEST(a_login_starts_only_under_a_declared_name) {
+  setenv("ONE_TEST_NAMED", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  const Provider provider;
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_CACHE",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_endpoints_cached.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const std::map<std::string, std::string> responses{
-      {"https://login.test/.well-known/openid-configuration",
-       R"JSON({
-         "issuer": "https://login.test",
-         "authorization_endpoint": "https://login.test/authorize",
-         "token_endpoint": "https://login.test/token",
-         "jwks_uri": "https://login.test/jwks",
-         "end_session_endpoint": "https://login.test/logout",
-         "response_types_supported": [ "code" ],
-         "subject_types_supported": [ "public" ],
-         "id_token_signing_alg_values_supported": [ "RS256" ]
-       })JSON"}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_NAMED",
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher(responses, calls)};
+      sourcemeta::one::Authentication::compile(policies, test_path("named"),
+                                               anywhere),
+      provider.fetcher()};
 
-  const auto first{authentication.endpoints("okta")};
-  EXPECT_TRUE(first.has_value());
-  EXPECT_EQ(first.value().authorization, "https://login.test/authorize");
-  EXPECT_EQ(first.value().token, "https://login.test/token");
-  EXPECT_EQ(first.value().jwks_uri, "https://login.test/jwks");
-  EXPECT_EQ(first.value().end_session, "https://login.test/logout");
-  EXPECT_EQ(*calls, 1);
-
-  // Asking again does not ask the provider again. A login is an
-  // unauthenticated endpoint, so fetching per request would let anybody drive
-  // outbound traffic one for one
-  const auto second{authentication.endpoints("okta")};
-  EXPECT_TRUE(second.has_value());
-  EXPECT_EQ(second.value().token, "https://login.test/token");
-  EXPECT_EQ(*calls, 1);
+  EXPECT_EQ(authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  EXPECT_EQ(
+      authentication.login("elsewhere", INSTANCE_URL, REDIRECT_URI, false, "")
+          .result,
+      sourcemeta::one::Authentication::Outcome::Result::Missing);
+  EXPECT_EQ(
+      authentication.login("", INSTANCE_URL, REDIRECT_URI, false, "").result,
+      sourcemeta::one::Authentication::Outcome::Result::Missing);
 }
 
-TEST(a_provider_naming_no_authentication_method_takes_the_header) {
+// What a provider says about itself is retrieved once and kept for as long as
+// it said, so a second login costs nothing. Anybody may start one, so asking
+// again each time would let a stranger drive traffic at the provider
+TEST(what_a_provider_said_is_retrieved_once_and_reused) {
+  setenv("ONE_TEST_OIDC_CACHE", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
+
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_AUTH_ABSENT",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_auth_absent.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const std::map<std::string, std::string> responses{
-      {"https://login.test/.well-known/openid-configuration",
-       R"JSON({
-         "issuer": "https://login.test",
-         "authorization_endpoint": "https://login.test/authorize",
-         "token_endpoint": "https://login.test/token",
-         "jwks_uri": "https://login.test/jwks",
-
-         "response_types_supported": [ "code" ],
-         "subject_types_supported": [ "public" ],
-         "id_token_signing_alg_values_supported": [ "RS256" ]
-       })JSON"}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_CACHE",
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher(responses, nullptr)};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_oidc_cache"), anywhere),
+      provider.fetcher()};
 
-  const auto endpoints{authentication.endpoints("okta")};
-  EXPECT_TRUE(endpoints.has_value());
-  // RFC 8414 Section 2 makes an absent list mean `client_secret_basic`, so
-  // saying nothing is an answer rather than the absence of one
-  EXPECT_TRUE(endpoints.value().token_endpoint_basic_auth);
+  EXPECT_EQ(authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  EXPECT_EQ(*provider.discoveries, 1);
+
+  EXPECT_EQ(authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  EXPECT_EQ(*provider.discoveries, 1);
 }
 
-TEST(a_provider_naming_the_header_takes_the_header) {
+// RFC 6749 Section 2.3.1 has every server accept the client secret in an
+// authorization header and discourages carrying it in the request body, so the
+// header is used wherever the provider takes it. A provider that lists nothing
+// is taken to accept it, which is what the specification assigns to silence
+TEST(a_provider_naming_no_authentication_method_gets_the_header) {
+  setenv("ONE_TEST_OIDC_AUTH_SILENT", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
+
   const std::array<std::string_view, 1> paths{{"/portal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_AUTH_BASIC",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_auth_basic.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const std::map<std::string, std::string> responses{
-      {"https://login.test/.well-known/openid-configuration",
-       R"JSON({
-         "issuer": "https://login.test",
-         "authorization_endpoint": "https://login.test/authorize",
-         "token_endpoint": "https://login.test/token",
-         "jwks_uri": "https://login.test/jwks",
-         "token_endpoint_auth_methods_supported": [ "client_secret_basic", "client_secret_post" ],
-         "response_types_supported": [ "code" ],
-         "subject_types_supported": [ "public" ],
-         "id_token_signing_alg_values_supported": [ "RS256" ]
-       })JSON"}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_AUTH_SILENT",
+            .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher(responses, nullptr)};
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_oidc_auth_silent"), anywhere),
+      provider.fetcher()};
 
-  const auto endpoints{authentication.endpoints("okta")};
-  EXPECT_TRUE(endpoints.has_value());
-  // Offering both, the header is the one RFC 6749 Section 2.3.1 asks for
-  EXPECT_TRUE(endpoints.value().token_endpoint_basic_auth);
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2" })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  EXPECT_TRUE(*provider.secret_in_header);
 }
 
+TEST(a_provider_naming_the_header_gets_the_header) {
+  setenv("ONE_TEST_OIDC_AUTH_BASIC", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
+  provider.advertises =
+      R"JSON("token_endpoint_auth_methods_supported": [ "client_secret_basic" ])JSON";
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_AUTH_BASIC",
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_oidc_auth_basic"), anywhere),
+      provider.fetcher()};
+
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2" })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  EXPECT_TRUE(*provider.secret_in_header);
+}
+
+// A provider that does not take the header leaves the body as the only way to
+// authenticate, so the preference gives way rather than the login failing. A
+// body is what logging and proxies keep, which is why it is the second choice
 TEST(a_provider_refusing_the_header_gets_the_body_instead) {
-  const std::array<std::string_view, 1> paths{{"/portal"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_AUTH_POST",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_auth_post.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const std::map<std::string, std::string> responses{
-      {"https://login.test/.well-known/openid-configuration",
-       R"JSON({
-         "issuer": "https://login.test",
-         "authorization_endpoint": "https://login.test/authorize",
-         "token_endpoint": "https://login.test/token",
-         "jwks_uri": "https://login.test/jwks",
-         "token_endpoint_auth_methods_supported": [ "client_secret_post" ],
-         "response_types_supported": [ "code" ],
-         "subject_types_supported": [ "public" ],
-         "id_token_signing_alg_values_supported": [ "RS256" ]
-       })JSON"}};
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher(responses, nullptr)};
-
-  const auto endpoints{authentication.endpoints("okta")};
-  EXPECT_TRUE(endpoints.has_value());
-  // A provider that does not take the header leaves the body as the only way
-  // to authenticate, so the preference gives way rather than the login failing
-  EXPECT_FALSE(endpoints.value().token_endpoint_basic_auth);
-}
-
-TEST(provider_endpoints_of_an_unreachable_provider_are_absent) {
-  const auto calls{std::make_shared<int>(0)};
-  const std::array<std::string_view, 1> paths{{"/portal"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_UNREACHABLE",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_endpoints_unreachable.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{path,
-                                                       stub_fetcher({}, calls)};
-  EXPECT_FALSE(authentication.endpoints("okta").has_value());
-  EXPECT_FALSE(authentication.endpoints("github").has_value());
-}
-
-TEST(client_secret_of_an_unset_variable_is_absent) {
-  unsetenv("ONE_TEST_OIDC_SECRET_UNSET");
-  const std::array<std::string_view, 1> paths{{"/alpha"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_SECRET_UNSET",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_secret_unset.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(authentication.interactive("okta").has_value());
-  EXPECT_FALSE(authentication.client_secret("okta").has_value());
-}
-
-TEST(client_secret_of_an_empty_variable_is_absent) {
-  setenv("ONE_TEST_OIDC_SECRET_EMPTY", "", 1);
-  const std::array<std::string_view, 1> paths{{"/alpha"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_SECRET_EMPTY",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_secret_empty.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  // A policy an operator meant to configure but left blank cannot authenticate
-  // to its provider, and says so rather than attempting the exchange with
-  // nothing
-  EXPECT_TRUE(authentication.interactive("okta").has_value());
-  EXPECT_FALSE(authentication.client_secret("okta").has_value());
-}
-
-TEST(client_secret_of_a_policy_naming_no_variable_is_absent) {
-  const std::array<std::string_view, 1> paths{{"/alpha"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "registry",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_secret_nameless.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  // A policy that names no variable at all has nowhere to read a secret from,
-  // which is not the same as naming one that happens to be unset
-  EXPECT_TRUE(authentication.interactive("okta").has_value());
-  EXPECT_FALSE(authentication.client_secret("okta").has_value());
-}
-
-TEST(client_secret_of_a_non_interactive_policy_is_absent) {
-  setenv("ONE_TEST_KEY_NOT_INTERACTIVE", "key-value", 1);
-  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_NOT_INTERACTIVE"}};
-  const std::array<std::string_view, 1> paths{{"/internal"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "internal"}}};
-  const auto path{test_path("oidc_secret_apikey.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.client_secret("internal").has_value());
-}
-
-TEST(interactive_default_path_is_the_first_path_declared) {
-  // Declared out of alphabetical order, so that the first declared path wins
-  // rather than the first sorted one
-  const std::array<std::string_view, 2> paths{{"/zeta", "/alpha"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_MULTI",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
-  const auto path{test_path("oidc_default_path.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-
-  const auto okta{authentication.interactive("okta")};
-  EXPECT_TRUE(okta.has_value());
-  EXPECT_EQ(okta.value().default_path, "/zeta");
-}
-
-TEST(interactive_through_a_broken_artifact_is_empty) {
-  const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"},
-      stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.interactive("okta").has_value());
-}
-
-TEST(seal_and_open_round_trip_under_the_policy_secret) {
+  setenv("ONE_TEST_OIDC_AUTH_POST", "confidential", 1);
   setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
-  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
-  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
+  Provider provider;
+  provider.advertises =
+      R"JSON("token_endpoint_auth_methods_supported": [ "client_secret_post" ])JSON";
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_AUTH_POST",
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_oidc_auth_post"), anywhere),
+      provider.fetcher()};
+
+  EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
+                    R"JSON({ "sub": "a1b2" })JSON")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  EXPECT_FALSE(*provider.secret_in_header);
+}
+
+TEST(a_login_against_an_unreachable_provider_cannot_start) {
+  setenv("ONE_TEST_OIDC_UNREACHABLE", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
+
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_UNREACHABLE",
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("one_test_oidc_unreachable"), anywhere),
+      provider.fetcher()};
+  Provider silent{provider};
+  silent.reachable = false;
+  const sourcemeta::one::Authentication unreachable{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("unreachable"), anywhere),
+      silent.fetcher()};
+
+  const auto outcome{
+      unreachable.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")};
+  EXPECT_EQ(outcome.result,
+            sourcemeta::one::Authentication::Outcome::Result::Unavailable);
+  EXPECT_TRUE(reported(outcome, "authorization endpoint"));
+
+  EXPECT_EQ(authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+}
+
+TEST(a_login_without_a_client_secret_cannot_start) {
+  unsetenv("ONE_TEST_SECRET_UNSET");
+  const Provider provider;
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_SECRET_UNSET",
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("secret_unset"), anywhere),
+      provider.fetcher()};
+
+  const auto outcome{
+      authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")};
+  EXPECT_EQ(outcome.result,
+            sourcemeta::one::Authentication::Outcome::Result::Unavailable);
+  EXPECT_TRUE(reported(outcome, "No client secret is set"));
+  // Nothing about the refusal reaches the person
+  EXPECT_TRUE(outcome.location.empty());
+  EXPECT_TRUE(outcome.cookies.empty());
+}
+
+// A variable set to nothing is not a secret, so it is the same answer as one
+// that was never set, which is what the control beside it shows
+TEST(a_login_with_a_blank_client_secret_cannot_start) {
+  setenv("ONE_TEST_SECRET_BLANK", "", 1);
+  setenv("ONE_TEST_SECRET_SET", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  const Provider provider;
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_SECRET_BLANK",
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("secret_blank"), anywhere),
+      provider.fetcher()};
+  const auto outcome{
+      authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")};
+  EXPECT_EQ(outcome.result,
+            sourcemeta::one::Authentication::Outcome::Result::Unavailable);
+  EXPECT_TRUE(reported(outcome, "No client secret is set"));
+
+  const std::array<sourcemeta::one::Authentication::Policy, 1> configured{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_SECRET_SET",
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication working{
+      sourcemeta::one::Authentication::compile(
+          configured, test_path("secret_set"), anywhere),
+      provider.fetcher()};
+  EXPECT_EQ(working.login("okta", INSTANCE_URL, REDIRECT_URI, false, "").result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+}
+
+// A policy naming no variable at all names no secret either
+TEST(a_login_naming_no_secret_variable_cannot_start) {
+  const Provider provider;
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("secret_unnamed"), anywhere),
+      provider.fetcher()};
+
+  const auto outcome{
+      authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")};
+  EXPECT_EQ(outcome.result,
+            sourcemeta::one::Authentication::Outcome::Result::Unavailable);
+  EXPECT_TRUE(reported(outcome, "No client secret is set"));
+}
+
+TEST(a_machine_policy_starts_no_login) {
+  const std::array<std::string_view, 1> paths{{"/machine"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_MACHINE_KEY"}};
+  setenv("ONE_TEST_MACHINE_KEY", "machine-secret", 1);
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "machine",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("machine_login"), anywhere),
+      Provider{}.fetcher()};
+
+  EXPECT_EQ(
+      authentication.login("machine", INSTANCE_URL, REDIRECT_URI, false, "")
+          .result,
+      sourcemeta::one::Authentication::Outcome::Result::Missing);
+}
+
+TEST(a_login_asking_for_nowhere_returns_to_what_the_policy_governs) {
+  setenv("ONE_TEST_DEFAULT_PATH", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  const Provider provider;
+  const std::array<std::string_view, 2> paths{{"/portal", "/second"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_DEFAULT_PATH",
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("default_path"), anywhere),
+      provider.fetcher()};
+
+  const auto completed{sign_in(authentication, provider, "okta", "client",
+                               R"JSON({ "sub": "a1b2" })JSON")};
+  EXPECT_EQ(completed.result,
+            sourcemeta::one::Authentication::Outcome::Result::Redirect);
+  EXPECT_EQ(completed.location, "/portal");
+}
+
+// An instance that could not read its artifact offers no login at all, which
+// is the same answer it gives to every other question
+TEST(a_login_through_a_broken_artifact_is_missing) {
+  const sourcemeta::one::Authentication authentication{
+      std::filesystem::path{"/no/such/authentication.bin"}, {}};
+  EXPECT_EQ(authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")
+                .result,
+            sourcemeta::one::Authentication::Outcome::Result::Missing);
+}
+
+// A session is sealed under the secret of the policy that established it, so a
+// value one policy minted is nothing to another, even where both are declared
+// here. That is what stops a caller choosing which policy a value is read as
+TEST(a_session_is_bound_to_the_policy_whose_secret_sealed_it) {
+  setenv("ONE_TEST_BIND_A", "confidential", 1);
+  setenv("ONE_TEST_BIND_B", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  setenv("ONE_TEST_BIND_OTHER_SECRET", "another-secret", 1);
+  Provider provider;
+  const std::array<std::string_view, 1> alpha{{"/alpha"}};
+  const std::array<std::string_view, 1> beta{{"/beta"}};
+  const std::array<std::string_view, 1> other{{"ONE_TEST_BIND_OTHER_SECRET"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SEAL_A",
+      {{.paths = alpha,
         .name = "okta",
-        .session_secrets = SESSION_SECRETS},
-       {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SEAL_B",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = provider.issuer,
+                .client_id = "client",
+                .client_secret_variable = "ONE_TEST_BIND_A",
+                .session_secrets = SESSION_SECRETS}},
+       {.paths = beta,
         .name = "google",
-        .session_secrets = SESSION_SECRETS_SEAL_OTHER}}};
-  const auto path{test_path("oidc_seal.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  // The other policy holds its own, distinct secret
-  setenv("ONE_TEST_OIDC_SEAL_OTHER", "another-secret", 1);
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_BIND_B",
+            .session_secrets = other}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  const auto sealed{authentication.seal(
-      "okta", sourcemeta::one::Authentication::Purpose::Session, "the-payload",
-      session_expiry())};
-  EXPECT_TRUE(sealed.has_value());
-  const auto payload{authentication.open(
-      "okta", sourcemeta::one::Authentication::Purpose::Session,
-      sealed.value())};
-  EXPECT_TRUE(payload.has_value());
-  EXPECT_EQ(payload.value(), "the-payload");
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("bind_policies"), anywhere),
+      provider.fetcher()};
 
-  // A value opened under a different policy, holding a different secret, does
-  // not verify
-  EXPECT_FALSE(authentication
-                   .open("google",
-                         sourcemeta::one::Authentication::Purpose::Session,
-                         sealed.value())
-                   .has_value());
+  const auto established{session_for("okta", SESSION_SECRETS, "jane")};
+  const auto carried{"sourcemeta_one_session=" + established};
 
-  // An unknown policy seals and opens nothing
-  EXPECT_FALSE(authentication
-                   .seal("github",
-                         sourcemeta::one::Authentication::Purpose::Session,
-                         "the-payload", session_expiry())
-                   .has_value());
-  EXPECT_FALSE(authentication
-                   .open("github",
-                         sourcemeta::one::Authentication::Purpose::Session,
-                         sealed.value())
-                   .has_value());
+  // It opens what the policy that minted it governs
+  EXPECT_TRUE(authentication.permits(
+      at("/alpha/x"), authentication.caller({.cookies = fields(carried)})));
+  // And nothing the other governs, which holds a secret of its own
+  EXPECT_FALSE(authentication.permits(
+      at("/beta/x"), authentication.caller({.cookies = fields(carried)})));
 }
 
-TEST(seal_without_a_configured_secret_produces_nothing) {
+// Without a secret there is nothing to seal a login with, so it does not start
+TEST(a_login_without_a_session_secret_cannot_start) {
+  setenv("ONE_TEST_SEAL_NONE", "confidential", 1);
+  unsetenv("ONE_TEST_SEAL_NONE_SECRET");
+  Provider provider;
   const std::array<std::string_view, 1> paths{{"/portal"}};
-  // The session secret variable is deliberately never set in the environment
+  const std::array<std::string_view, 1> absent{{"ONE_TEST_SEAL_NONE_SECRET"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SEAL_NONE",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS_SEAL_NONE}}};
-  const auto path{test_path("oidc_seal_none.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_SEAL_NONE",
+            .session_secrets = absent}}}};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication
-                   .seal("okta",
-                         sourcemeta::one::Authentication::Purpose::Session,
-                         "the-payload", session_expiry())
-                   .has_value());
-  EXPECT_FALSE(authentication
-                   .open("okta",
-                         sourcemeta::one::Authentication::Purpose::Session,
-                         "anything")
-                   .has_value());
-}
+      sourcemeta::one::Authentication::compile(policies, test_path("seal_none"),
+                                               anywhere),
+      provider.fetcher()};
 
-TEST(open_rejects_an_expired_value) {
-  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
-  const std::array<std::string_view, 1> paths{{"/portal"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_OIDC_SEAL_EXPIRED",
-        .name = "okta",
-        .session_secrets = SESSION_SECRETS}}};
-  const auto path{test_path("oidc_seal_expired.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
-
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  const std::chrono::sys_seconds past{std::chrono::seconds{1000}};
-  const auto sealed{authentication.seal(
-      "okta", sourcemeta::one::Authentication::Purpose::Session, "the-payload",
-      past)};
-  EXPECT_TRUE(sealed.has_value());
-  EXPECT_FALSE(authentication
-                   .open("okta",
-                         sourcemeta::one::Authentication::Purpose::Session,
-                         sealed.value())
-                   .has_value());
+  const auto outcome{
+      authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")};
+  EXPECT_EQ(outcome.result,
+            sourcemeta::one::Authentication::Outcome::Result::Unavailable);
+  EXPECT_TRUE(reported(outcome, "No session secret is set"));
+  EXPECT_TRUE(outcome.cookies.empty());
 }
 
 TEST(reference_within_the_same_oidc_scope_is_permitted) {
@@ -3333,21 +3619,22 @@ TEST(reference_within_the_same_oidc_scope_is_permitted) {
   // stay equal
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_SAME",
         .name = "alpha",
-        .session_secrets = SESSION_SECRETS_UNUSED},
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "https://login.test",
+                .client_id = "registry",
+                .client_secret_variable = "ONE_TEST_OIDC_REF_SAME",
+                .session_secrets = SESSION_SECRETS_UNUSED}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_SAME_OTHER",
         .name = "beta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://login.test",
+            .client_id = "registry",
+            .client_secret_variable = "ONE_TEST_OIDC_REF_SAME_OTHER",
+            .session_secrets = SESSION_SECRETS_UNUSED}}}};
   const auto path{test_path("oidc_ref_same.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -3362,21 +3649,22 @@ TEST(reference_across_distinct_oidc_clients_is_rejected) {
   const std::array<std::string_view, 1> beta_paths{{"/beta"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_ALPHA",
         .name = "alpha",
-        .session_secrets = SESSION_SECRETS_UNUSED},
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "https://login.test",
+                .client_id = "registry",
+                .client_secret_variable = "ONE_TEST_OIDC_REF_ALPHA",
+                .session_secrets = SESSION_SECRETS_UNUSED}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_BETA",
         .name = "beta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://login.test",
+            .client_id = "dashboard",
+            .client_secret_variable = "ONE_TEST_OIDC_REF_BETA",
+            .session_secrets = SESSION_SECRETS_UNUSED}}}};
   const auto path{test_path("oidc_ref_distinct.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -3393,21 +3681,22 @@ TEST(reference_across_swapped_oidc_identities_is_rejected) {
   // the scopes share both strings yet denote different provider clients
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://login.test",
-        .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_SWAP_ALPHA",
         .name = "alpha",
-        .session_secrets = SESSION_SECRETS_UNUSED},
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "https://login.test",
+                .client_id = "registry",
+                .client_secret_variable = "ONE_TEST_OIDC_REF_SWAP_ALPHA",
+                .session_secrets = SESSION_SECRETS_UNUSED}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "registry",
-        .client_id = "https://login.test",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_SWAP_BETA",
         .name = "beta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "registry",
+            .client_id = "https://login.test",
+            .client_secret_variable = "ONE_TEST_OIDC_REF_SWAP_BETA",
+            .session_secrets = SESSION_SECRETS_UNUSED}}}};
   const auto path{test_path("oidc_ref_swapped.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -3425,28 +3714,30 @@ TEST(reference_mixing_identities_across_oidc_policies_is_rejected) {
   // matches and the reference must not slip through their union
   const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
       {{.paths = source_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://alpha.test",
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_SOURCE",
         .name = "source",
-        .session_secrets = SESSION_SECRETS_UNUSED},
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "https://alpha.test",
+                .client_id = "dashboard",
+                .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_SOURCE",
+                .session_secrets = SESSION_SECRETS_UNUSED}},
        {.paths = target_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://alpha.test",
-        .client_id = "registry",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_ONE",
         .name = "target-one",
-        .session_secrets = SESSION_SECRETS_UNUSED},
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "https://alpha.test",
+                .client_id = "registry",
+                .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_ONE",
+                .session_secrets = SESSION_SECRETS_UNUSED}},
        {.paths = target_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://beta.test",
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_TWO",
         .name = "target-two",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://beta.test",
+            .client_id = "dashboard",
+            .client_secret_variable = "ONE_TEST_OIDC_REF_MIX_TWO",
+            .session_secrets = SESSION_SECRETS_UNUSED}}}};
   const auto path{test_path("oidc_ref_mixed.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -3460,22 +3751,23 @@ TEST(reference_between_oidc_scopes_distinguishes_claims) {
   const std::array<std::string_view, 1> gated_paths{{"/gated"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = open_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_CLAIMS",
         .name = "open",
-        .session_secrets = SESSION_SECRETS_UNUSED},
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "https://acme.test",
+                .client_id = "dashboard",
+                .client_secret_variable = "ONE_TEST_OIDC_REF_CLAIMS",
+                .session_secrets = SESSION_SECRETS_UNUSED}},
        {.paths = gated_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .claims = CLAIMS_ONE_GROUP,
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_CLAIMS",
         .name = "gated",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://acme.test",
+            .client_id = "dashboard",
+            .client_secret_variable = "ONE_TEST_OIDC_REF_CLAIMS",
+            .claims = CLAIMS_ONE_GROUP,
+            .session_secrets = SESSION_SECRETS_UNUSED}}}};
   const auto path{test_path("oidc_ref_claims.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -3495,23 +3787,24 @@ TEST(reference_between_oidc_scopes_distinguishes_email_domains) {
   const std::array<std::string_view, 1> beta_domains{{"other.test"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .email_domains = alpha_domains,
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_DOMAINS",
         .name = "alpha",
-        .session_secrets = SESSION_SECRETS_UNUSED},
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "https://acme.test",
+                .client_id = "dashboard",
+                .client_secret_variable = "ONE_TEST_OIDC_REF_DOMAINS",
+                .email_domains = alpha_domains,
+                .session_secrets = SESSION_SECRETS_UNUSED}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .email_domains = beta_domains,
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_DOMAINS",
         .name = "beta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://acme.test",
+            .client_id = "dashboard",
+            .client_secret_variable = "ONE_TEST_OIDC_REF_DOMAINS",
+            .email_domains = beta_domains,
+            .session_secrets = SESSION_SECRETS_UNUSED}}}};
   const auto path{test_path("oidc_ref_domains.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -3530,25 +3823,26 @@ TEST(reference_between_oidc_scopes_ignores_how_rules_were_written) {
       {"OTHER.test", "ACME.TEST"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .claims = CLAIMS_TWO_GROUPS,
-        .email_domains = alpha_domains,
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_SPELLING",
         .name = "alpha",
-        .session_secrets = SESSION_SECRETS_UNUSED},
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "https://acme.test",
+                .client_id = "dashboard",
+                .client_secret_variable = "ONE_TEST_OIDC_REF_SPELLING",
+                .claims = CLAIMS_TWO_GROUPS,
+                .email_domains = alpha_domains,
+                .session_secrets = SESSION_SECRETS_UNUSED}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://acme.test",
-        .claims = CLAIMS_TWO_GROUPS,
-        .email_domains = beta_domains,
-        .client_id = "dashboard",
-        .client_secret_variable = "ONE_TEST_OIDC_REF_SPELLING",
         .name = "beta",
-        .session_secrets = SESSION_SECRETS_UNUSED}}};
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://acme.test",
+            .client_id = "dashboard",
+            .client_secret_variable = "ONE_TEST_OIDC_REF_SPELLING",
+            .claims = CLAIMS_TWO_GROUPS,
+            .email_domains = beta_domains,
+            .session_secrets = SESSION_SECRETS_UNUSED}}}};
   const auto path{test_path("oidc_ref_spelling.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -3565,19 +3859,19 @@ TEST(admission_by_an_apikey_policy_identifies_the_principal) {
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_PRINCIPAL"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("principal_apikey.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  const auto verdict{authentication.admits(at("/internal/foo"),
-                                           {.bearer = "principal-secret"})};
-  EXPECT_TRUE(verdict.allowed);
-  EXPECT_TRUE(verdict.principal.has_value());
-  EXPECT_EQ(verdict.principal.value().type,
-            sourcemeta::one::Authentication::Type::ApiKey);
-  EXPECT_EQ(verdict.principal.value().policy, std::size_t{0});
+  const auto permitted{authentication.permits(
+      at("/internal/foo"),
+      authentication.caller({.bearer = "principal-secret"}))};
+  EXPECT_TRUE(permitted);
 }
 
 TEST(admission_by_a_jwt_policy_identifies_the_principal) {
@@ -3586,25 +3880,21 @@ TEST(admission_by_a_jwt_policy_identifies_the_principal) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("principal_jwt.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
-  const auto verdict{
-      authentication.admits(at("/secure/foo"), {.bearer = SIGNED_TOKEN})};
-  EXPECT_TRUE(verdict.allowed);
-  EXPECT_TRUE(verdict.principal.has_value());
-  EXPECT_EQ(verdict.principal.value().type,
-            sourcemeta::one::Authentication::Type::JWT);
-  EXPECT_EQ(verdict.principal.value().policy, std::size_t{0});
+  const auto permitted{authentication.permits(
+      at("/secure/foo"), authentication.caller({.bearer = SIGNED_TOKEN}))};
+  EXPECT_TRUE(permitted);
 }
 
 TEST(principal_identifies_the_admitting_policy_among_several) {
@@ -3614,36 +3904,31 @@ TEST(principal_identifies_the_admitting_policy_among_several) {
   const std::array<sourcemeta::core::JWSAlgorithm, 1> algorithms{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = paths, .keys = keys, .name = "policy-0"},
+      {{.paths = paths,
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}},
        {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("principal_mixed.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
                          nullptr)};
 
-  const auto apikey_verdict{
-      authentication.admits(at("/both/x"), {.bearer = "principal-mixed"})};
-  EXPECT_TRUE(apikey_verdict.allowed);
-  EXPECT_TRUE(apikey_verdict.principal.has_value());
-  EXPECT_EQ(apikey_verdict.principal.value().type,
-            sourcemeta::one::Authentication::Type::ApiKey);
-  EXPECT_EQ(apikey_verdict.principal.value().policy, std::size_t{0});
+  const auto apikey_permitted{authentication.permits(
+      at("/both/x"), authentication.caller({.bearer = "principal-mixed"}))};
+  EXPECT_TRUE(apikey_permitted);
 
-  const auto jwt_verdict{
-      authentication.admits(at("/both/x"), {.bearer = SIGNED_TOKEN})};
-  EXPECT_TRUE(jwt_verdict.allowed);
-  EXPECT_TRUE(jwt_verdict.principal.has_value());
-  EXPECT_EQ(jwt_verdict.principal.value().type,
-            sourcemeta::one::Authentication::Type::JWT);
-  EXPECT_EQ(jwt_verdict.principal.value().policy, std::size_t{1});
+  const auto jwt_permitted{authentication.permits(
+      at("/both/x"), authentication.caller({.bearer = SIGNED_TOKEN}))};
+  EXPECT_TRUE(jwt_permitted);
 }
 
 TEST(anonymous_and_denied_verdicts_carry_no_principal) {
@@ -3651,33 +3936,33 @@ TEST(anonymous_and_denied_verdicts_carry_no_principal) {
   const std::array<std::string_view, 1> paths{{"/internal"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_PRINCIPAL_NONE"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("principal_none.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
 
   // An uncovered path admits an anonymous caller
-  const auto anonymous_verdict{
-      authentication.admits(at("/open/foo"), {.bearer = ""})};
-  EXPECT_TRUE(anonymous_verdict.allowed);
-  EXPECT_FALSE(anonymous_verdict.principal.has_value());
+  const auto anonymous_permitted{authentication.permits(
+      at("/open/foo"), authentication.caller({.bearer = ""}))};
+  EXPECT_TRUE(anonymous_permitted);
 
   // A denial identifies nobody
-  const auto denied_verdict{
-      authentication.admits(at("/internal/foo"), {.bearer = "wrong"})};
-  EXPECT_FALSE(denied_verdict.allowed);
-  EXPECT_FALSE(denied_verdict.principal.has_value());
+  const auto denied_permitted{authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "wrong"}))};
+  EXPECT_FALSE(denied_permitted);
 
   // A broken artifact denies with no principal either
   const sourcemeta::one::Authentication missing{
       std::filesystem::path{"/no/such/authentication.bin"},
       stub_fetcher({}, nullptr)};
-  const auto missing_verdict{
-      missing.admits(at("/internal/foo"), {.bearer = "principal-none"})};
-  EXPECT_FALSE(missing_verdict.allowed);
-  EXPECT_FALSE(missing_verdict.principal.has_value());
+  const auto missing_permitted{missing.permits(
+      at("/internal/foo"), missing.caller({.bearer = "principal-none"}))};
+  EXPECT_FALSE(missing_permitted);
 }
 
 TEST(reference_rules_treat_a_jwt_scope_conservatively) {
@@ -3686,14 +3971,14 @@ TEST(reference_rules_treat_a_jwt_scope_conservatively) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_reference.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   // Reference checks read only the policy, so no key set transport is needed
   const sourcemeta::one::Authentication authentication{
@@ -3714,18 +3999,18 @@ TEST(jwt_without_a_transport_denies_rather_than_crashes) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_no_transport.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{path, {}};
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = SIGNED_TOKEN}).allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
 
 TEST(jwt_policies_sharing_an_issuer_use_their_own_key_set) {
@@ -3735,21 +4020,22 @@ TEST(jwt_policies_sharing_an_issuer_use_their_own_key_set) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = primary_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/primary",
-        .algorithms = algorithms,
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/primary",
+                .algorithms = algorithms}},
        {.paths = secondary_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/secondary",
-        .algorithms = algorithms,
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/secondary",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_shared_issuer.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher(
@@ -3758,11 +4044,10 @@ TEST(jwt_policies_sharing_an_issuer_use_their_own_key_set) {
                 nullptr)};
   // The primary path is populated first, which under a per-issuer cache would
   // have leaked its key set to the secondary path
-  EXPECT_TRUE(authentication.admits(at("/primary/x"), {.bearer = SIGNED_TOKEN})
-                  .allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/secondary/x"), {.bearer = SIGNED_TOKEN})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/primary/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
+  EXPECT_FALSE(authentication.permits(
+      at("/secondary/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
 
 TEST(jwt_claims_admit_only_a_token_carrying_a_named_value) {
@@ -3771,33 +4056,30 @@ TEST(jwt_claims_admit_only_a_token_carrying_a_named_value) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_ONE_GROUP,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_ONE_GROUP}}}};
   const auto path{test_path("jwt_claims_value.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
-  EXPECT_TRUE(authentication
-                  .admits(at("/secure/x"),
-                          {.bearer = token_with(
-                               R"JSON({ "groups": [ "platform" ] })JSON")})
-                  .allowed);
-  EXPECT_FALSE(authentication
-                   .admits(at("/secure/x"),
-                           {.bearer = token_with(
-                                R"JSON({ "groups": [ "support" ] })JSON")})
-                   .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "groups": [ "platform" ] })JSON")})));
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "groups": [ "support" ] })JSON")})));
   // A token the policy would otherwise admit, carrying no such claim at all
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = token_with("{}")})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = token_with("{}")})));
 }
 
 TEST(jwt_claims_admit_any_one_of_the_named_values) {
@@ -3806,41 +4088,37 @@ TEST(jwt_claims_admit_any_one_of_the_named_values) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_TWO_GROUPS,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_TWO_GROUPS}}}};
   const auto path{test_path("jwt_claims_alternatives.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
-  EXPECT_TRUE(authentication
-                  .admits(at("/secure/x"),
-                          {.bearer = token_with(
-                               R"JSON({ "groups": [ "platform" ] })JSON")})
-                  .allowed);
-  EXPECT_TRUE(authentication
-                  .admits(at("/secure/x"),
-                          {.bearer = token_with(
-                               R"JSON({ "groups": [ "oncall" ] })JSON")})
-                  .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "groups": [ "platform" ] })JSON")})));
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "groups": [ "oncall" ] })JSON")})));
   // Belonging to something else as well takes nothing away
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/secure/x"),
-                  {.bearer = token_with(
-                       R"JSON({ "groups": [ "support", "oncall" ] })JSON")})
-          .allowed);
-  EXPECT_FALSE(authentication
-                   .admits(at("/secure/x"),
-                           {.bearer = token_with(
-                                R"JSON({ "groups": [ "support" ] })JSON")})
-                   .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(
+               R"JSON({ "groups": [ "support", "oncall" ] })JSON")})));
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "groups": [ "support" ] })JSON")})));
 }
 
 TEST(jwt_claims_require_every_rule_it_declares) {
@@ -3849,37 +4127,34 @@ TEST(jwt_claims_require_every_rule_it_declares) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_GROUP_AND_DEPARTMENT,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_GROUP_AND_DEPARTMENT}}}};
   const auto path{test_path("jwt_claims_cumulative.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
-  EXPECT_TRUE(
-      authentication
-          .admits(
-              at("/secure/x"),
-              {.bearer = token_with(
-                   R"JSON({ "groups": [ "platform" ], "department": "engineering" })JSON")})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(
+               R"JSON({ "groups": [ "platform" ], "department": "engineering" })JSON")})));
   // Either rule alone leaves the other unsatisfied
-  EXPECT_FALSE(authentication
-                   .admits(at("/secure/x"),
-                           {.bearer = token_with(
-                                R"JSON({ "groups": [ "platform" ] })JSON")})
-                   .allowed);
-  EXPECT_FALSE(authentication
-                   .admits(at("/secure/x"),
-                           {.bearer = token_with(
-                                R"JSON({ "department": "engineering" })JSON")})
-                   .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "groups": [ "platform" ] })JSON")})));
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer =
+               token_with(R"JSON({ "department": "engineering" })JSON")})));
 }
 
 TEST(jwt_claims_read_a_scope_as_a_space_delimited_set) {
@@ -3888,51 +4163,45 @@ TEST(jwt_claims_read_a_scope_as_a_space_delimited_set) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_SCOPE,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_SCOPE}}}};
   const auto path{test_path("jwt_claims_scope.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
-  EXPECT_TRUE(authentication
-                  .admits(at("/secure/x"),
-                          {.bearer = token_with(
-                               R"JSON({ "scope": "registry:read" })JSON")})
-                  .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "scope": "registry:read" })JSON")})));
   // The value is one of several granted, in any position
-  EXPECT_TRUE(
-      authentication
-          .admits(
-              at("/secure/x"),
-              {.bearer = token_with(
-                   R"JSON({ "scope": "openid registry:read profile" })JSON")})
-          .allowed);
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/secure/x"),
-                  {.bearer = token_with(R"JSON({ "scope": "openid" })JSON")})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(
+               R"JSON({ "scope": "openid registry:read profile" })JSON")})));
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "scope": "openid" })JSON")})));
   // A granted scope that merely contains the required one as a prefix is a
   // different grant, and admitting it would hand over what nobody issued
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/secure/x"),
-                  {.bearer = token_with(
-                       R"JSON({ "scope": "registry:readwrite" })JSON")})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer =
+               token_with(R"JSON({ "scope": "registry:readwrite" })JSON")})));
   // Scope values are case-sensitive by RFC 6749 Section 3.3
-  EXPECT_FALSE(authentication
-                   .admits(at("/secure/x"),
-                           {.bearer = token_with(
-                                R"JSON({ "scope": "Registry:Read" })JSON")})
-                   .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "scope": "Registry:Read" })JSON")})));
 }
 
 TEST(jwt_claims_deny_an_ordinary_rule_that_names_no_value) {
@@ -3941,26 +4210,25 @@ TEST(jwt_claims_deny_an_ordinary_rule_that_names_no_value) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_GROUPS_NO_VALUES,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_GROUPS_NO_VALUES}}}};
   const auto path{test_path("jwt_claims_groups_empty.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
   // The same reading the scope rule gets, on the path that defers the
   // comparison rather than making it here
-  EXPECT_FALSE(authentication
-                   .admits(at("/secure/x"),
-                           {.bearer = token_with(
-                                R"JSON({ "groups": [ "platform" ] })JSON")})
-                   .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "groups": [ "platform" ] })JSON")})));
 }
 
 TEST(jwt_claims_deny_a_scope_rule_that_names_no_value) {
@@ -3969,26 +4237,25 @@ TEST(jwt_claims_deny_a_scope_rule_that_names_no_value) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_SCOPE_NO_VALUES,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_SCOPE_NO_VALUES}}}};
   const auto path{test_path("jwt_claims_scope_empty.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
   // An allow list naming nothing admits nobody, rather than widening to
   // every token that carries any scope at all
-  EXPECT_FALSE(authentication
-                   .admits(at("/secure/x"),
-                           {.bearer = token_with(
-                                R"JSON({ "scope": "registry:read" })JSON")})
-                   .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "scope": "registry:read" })JSON")})));
 }
 
 TEST(jwt_claims_deny_a_scope_rule_this_cannot_read) {
@@ -3997,26 +4264,25 @@ TEST(jwt_claims_deny_a_scope_rule_this_cannot_read) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_SCOPE_UNREADABLE,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_SCOPE_UNREADABLE}}}};
   const auto path{test_path("jwt_claims_scope_unreadable.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
   // A value that is not a scope token denies, since passing it over would
   // leave a rule that admits every token carrying any scope
-  EXPECT_FALSE(authentication
-                   .admits(at("/secure/x"),
-                           {.bearer = token_with(
-                                R"JSON({ "scope": "registry:read" })JSON")})
-                   .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "scope": "registry:read" })JSON")})));
 }
 
 TEST(jwt_claims_scope_without_a_constraint_still_requires_a_scope) {
@@ -4025,34 +4291,31 @@ TEST(jwt_claims_scope_without_a_constraint_still_requires_a_scope) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_SCOPE_UNCONSTRAINED,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_SCOPE_UNCONSTRAINED}}}};
   const auto path{test_path("jwt_claims_scope_open.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
   // Constraining no value asks only that a scope be carried, so any one does
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/secure/x"),
-                  {.bearer = token_with(R"JSON({ "scope": "anything" })JSON")})
-          .allowed);
-  EXPECT_FALSE(
-      authentication.admits(at("/secure/x"), {.bearer = token_with("{}")})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "scope": "anything" })JSON")})));
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = token_with("{}")})));
   // A scope that is not a space-delimited string grants nothing this can read
-  EXPECT_FALSE(authentication
-                   .admits(at("/secure/x"),
-                           {.bearer = token_with(
-                                R"JSON({ "scope": [ "anything" ] })JSON")})
-                   .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "scope": [ "anything" ] })JSON")})));
 }
 
 TEST(jwt_claims_match_a_group_object_on_its_identifier_alone) {
@@ -4061,36 +4324,32 @@ TEST(jwt_claims_match_a_group_object_on_its_identifier_alone) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_ONE_GROUP,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_ONE_GROUP}}}};
   const auto path{test_path("jwt_claims_group_object.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
   // The shape RFC 9068 Section 2.2.3.1 gives the claim by way of RFC 7643
-  EXPECT_TRUE(
-      authentication
-          .admits(
-              at("/secure/x"),
-              {.bearer = token_with(
-                   R"JSON({ "groups": [ { "value": "platform", "display": "Platform" } ] })JSON")})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(
+               R"JSON({ "groups": [ { "value": "platform", "display": "Platform" } ] })JSON")})));
   // A display name is neither unique nor stable, so admitting on one would let
   // whoever can rename a group grant access
-  EXPECT_FALSE(
-      authentication
-          .admits(
-              at("/secure/x"),
-              {.bearer = token_with(
-                   R"JSON({ "groups": [ { "value": "g-1", "display": "platform" } ] })JSON")})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(
+               R"JSON({ "groups": [ { "value": "g-1", "display": "platform" } ] })JSON")})));
 }
 
 TEST(jwt_claims_never_match_a_value_that_is_not_a_string) {
@@ -4099,34 +4358,31 @@ TEST(jwt_claims_never_match_a_value_that_is_not_a_string) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_VERIFIED,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_VERIFIED}}}};
   const auto path{test_path("jwt_claims_non_string.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/secure/x"),
-                  {.bearer = token_with(R"JSON({ "verified": true })JSON")})
-          .allowed);
-  EXPECT_FALSE(
-      authentication
-          .admits(at("/secure/x"),
-                  {.bearer = token_with(R"JSON({ "verified": 1 })JSON")})
-          .allowed);
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/secure/x"),
-                  {.bearer = token_with(R"JSON({ "verified": "true" })JSON")})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "verified": true })JSON")})));
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "verified": 1 })JSON")})));
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "verified": "true" })JSON")})));
 }
 
 TEST(jwt_without_claims_admits_a_token_carrying_none) {
@@ -4135,21 +4391,20 @@ TEST(jwt_without_claims_admits_a_token_carrying_none) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy"}}};
+        .name = "policy",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_claims_absent.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
-  EXPECT_TRUE(
-      authentication.admits(at("/secure/x"), {.bearer = token_with("{}")})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/secure/x"), authentication.caller({.bearer = token_with("{}")})));
 }
 
 TEST(jwt_claims_that_do_not_parse_deny_everything) {
@@ -4159,22 +4414,23 @@ TEST(jwt_claims_that_do_not_parse_deny_everything) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_ONE_GROUP,
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = algorithms,
+                .claims = CLAIMS_ONE_GROUP}},
        {.paths = open_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("jwt_claims_corrupt.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   // Overwrite the first byte of the serialised rules, leaving their length
   // intact so that they are read but no longer parse
@@ -4200,15 +4456,13 @@ TEST(jwt_claims_that_do_not_parse_deny_everything) {
                          nullptr)};
   // Rules that cannot be read are not passed over, since doing so would drop
   // the restriction and admit everyone the policy was meant to narrow
-  EXPECT_FALSE(authentication
-                   .admits(at("/secure/x"),
-                           {.bearer = token_with(
-                                R"JSON({ "groups": [ "platform" ] })JSON")})
-                   .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/secure/x"),
+      authentication.caller(
+          {.bearer = token_with(R"JSON({ "groups": [ "platform" ] })JSON")})));
   // The whole artifact denies, rather than only the policy that carried them
-  EXPECT_FALSE(
-      authentication.admits(at("/open/x"), {.bearer = token_with("{}")})
-          .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/open/x"), authentication.caller({.bearer = token_with("{}")})));
 }
 
 TEST(reference_between_jwt_scopes_distinguishes_claims) {
@@ -4218,22 +4472,23 @@ TEST(reference_between_jwt_scopes_distinguishes_claims) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = open_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = algorithms}},
        {.paths = gated_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_ONE_GROUP,
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_ONE_GROUP}}}};
   const auto path{test_path("jwt_claims_reference.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
@@ -4257,23 +4512,24 @@ TEST(reference_between_jwt_scopes_ignores_the_order_rules_were_written_in) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_TWO_GROUPS,
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = algorithms,
+                .claims = CLAIMS_TWO_GROUPS}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_TWO_GROUPS,
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_TWO_GROUPS}}}};
   const auto path{test_path("jwt_claims_reference_order.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
@@ -4296,28 +4552,30 @@ TEST(reference_between_jwt_scopes_distinguishes_algorithms) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = rsa}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = ecdsa,
-        .name = "policy-1"},
+        .name = "policy-1",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = ecdsa}},
        {.paths = gamma_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .name = "policy-2"}}};
+        .name = "policy-2",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = rsa}}}};
   const auto path{test_path("jwt_reference_algorithms.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -4343,21 +4601,22 @@ TEST(reference_between_jwt_scopes_ignores_algorithm_order) {
   // the same tokens and must be the same scope
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = one_order,
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = one_order}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = other_order,
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = other_order}}}};
   const auto path{test_path("jwt_reference_algorithm_order.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -4376,23 +4635,24 @@ TEST(reference_between_jwt_scopes_ignores_token_type_spelling) {
   // prefix optional, so these two admit exactly the same tokens
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .token_type = "at+jwt",
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = rsa,
+                .token_type = "at+jwt"}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .token_type = "Application/AT+JWT",
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = rsa,
+            .token_type = "Application/AT+JWT"}}}};
   const auto path{test_path("jwt_reference_token_type_spelling.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -4415,21 +4675,22 @@ TEST(reference_between_jwt_scopes_ignores_repeated_algorithms) {
   // Naming an algorithm twice admits nothing a single mention does not
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = repeated,
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = repeated}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = once,
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = once}}}};
   const auto path{test_path("jwt_reference_repeated_algorithms.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -4449,22 +4710,23 @@ TEST(a_token_type_that_is_the_bare_media_prefix_still_names_a_type) {
   // that does not
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .token_type = "application/",
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = rsa,
+                .token_type = "application/"}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = rsa}}}};
   const auto path{test_path("jwt_token_type_bare_prefix.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -4483,23 +4745,24 @@ TEST(a_token_type_carrying_a_further_separator_keeps_its_prefix) {
   // its own, so these two name different types and are read as such
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .token_type = "application/one/two",
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = rsa,
+                .token_type = "application/one/two"}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .token_type = "one/two",
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = rsa,
+            .token_type = "one/two"}}}};
   const auto path{test_path("jwt_token_type_nested_separator.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -4518,21 +4781,22 @@ TEST(reference_across_swapped_jwt_identities_is_rejected) {
   // share both strings yet no token satisfies them both
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://login.test",
-        .audience = "registry",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "https://login.test",
+                .audience = "registry",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = rsa}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "registry",
-        .audience = "https://login.test",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "registry",
+            .audience = "https://login.test",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = rsa}}}};
   const auto path{test_path("jwt_reference_swapped.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -4552,28 +4816,30 @@ TEST(reference_mixing_identities_across_jwt_policies_is_rejected) {
   // matches and the reference must not slip through their union
   const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
       {{.paths = source_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://alpha.test",
-        .audience = "dashboard",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "https://alpha.test",
+                .audience = "dashboard",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = rsa}},
        {.paths = target_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://alpha.test",
-        .audience = "registry",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .name = "policy-1"},
+        .name = "policy-1",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "https://alpha.test",
+                .audience = "registry",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = rsa}},
        {.paths = target_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://beta.test",
-        .audience = "dashboard",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .name = "policy-2"}}};
+        .name = "policy-2",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://beta.test",
+            .audience = "dashboard",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = rsa}}}};
   const auto path{test_path("jwt_reference_mixed.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -4591,21 +4857,22 @@ TEST(reference_across_swapped_jwt_key_set_locations_is_rejected) {
   // trading the issuer does
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = alpha_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "https://idp.test/jwks",
-        .jwks_uri = "registry",
-        .algorithms = rsa,
-        .name = "policy-0"},
+        .name = "policy-0",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "https://idp.test/jwks",
+                .jwks_uri = "registry",
+                .algorithms = rsa}},
        {.paths = beta_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "registry",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = rsa,
-        .name = "policy-1"}}};
+        .name = "policy-1",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "registry",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = rsa}}}};
   const auto path{test_path("jwt_reference_swapped_keys.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -4624,20 +4891,23 @@ TEST(a_policy_path_declared_canonically_gates_its_location) {
   const std::array<std::string_view, 1> paths{{"/private"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_CANONICAL"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("policy_declared_canonically.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/private/secret"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication
-                  .admits(at("/private/secret"), {.bearer = "spelling-secret"})
-                  .allowed);
+  EXPECT_FALSE(authentication.permits(at("/private/secret"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(
+      at("/private/secret"),
+      authentication.caller({.bearer = "spelling-secret"})));
   // A location the policy does not name stays public
-  EXPECT_TRUE(
-      authentication.admits(at("/public/string"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/public/string"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(a_policy_path_carrying_a_dot_segment_gates_its_location) {
@@ -4645,20 +4915,23 @@ TEST(a_policy_path_carrying_a_dot_segment_gates_its_location) {
   const std::array<std::string_view, 1> paths{{"/./private"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_DOT"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("policy_carrying_a_dot_segment.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/private/secret"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication
-                  .admits(at("/private/secret"), {.bearer = "spelling-secret"})
-                  .allowed);
+  EXPECT_FALSE(authentication.permits(at("/private/secret"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(
+      at("/private/secret"),
+      authentication.caller({.bearer = "spelling-secret"})));
   // A location the policy does not name stays public
-  EXPECT_TRUE(
-      authentication.admits(at("/public/string"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/public/string"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(a_policy_path_that_climbs_back_into_itself_gates_its_location) {
@@ -4666,20 +4939,23 @@ TEST(a_policy_path_that_climbs_back_into_itself_gates_its_location) {
   const std::array<std::string_view, 1> paths{{"/private/../private"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_CLIMB"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("policy_that_climbs_back_into_itself.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/private/secret"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication
-                  .admits(at("/private/secret"), {.bearer = "spelling-secret"})
-                  .allowed);
+  EXPECT_FALSE(authentication.permits(at("/private/secret"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(
+      at("/private/secret"),
+      authentication.caller({.bearer = "spelling-secret"})));
   // A location the policy does not name stays public
-  EXPECT_TRUE(
-      authentication.admits(at("/public/string"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/public/string"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(a_policy_path_carrying_a_repeated_separator_gates_its_location) {
@@ -4687,20 +4963,23 @@ TEST(a_policy_path_carrying_a_repeated_separator_gates_its_location) {
   const std::array<std::string_view, 1> paths{{"//private"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_SEPARATOR"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "policy"}}};
+      {{.paths = paths,
+        .name = "policy",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("policy_carrying_a_repeated_separator.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.admits(at("/private/secret"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication
-                  .admits(at("/private/secret"), {.bearer = "spelling-secret"})
-                  .allowed);
+  EXPECT_FALSE(authentication.permits(at("/private/secret"),
+                                      authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(
+      at("/private/secret"),
+      authentication.caller({.bearer = "spelling-secret"})));
   // A location the policy does not name stays public
-  EXPECT_TRUE(
-      authentication.admits(at("/public/string"), {.bearer = ""}).allowed);
+  EXPECT_TRUE(authentication.permits(at("/public/string"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(views_of_nothing_are_the_public_one_alone) {
@@ -4714,9 +4993,9 @@ TEST(views_name_a_static_key_policy_on_its_own) {
   const std::array<std::string_view, 1> keys{{"secret"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .keys = keys,
-        .type = sourcemeta::one::Authentication::Type::ApiKey,
-        .name = "vault"}}};
+        .name = "vault",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
@@ -4728,9 +5007,9 @@ TEST(views_name_an_interactive_policy_on_its_own) {
   const std::array<std::string_view, 1> paths{{"/console"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "desk"}}};
+        .name = "desk",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://idp.example.com/realms/staff"}}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
@@ -4742,9 +5021,9 @@ TEST(views_name_a_token_policy_on_its_own) {
   const std::array<std::string_view, 1> paths{{"/machine"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "machine"}}};
+        .name = "machine",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://idp.example.com/realms/staff"}}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
@@ -4757,13 +5036,14 @@ TEST(views_combine_token_policies_that_name_one_issuer) {
   const std::array<std::string_view, 1> tech_paths{{"/tech"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = legal_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "legal"},
+        .name = "legal",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "https://idp.example.com/realms/staff"}},
        {.paths = tech_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "tech"}}};
+        .name = "tech",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://idp.example.com/realms/staff"}}}};
 
   // A claim is a list and a rule is met by any of its values, so one token can
   // satisfy both
@@ -4780,13 +5060,14 @@ TEST(views_never_combine_token_policies_across_issuers) {
   const std::array<std::string_view, 1> partner_paths{{"/partners"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = staff_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "staff"},
+        .name = "staff",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "https://idp.example.com/realms/staff"}},
        {.paths = partner_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.partner.com/realms/main",
-        .name = "partner"}}};
+        .name = "partner",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://idp.partner.com/realms/main"}}}};
 
   // A token carries one issuer and is verified against it before any rule is
   // read, so nobody can ever hold both
@@ -4802,15 +5083,16 @@ TEST(views_never_combine_token_policies_testing_one_claim_across_issuers) {
   const std::array<std::string_view, 1> partner_paths{{"/partners"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = legal_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .claims = R"({"department":{"values":["legal"]}})",
-        .name = "legal"},
+        .name = "legal",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "https://idp.example.com/realms/staff",
+                .claims = R"({"department":{"values":["legal"]}})"}},
        {.paths = partner_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.partner.com/realms/main",
-        .claims = R"({"department":{"values":["legal"]}})",
-        .name = "partner-legal"}}};
+        .name = "partner-legal",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://idp.partner.com/realms/main",
+            .claims = R"({"department":{"values":["legal"]}})"}}}};
 
   // The issuer is decisive and is read first, so testing the same claim for the
   // same value means nothing across them
@@ -4826,13 +5108,14 @@ TEST(views_never_combine_interactive_policies_under_one_issuer) {
   const std::array<std::string_view, 1> second_paths{{"/two"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = first_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "first"},
+        .name = "first",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "https://idp.example.com/realms/staff"}},
        {.paths = second_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "second"}}};
+        .name = "second",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://idp.example.com/realms/staff"}}}};
 
   // A browser holds one session naming one policy, so sharing an issuer buys an
   // interactive caller nothing
@@ -4850,13 +5133,14 @@ TEST(views_never_combine_static_key_policies) {
   const std::array<std::string_view, 1> second_keys{{"two-secret"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = first_paths,
-        .keys = first_keys,
-        .type = sourcemeta::one::Authentication::Type::ApiKey,
-        .name = "first"},
+        .name = "first",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys =
+                                                                first_keys}},
        {.paths = second_paths,
-        .keys = second_keys,
-        .type = sourcemeta::one::Authentication::Type::ApiKey,
-        .name = "second"}}};
+        .name = "second",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = second_keys}}}};
 
   // A caller presents one key, so it satisfies one of these whatever it holds
   const auto views{sourcemeta::one::Authentication::views(policies)};
@@ -4871,13 +5155,14 @@ TEST(views_spell_a_combination_the_same_however_it_was_declared) {
   const std::array<std::string_view, 1> legal_paths{{"/legal"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = tech_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "tech"},
+        .name = "tech",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "https://idp.example.com/realms/staff"}},
        {.paths = legal_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "legal"}}};
+        .name = "legal",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://idp.example.com/realms/staff"}}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
@@ -4891,17 +5176,19 @@ TEST(views_of_three_token_policies_under_one_issuer_are_every_combination) {
   const std::array<std::string_view, 1> paths{{"/one"}};
   const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
       {{.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "a"},
+        .name = "a",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "https://idp.example.com/realms/staff"}},
        {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "b"},
+        .name = "b",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "https://idp.example.com/realms/staff"}},
        {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "c"}}};
+        .name = "c",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://idp.example.com/realms/staff"}}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
@@ -4920,17 +5207,18 @@ TEST(views_mix_a_combining_group_with_policies_that_stand_alone) {
   const std::array<std::string_view, 1> keys{{"secret"}};
   const std::array<sourcemeta::one::Authentication::Policy, 3> policies{
       {{.paths = paths,
-        .keys = keys,
-        .type = sourcemeta::one::Authentication::Type::ApiKey,
-        .name = "vault"},
+        .name = "vault",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}},
        {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "legal"},
+        .name = "legal",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "https://idp.example.com/realms/staff"}},
        {.paths = paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "tech"}}};
+        .name = "tech",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://idp.example.com/realms/staff"}}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
@@ -4946,9 +5234,9 @@ TEST(views_hold_the_public_one_even_when_every_path_is_governed) {
   const std::array<std::string_view, 1> keys{{"secret"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .keys = keys,
-        .type = sourcemeta::one::Authentication::Type::ApiKey,
-        .name = "everything"}}};
+        .name = "everything",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
@@ -4962,9 +5250,10 @@ TEST(views_of_six_token_policies_under_one_issuer_are_every_combination) {
   const std::array<std::string_view, 6> names{{"a", "b", "c", "d", "e", "f"}};
   for (std::size_t index{0}; index < policies.size(); index++) {
     policies.at(index).paths = paths;
-    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
-    policies.at(index).issuer = "https://idp.example.com/realms/staff";
     policies.at(index).name = names.at(index);
+    policies.at(index).credential =
+        sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://idp.example.com/realms/staff"};
   }
 
   // Two to the sixth, being every non-empty combination plus the anonymous one
@@ -4979,11 +5268,11 @@ TEST(views_of_two_issuer_groups_are_a_sum_rather_than_a_product) {
       {"a", "b", "c", "d", "e", "f", "g", "h"}};
   for (std::size_t index{0}; index < policies.size(); index++) {
     policies.at(index).paths = paths;
-    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
-    policies.at(index).issuer = index < 4
-                                    ? "https://idp.example.com/realms/staff"
-                                    : "https://idp.partner.com/realms/main";
     policies.at(index).name = names.at(index);
+    policies.at(index).credential =
+        sourcemeta::one::Authentication::Policy::Token{
+            .issuer = index < 4 ? "https://idp.example.com/realms/staff"
+                                : "https://idp.partner.com/realms/main"};
   }
 
   // Each group contributes its own combinations and nothing crosses between
@@ -5005,9 +5294,10 @@ TEST(views_of_the_largest_combinable_group_are_every_combination) {
 
   for (std::size_t index{0}; index < policies.size(); index++) {
     policies.at(index).paths = paths;
-    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
-    policies.at(index).issuer = "https://idp.example.com/realms/staff";
     policies.at(index).name = names.at(index);
+    policies.at(index).credential =
+        sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://idp.example.com/realms/staff"};
   }
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
@@ -5030,9 +5320,10 @@ TEST(views_refuse_a_group_whose_combinations_cannot_be_produced) {
 
   for (std::size_t index{0}; index < policies.size(); index++) {
     policies.at(index).paths = paths;
-    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
-    policies.at(index).issuer = "https://idp.example.com/realms/staff";
     policies.at(index).name = names.at(index);
+    policies.at(index).credential =
+        sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://idp.example.com/realms/staff"};
   }
 
   try {
@@ -5061,9 +5352,10 @@ TEST(views_of_many_policies_across_issuers_are_never_refused) {
   // refused. What a build makes of forty views is not decided here
   for (std::size_t index{0}; index < policies.size(); index++) {
     policies.at(index).paths = paths;
-    policies.at(index).type = sourcemeta::one::Authentication::Type::JWT;
-    policies.at(index).issuer = names.at(index);
     policies.at(index).name = names.at(index);
+    policies.at(index).credential =
+        sourcemeta::one::Authentication::Policy::Token{.issuer =
+                                                           names.at(index)};
   }
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
@@ -5080,48 +5372,42 @@ TEST(a_presented_key_decides_over_a_session) {
       {"ONE_TEST_PRECEDENCE_KEY"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = portal_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_PRECEDENCE_SECRET",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS},
-       {.paths = machine_paths, .keys = machine_keys, .name = "machine"}}};
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "acme",
+                .client_id = "client",
+                .client_secret_variable = "ONE_TEST_PRECEDENCE_SECRET",
+                .session_secrets = SESSION_SECRETS}},
+       {.paths = machine_paths,
+        .name = "machine",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = machine_keys}}}};
   const auto path{test_path("precedence.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta", "subject": "jane@acme.test" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "jane@acme.test")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
 
   // Each alone opens what it governs, which is what makes the pair below a
   // choice between two live credentials rather than one working answer
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
-  EXPECT_TRUE(
-      authentication.admits(at("/machine/x"), {.bearer = "machine-secret"})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)})));
+  EXPECT_TRUE(authentication.permits(
+      at("/machine/x"), authentication.caller({.bearer = "machine-secret"})));
 
   // Presented together, the request is read as the key it carried, so the
   // portal the session would have opened is refused
-  EXPECT_FALSE(authentication
-                   .admits(at("/portal/x"), {.bearer = "machine-secret",
-                                             .cookies = fields(cookies)})
-                   .allowed);
-  const auto verdict{
-      authentication.admits(at("/machine/x"), {.bearer = "machine-secret",
-                                               .cookies = fields(cookies)})};
-  EXPECT_TRUE(verdict.allowed);
-  EXPECT_TRUE(verdict.principal.has_value());
-  EXPECT_EQ(verdict.principal.value().type,
-            sourcemeta::one::Authentication::Type::ApiKey);
-  EXPECT_EQ(verdict.principal.value().policy, std::size_t{1});
+  EXPECT_FALSE(authentication.permits(
+      at("/portal/x"), authentication.caller({.bearer = "machine-secret",
+                                              .cookies = fields(cookies)})));
+  const auto permitted{authentication.permits(
+      at("/machine/x"), authentication.caller({.bearer = "machine-secret",
+                                               .cookies = fields(cookies)}))};
+  EXPECT_TRUE(permitted);
 }
 
 TEST(a_presented_key_that_opens_nothing_sets_a_session_aside) {
@@ -5133,38 +5419,37 @@ TEST(a_presented_key_that_opens_nothing_sets_a_session_aside) {
   const std::array<std::string_view, 1> machine_keys{{"ONE_TEST_FALLBACK_KEY"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = portal_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_FALLBACK_SECRET",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS},
-       {.paths = machine_paths, .keys = machine_keys, .name = "machine"}}};
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "acme",
+                .client_id = "client",
+                .client_secret_variable = "ONE_TEST_FALLBACK_SECRET",
+                .session_secrets = SESSION_SECRETS}},
+       {.paths = machine_paths,
+        .name = "machine",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = machine_keys}}}};
   const auto path{test_path("precedence_stale.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta", "subject": "jane@acme.test" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "jane@acme.test")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
 
   // A key that opens nothing is still a key that was presented, so the session
   // is set aside and nothing admits. The cost of the rule, and the reason it is
   // worth stating rather than leaving to be discovered
-  EXPECT_FALSE(authentication
-                   .admits(at("/portal/x"), {.bearer = "retired-secret",
-                                             .cookies = fields(cookies)})
-                   .allowed);
+  EXPECT_FALSE(authentication.permits(
+      at("/portal/x"), authentication.caller({.bearer = "retired-secret",
+                                              .cookies = fields(cookies)})));
 
   // The same session presented on its own still opens it, so what changed is
   // what the request carried rather than whether the session is any good
-  EXPECT_TRUE(
-      authentication
-          .admits(at("/portal/x"), {.bearer = "", .cookies = fields(cookies)})
-          .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller({.bearer = "", .cookies = fields(cookies)})));
 }
 
 TEST(a_caller_presenting_nothing_is_served_the_anonymous_view) {
@@ -5172,15 +5457,20 @@ TEST(a_caller_presenting_nothing_is_served_the_anonymous_view) {
   const std::array<std::string_view, 1> paths{{"/machine"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_VIEW_ANONYMOUS_KEY"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "machine"}}};
+      {{.paths = paths,
+        .name = "machine",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("view_anonymous.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_EQ(authentication.view({.bearer = ""}), "public");
-  EXPECT_EQ(authentication.view({.bearer = "retired-secret"}), "public");
-  EXPECT_EQ(authentication.view({.bearer = "machine-secret"}), "machine");
+  EXPECT_EQ(authentication.caller({.bearer = ""}).view(), "public");
+  EXPECT_EQ(authentication.caller({.bearer = "retired-secret"}).view(),
+            "public");
+  EXPECT_EQ(authentication.caller({.bearer = "machine-secret"}).view(),
+            "machine");
 }
 
 TEST(a_token_satisfying_two_policies_is_served_their_combined_view) {
@@ -5190,44 +5480,51 @@ TEST(a_token_satisfying_two_policies_is_served_their_combined_view) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = platform_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_ONE_GROUP,
-        .name = "platform"},
+        .name = "platform",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = algorithms,
+                .claims = CLAIMS_ONE_GROUP}},
        {.paths = oncall_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_ONCALL_GROUP,
-        .name = "oncall"}}};
+        .name = "oncall",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_ONCALL_GROUP}}}};
   const auto path{test_path("view_token_groups.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
-  EXPECT_EQ(
-      authentication.view(
-          {.bearer = token_with(R"JSON({ "groups": [ "platform" ] })JSON")}),
-      "platform");
-  EXPECT_EQ(authentication.view({.bearer = token_with(
-                                     R"JSON({ "groups": [ "oncall" ] })JSON")}),
+  EXPECT_EQ(authentication
+                .caller({.bearer = token_with(
+                             R"JSON({ "groups": [ "platform" ] })JSON")})
+                .view(),
+            "platform");
+  EXPECT_EQ(authentication
+                .caller({.bearer = token_with(
+                             R"JSON({ "groups": [ "oncall" ] })JSON")})
+                .view(),
             "oncall");
   // Spelled from the policies sorted rather than in the order they were
   // declared, so one combination has one name wherever it is reached from
-  EXPECT_EQ(authentication.view(
-                {.bearer = token_with(
-                     R"JSON({ "groups": [ "oncall", "platform" ] })JSON")}),
-            "oncall+platform");
   EXPECT_EQ(
-      authentication.view(
-          {.bearer = token_with(R"JSON({ "groups": [ "support" ] })JSON")}),
-      "public");
+      authentication
+          .caller({.bearer = token_with(
+                       R"JSON({ "groups": [ "oncall", "platform" ] })JSON")})
+          .view(),
+      "oncall+platform");
+  EXPECT_EQ(authentication
+                .caller({.bearer = token_with(
+                             R"JSON({ "groups": [ "support" ] })JSON")})
+                .view(),
+            "public");
 }
 
 TEST(the_recorded_table_names_a_view_at_every_index) {
@@ -5237,21 +5534,22 @@ TEST(the_recorded_table_names_a_view_at_every_index) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = platform_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "platform"},
+        .name = "platform",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = algorithms}},
        {.paths = oncall_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "oncall"}}};
+        .name = "oncall",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("recorded_table.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -5279,21 +5577,22 @@ TEST(a_view_shows_what_it_governs_and_whatever_nobody_governs) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = platform_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "platform"},
+        .name = "platform",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = algorithms}},
        {.paths = oncall_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .name = "oncall"}}};
+        .name = "oncall",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms}}}};
   const auto path{test_path("view_visibility.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -5327,7 +5626,8 @@ TEST(an_instance_that_read_no_artifact_shows_nothing) {
       stub_fetcher({}, nullptr)};
   // It admits nobody, so it must not answer that everything is public either,
   // which is what knowing nothing about who governs what would otherwise mean
-  EXPECT_FALSE(authentication.admits(at("/anywhere"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(at("/anywhere"),
+                                      authentication.caller({.bearer = ""})));
   EXPECT_EQ(authentication.view_count(), std::size_t{0});
   EXPECT_FALSE(authentication.visible(at("/anywhere"), 0));
   EXPECT_FALSE(authentication.visible(at("/"), 0));
@@ -5342,7 +5642,8 @@ TEST(a_corrupt_artifact_shows_nothing) {
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(authentication.admits(at("/anywhere"), {.bearer = ""}).allowed);
+  EXPECT_FALSE(authentication.permits(at("/anywhere"),
+                                      authentication.caller({.bearer = ""})));
   EXPECT_EQ(authentication.view_count(), std::size_t{0});
   EXPECT_FALSE(authentication.visible(at("/anywhere"), 0));
 }
@@ -5352,9 +5653,12 @@ TEST(an_index_naming_no_view_shows_nothing) {
   const std::array<std::string_view, 1> paths{{"/machine"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_VIEW_INDEX"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "machine"}}};
+      {{.paths = paths,
+        .name = "machine",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("visible_index.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
@@ -5373,14 +5677,17 @@ TEST(a_caller_presenting_nothing_belongs_to_no_policy) {
   const std::array<std::string_view, 1> keys{
       {"ONE_TEST_CLASSIFY_ANONYMOUS_KEY"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "machine"}}};
+      {{.paths = paths,
+        .name = "machine",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("classify_anonymous.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_EQ(authentication.classify({.bearer = ""}),
-            sourcemeta::one::Authentication::PolicySet{0});
+  EXPECT_EQ(authentication.caller({.bearer = ""}).view(),
+            sourcemeta::one::VIEW_PUBLIC);
 }
 
 TEST(a_credential_opening_nothing_belongs_to_no_policy) {
@@ -5388,14 +5695,17 @@ TEST(a_credential_opening_nothing_belongs_to_no_policy) {
   const std::array<std::string_view, 1> paths{{"/machine"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_CLASSIFY_UNKNOWN_KEY"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "machine"}}};
+      {{.paths = paths,
+        .name = "machine",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("classify_unknown.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_EQ(authentication.classify({.bearer = "retired-secret"}),
-            sourcemeta::one::Authentication::PolicySet{0});
+  EXPECT_EQ(authentication.caller({.bearer = "retired-secret"}).view(),
+            sourcemeta::one::VIEW_PUBLIC);
 }
 
 TEST(a_key_places_its_caller_in_the_policy_it_opens) {
@@ -5408,17 +5718,23 @@ TEST(a_key_places_its_caller_in_the_policy_it_opens) {
   const std::array<std::string_view, 1> second_keys{
       {"ONE_TEST_CLASSIFY_SECOND_KEY"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = first_paths, .keys = first_keys, .name = "first"},
-       {.paths = second_paths, .keys = second_keys, .name = "second"}}};
+      {{.paths = first_paths,
+        .name = "first",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys =
+                                                                first_keys}},
+       {.paths = second_paths,
+        .name = "second",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = second_keys}}}};
   const auto path{test_path("classify_key.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  EXPECT_EQ(authentication.classify({.bearer = "first-secret"}),
-            sourcemeta::one::Authentication::PolicySet{0b01});
-  EXPECT_EQ(authentication.classify({.bearer = "second-secret"}),
-            sourcemeta::one::Authentication::PolicySet{0b10});
+  EXPECT_EQ(authentication.caller({.bearer = "first-secret"}).view(), "first");
+  EXPECT_EQ(authentication.caller({.bearer = "second-secret"}).view(),
+            "second");
 }
 
 TEST(a_key_is_placed_without_reference_to_any_path) {
@@ -5426,43 +5742,41 @@ TEST(a_key_is_placed_without_reference_to_any_path) {
   const std::array<std::string_view, 1> paths{{"/deep/inside/somewhere"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_CLASSIFY_DEEP_KEY"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths, .keys = keys, .name = "deep"}}};
+      {{.paths = paths,
+        .name = "deep",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const auto path{test_path("classify_deep.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // Admitted under the policy where it governs, so the gate has read the key
-  const auto governed{authentication.admits(at("/deep/inside/somewhere/x"),
-                                            {.bearer = "deep-secret"})};
-  EXPECT_TRUE(governed.allowed);
-  EXPECT_TRUE(governed.principal.has_value());
-  EXPECT_EQ(governed.principal.value().type,
-            sourcemeta::one::Authentication::Type::ApiKey);
-  EXPECT_EQ(governed.principal.value().policy, std::size_t{0});
+  const auto governed{
+      authentication.permits(at("/deep/inside/somewhere/x"),
+                             authentication.caller({.bearer = "deep-secret"}))};
+  EXPECT_TRUE(governed);
 
   // Admitted anonymously where no policy governs, which is a different answer
   // reached without reading the key at all
-  const auto ungoverned{
-      authentication.admits(at("/elsewhere"), {.bearer = "deep-secret"})};
-  EXPECT_TRUE(ungoverned.allowed);
-  EXPECT_FALSE(ungoverned.principal.has_value());
+  const auto ungoverned{authentication.permits(
+      at("/elsewhere"), authentication.caller({.bearer = "deep-secret"}))};
+  EXPECT_TRUE(ungoverned);
 
   // The same answer for a caller carrying nothing, so being admitted there says
   // nothing about who is asking
-  const auto anonymous{authentication.admits(at("/elsewhere"), {.bearer = ""})};
-  EXPECT_TRUE(anonymous.allowed);
-  EXPECT_FALSE(anonymous.principal.has_value());
+  const auto anonymous{authentication.permits(
+      at("/elsewhere"), authentication.caller({.bearer = ""}))};
+  EXPECT_TRUE(anonymous);
 
   // The placement answers once for the caller, naming the policy the key opens
   // wherever they happen to be asking from
-  EXPECT_EQ(authentication.classify({.bearer = "deep-secret"}),
-            sourcemeta::one::Authentication::PolicySet{0b1});
-  EXPECT_EQ(authentication.classify({.bearer = ""}),
-            sourcemeta::one::Authentication::PolicySet{0});
+  EXPECT_EQ(authentication.caller({.bearer = "deep-secret"}).view(), "deep");
+  EXPECT_EQ(authentication.caller({.bearer = ""}).view(),
+            sourcemeta::one::VIEW_PUBLIC);
 }
 
-TEST(a_key_opening_two_policies_is_read_as_the_first_declared) {
+TEST(a_key_opening_two_policies_reaches_only_the_first_declared) {
   setenv("ONE_TEST_CLASSIFY_SHARED_EARLY", "shared-secret", 1);
   setenv("ONE_TEST_CLASSIFY_SHARED_LATE", "shared-secret", 1);
   const std::array<std::string_view, 1> early_paths{{"/early"}};
@@ -5472,30 +5786,36 @@ TEST(a_key_opening_two_policies_is_read_as_the_first_declared) {
   const std::array<std::string_view, 1> late_keys{
       {"ONE_TEST_CLASSIFY_SHARED_LATE"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = early_paths, .keys = early_keys, .name = "early"},
-       {.paths = late_paths, .keys = late_keys, .name = "late"}}};
+      {{.paths = early_paths,
+        .name = "early",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys =
+                                                                early_keys}},
+       {.paths = late_paths,
+        .name = "late",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = late_keys}}}};
   const auto path{test_path("classify_shared.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
   // Two variables holding one value is the form the configuration cannot see,
-  // so one key is admitted under each policy in turn
-  const auto early{
-      authentication.admits(at("/early/x"), {.bearer = "shared-secret"})};
-  EXPECT_TRUE(early.allowed);
-  EXPECT_TRUE(early.principal.has_value());
-  EXPECT_EQ(early.principal.value().policy, std::size_t{0});
-  const auto late{
-      authentication.admits(at("/late/x"), {.bearer = "shared-secret"})};
-  EXPECT_TRUE(late.allowed);
-  EXPECT_TRUE(late.principal.has_value());
-  EXPECT_EQ(late.principal.value().policy, std::size_t{1});
+  // and it is the only shape where being admitted and being shown could ever
+  // have parted. A caller is read as the first policy their key opens, and what
+  // they reach is what that placement holds, so the second policy's area is not
+  // theirs. It never was in any useful sense: the answer served there would
+  // have been read from a view that does not hold it
+  const auto early{authentication.permits(
+      at("/early/x"), authentication.caller({.bearer = "shared-secret"}))};
+  EXPECT_TRUE(early);
+  const auto late{authentication.permits(
+      at("/late/x"), authentication.caller({.bearer = "shared-secret"}))};
+  EXPECT_FALSE(late);
 
-  // And the placement still names one of them, which is the cost of reading a
-  // key as the first policy it opens
-  EXPECT_EQ(authentication.classify({.bearer = "shared-secret"}),
-            sourcemeta::one::Authentication::PolicySet{0b01});
+  // What is reached and where it is read from are one answer, which is what
+  // naming the placement here pins
+  EXPECT_EQ(authentication.caller({.bearer = "shared-secret"}).view(), "early");
 }
 
 TEST(a_token_belongs_to_every_policy_of_its_issuer_that_it_satisfies) {
@@ -5505,45 +5825,51 @@ TEST(a_token_belongs_to_every_policy_of_its_issuer_that_it_satisfies) {
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = platform_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_ONE_GROUP,
-        .name = "platform"},
+        .name = "platform",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "acme",
+                .audience = "client",
+                .jwks_uri = "https://idp.test/jwks",
+                .algorithms = algorithms,
+                .claims = CLAIMS_ONE_GROUP}},
        {.paths = oncall_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "acme",
-        .audience = "client",
-        .jwks_uri = "https://idp.test/jwks",
-        .algorithms = algorithms,
-        .claims = CLAIMS_ONCALL_GROUP,
-        .name = "oncall"}}};
+        .name = "oncall",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "acme",
+            .audience = "client",
+            .jwks_uri = "https://idp.test/jwks",
+            .algorithms = algorithms,
+            .claims = CLAIMS_ONCALL_GROUP}}}};
   const auto path{test_path("classify_token_groups.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
                          nullptr)};
-  EXPECT_EQ(
-      authentication.classify(
-          {.bearer = token_with(R"JSON({ "groups": [ "platform" ] })JSON")}),
-      sourcemeta::one::Authentication::PolicySet{0b01});
-  EXPECT_EQ(
-      authentication.classify(
-          {.bearer = token_with(R"JSON({ "groups": [ "oncall" ] })JSON")}),
-      sourcemeta::one::Authentication::PolicySet{0b10});
+  EXPECT_EQ(authentication
+                .caller({.bearer = token_with(
+                             R"JSON({ "groups": [ "platform" ] })JSON")})
+                .view(),
+            "platform");
+  EXPECT_EQ(authentication
+                .caller({.bearer = token_with(
+                             R"JSON({ "groups": [ "oncall" ] })JSON")})
+                .view(),
+            "oncall");
   // One token carrying both reaches both areas, so a placement naming either
   // alone would hide one of them
-  EXPECT_EQ(authentication.classify(
-                {.bearer = token_with(
-                     R"JSON({ "groups": [ "oncall", "platform" ] })JSON")}),
-            sourcemeta::one::Authentication::PolicySet{0b11});
   EXPECT_EQ(
-      authentication.classify(
-          {.bearer = token_with(R"JSON({ "groups": [ "support" ] })JSON")}),
-      sourcemeta::one::Authentication::PolicySet{0});
+      authentication
+          .caller({.bearer = token_with(
+                       R"JSON({ "groups": [ "oncall", "platform" ] })JSON")})
+          .view(),
+      "oncall+platform");
+  EXPECT_EQ(authentication
+                .caller({.bearer = token_with(
+                             R"JSON({ "groups": [ "support" ] })JSON")})
+                .view(),
+            sourcemeta::one::VIEW_PUBLIC);
 }
 
 TEST(a_session_places_its_caller_in_the_policy_that_established_it) {
@@ -5556,34 +5882,109 @@ TEST(a_session_places_its_caller_in_the_policy_that_established_it) {
       {"ONE_TEST_CLASSIFY_SESSION_KEY"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = portal_paths,
-        .type = sourcemeta::one::Authentication::Type::OIDC,
-        .issuer = "acme",
-        .client_id = "client",
-        .client_secret_variable = "ONE_TEST_CLASSIFY_SESSION_SECRET",
         .name = "okta",
-        .session_secrets = SESSION_SECRETS},
-       {.paths = machine_paths, .keys = machine_keys, .name = "machine"}}};
+        .credential =
+            sourcemeta::one::Authentication::Policy::Interactive{
+                .issuer = "acme",
+                .client_id = "client",
+                .client_secret_variable = "ONE_TEST_CLASSIFY_SESSION_SECRET",
+                .session_secrets = SESSION_SECRETS}},
+       {.paths = machine_paths,
+        .name = "machine",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = machine_keys}}}};
   const auto path{test_path("classify_session.bin")};
-  sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+  save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
       path, stub_fetcher({}, nullptr)};
-  const auto sealed{sourcemeta::one::Authentication::seal_value(
-      R"JSON({ "policy": "okta", "subject": "jane@acme.test" })JSON",
-      sourcemeta::one::Authentication::Purpose::Session, SESSION_SECRET,
-      minted_now(), session_expiry())};
+  const auto sealed{session_for("okta", SESSION_SECRETS, "jane@acme.test")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
 
-  EXPECT_EQ(authentication.classify({.bearer = "", .cookies = fields(cookies)}),
-            sourcemeta::one::Authentication::PolicySet{0b01});
-  EXPECT_EQ(authentication.classify({.bearer = "machine-secret"}),
-            sourcemeta::one::Authentication::PolicySet{0b10});
+  EXPECT_EQ(
+      authentication.caller({.bearer = "", .cookies = fields(cookies)}).view(),
+      "okta");
+  EXPECT_EQ(authentication.caller({.bearer = "machine-secret"}).view(),
+            "machine");
   // A request carrying a key is read as that key, so the session it also
   // carried places nobody, exactly as it admits nobody
-  EXPECT_EQ(authentication.classify(
-                {.bearer = "machine-secret", .cookies = fields(cookies)}),
-            sourcemeta::one::Authentication::PolicySet{0b10});
-  EXPECT_EQ(authentication.classify(
-                {.bearer = "retired-secret", .cookies = fields(cookies)}),
-            sourcemeta::one::Authentication::PolicySet{0});
+  EXPECT_EQ(
+      authentication
+          .caller({.bearer = "machine-secret", .cookies = fields(cookies)})
+          .view(),
+      "machine");
+  EXPECT_EQ(
+      authentication
+          .caller({.bearer = "retired-secret", .cookies = fields(cookies)})
+          .view(),
+      sourcemeta::one::VIEW_PUBLIC);
+}
+
+// A table compiled in this process reads every section from the bytes it holds
+// rather than from a mapping it does not have, so it answers a credential the
+// same way one read back from a file does
+TEST(a_compiled_table_reads_a_policy_without_a_mapping) {
+  setenv("ONE_TEST_COMPILED_KEY", "compiled-secret", 1);
+  const std::array<std::string_view, 1> paths{{"/private"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_COMPILED_KEY"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "guard",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
+
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("compiled_only"), anywhere),
+      stub_fetcher({}, nullptr)};
+
+  EXPECT_TRUE(authentication.permits(at("/open"), authentication.caller({})));
+  EXPECT_FALSE(
+      authentication.permits(at("/private"), authentication.caller({})));
+  EXPECT_TRUE(authentication.permits(
+      at("/private"), authentication.caller({.bearer = "compiled-secret"})));
+  EXPECT_FALSE(authentication.permits(
+      at("/private"), authentication.caller({.bearer = "wrong-secret"})));
+  EXPECT_EQ(authentication.caller({.bearer = "compiled-secret"}).view(),
+            "guard");
+}
+
+// A route nobody governs is reached by anybody, so an audience requirement on
+// it narrows nothing. Refusing a caller there for presenting a token issued
+// elsewhere would refuse them for holding a credential they did not need, at a
+// route they could have reached by presenting nothing at all
+TEST(an_ungoverned_route_ignores_the_audience_it_requires) {
+  setenv("ONE_TEST_UNGOVERNED_ROUTE_KEY", "elsewhere-secret", 1);
+  const std::array<std::string_view, 1> paths{{"/elsewhere"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_UNGOVERNED_ROUTE_KEY"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "elsewhere",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
+
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("ungoverned_route"), anywhere),
+      stub_fetcher({}, nullptr)};
+
+  const sourcemeta::one::RouteTarget target{"/self/v1/mcp"};
+
+  // Nobody governs it, so it opens whatever the caller brought
+  EXPECT_TRUE(authentication.permits(target, authentication.caller({}),
+                                     "https://example.com/self/v1/mcp"));
+  EXPECT_TRUE(authentication.permits(
+      target, authentication.caller({.bearer = "elsewhere-secret"}),
+      "https://example.com/self/v1/mcp"));
+
+  // And the same route without a requirement answers identically, which is
+  // what shows the requirement is what did nothing rather than the route
+  EXPECT_TRUE(authentication.permits(target, authentication.caller({})));
+
+  // A governed path still answers to who is asking
+  EXPECT_FALSE(
+      authentication.permits(at("/elsewhere/x"), authentication.caller({})));
+  EXPECT_TRUE(authentication.permits(
+      at("/elsewhere/x"),
+      authentication.caller({.bearer = "elsewhere-secret"})));
 }

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -5988,3 +5988,48 @@ TEST(an_ungoverned_route_ignores_the_audience_it_requires) {
       at("/elsewhere/x"),
       authentication.caller({.bearer = "elsewhere-secret"})));
 }
+
+// The other direction of the same separation. A session is what somebody holds
+// once they are signed in, and a transaction is what anybody may obtain without
+// holding anything, so reading either as the other is what the purposes exist
+// to stop. Both are sealed under one policy secret, so nothing but the purpose
+// tells them apart
+TEST(a_session_never_opens_as_a_transaction) {
+  setenv("ONE_TEST_PURPOSE_BACK", "confidential", 1);
+  setenv(SESSION_SECRET_VARIABLE, "session-secret", 1);
+  Provider provider;
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = provider.issuer,
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_PURPOSE_BACK",
+            .session_secrets = SESSION_SECRETS}}}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::compile(
+          policies, test_path("purpose_back"), anywhere),
+      provider.fetcher()};
+
+  // A session this instance established, obtained the way anybody obtains one
+  const auto established{session_for("okta", SESSION_SECRETS, "jane")};
+
+  // Presented where a callback looks for the transaction it is completing. It
+  // cannot open there, so the callback is refused before the provider is
+  // consulted at all
+  const auto carried{"sourcemeta_one_transaction=" + established};
+  const std::array<std::string_view, 1> presented{{carried}};
+  const auto outcome{authentication.callback(
+      "okta", "https://registry.test", "https://registry.test/callback",
+      {.state = "any-state", .code = "a-code"}, {.cookies = presented})};
+  EXPECT_EQ(outcome.result,
+            sourcemeta::one::Authentication::Outcome::Result::Invalid);
+
+  // And the control: the same value read as what it is does open, so the
+  // refusal above came from the purpose rather than from the value
+  const auto as_a_session{"sourcemeta_one_session=" + established};
+  EXPECT_TRUE(authentication.permits(
+      at("/portal/x"),
+      authentication.caller({.cookies = fields(as_a_session)})));
+}

--- a/src/actions/action_auth_callback_v1.h
+++ b/src/actions/action_auth_callback_v1.h
@@ -49,8 +49,9 @@ public:
     return true;
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);
@@ -79,7 +80,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/actions/action_auth_login_page_v1.h
+++ b/src/actions/action_auth_login_page_v1.h
@@ -48,8 +48,9 @@ public:
     return true;
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);
@@ -78,7 +79,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/actions/action_auth_login_v1.h
+++ b/src/actions/action_auth_login_v1.h
@@ -49,8 +49,9 @@ public:
     return true;
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);
@@ -79,7 +80,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/actions/action_auth_logout_v1.h
+++ b/src/actions/action_auth_logout_v1.h
@@ -43,8 +43,9 @@ public:
         });
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);
@@ -77,7 +78,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/actions/action_default_v1.h
+++ b/src/actions/action_default_v1.h
@@ -42,8 +42,9 @@ public:
         });
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view credential,
-            std::string_view view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &caller,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",
@@ -76,8 +77,7 @@ public:
       const auto serve_html{
           sourcemeta::one::prefers_html(request.header("accept"))};
       const auto root_html{this->artifact_resolve_path(
-          view, {.bearer = credential, .cookies = cookies}, "", Tree::Explorer,
-          "directory-html")};
+          caller, "", Tree::Explorer, "directory-html")};
       if (serve_html && root_html.path.has_value()) {
         this->artifact_serve(
             root_html.path.value(), sourcemeta::core::HTTP_STATUS_OK, false, {},
@@ -85,7 +85,7 @@ public:
             this->content_cache_control(root_html.is_public),
             "Accept, Accept-Encoding");
       } else if (serve_html) {
-        this->serve_missing_html(view, request, response);
+        this->serve_missing_html(caller.view(), request, response);
       } else {
         sourcemeta::one::json_error(
             request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
@@ -98,7 +98,7 @@ public:
     const auto stripped_json{
         sourcemeta::core::remove_suffix_ignore_case(path, ".json")};
     if (stripped_json.size() != path.size()) {
-      ActionJSONSchemaServe_v1::serve(*this, credential, stripped_json, request,
+      ActionJSONSchemaServe_v1::serve(*this, caller, stripped_json, request,
                                       response, this->error_schema_);
       return;
     }
@@ -106,11 +106,9 @@ public:
     if (request.method() == "get" || request.method() == "head") {
       if (sourcemeta::one::prefers_html(request.header("accept"))) {
         const auto schema_html{this->artifact_resolve_path(
-            view, {.bearer = credential, .cookies = cookies}, path,
-            Tree::Explorer, "schema-html")};
+            caller, path, Tree::Explorer, "schema-html")};
         const auto directory_html{this->artifact_resolve_path(
-            view, {.bearer = credential, .cookies = cookies}, path,
-            Tree::Explorer, "directory-html")};
+            caller, path, Tree::Explorer, "directory-html")};
         if (!path.ends_with("/") && schema_html.path.has_value()) {
           this->artifact_serve(
               schema_html.path.value(), sourcemeta::core::HTTP_STATUS_OK, false,
@@ -126,26 +124,22 @@ public:
               this->content_cache_control(directory_html.is_public),
               "Accept, Accept-Encoding");
         } else {
-          this->serve_missing_html(view, request, response);
+          this->serve_missing_html(caller.view(), request, response);
         }
       } else {
-        ActionJSONSchemaServe_v1::serve(*this, credential, path, request,
-                                        response, this->error_schema_);
+        ActionJSONSchemaServe_v1::serve(*this, caller, path, request, response,
+                                        this->error_schema_);
       }
     } else {
       // RFC 9110 §15.5.6: when the path resolves to an existing resource
       // the response must be 405 with Allow listing what is supported.
       // https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.6
-      const auto schema_json{this->artifact_resolve_path(
-          sourcemeta::one::VIEW_PUBLIC,
-          {.bearer = credential, .cookies = cookies}, path, Tree::Schemas,
-          "schema")};
+      const auto schema_json{
+          this->artifact_resolve_path(caller, path, Tree::Schemas, "schema")};
       const auto schema_html{this->artifact_resolve_path(
-          view, {.bearer = credential, .cookies = cookies}, path,
-          Tree::Explorer, "schema-html")};
+          caller, path, Tree::Explorer, "schema-html")};
       const auto directory_html{this->artifact_resolve_path(
-          view, {.bearer = credential, .cookies = cookies}, path,
-          Tree::Explorer, "directory-html")};
+          caller, path, Tree::Explorer, "directory-html")};
       if (schema_json.path.has_value() ||
           (!path.ends_with("/") && schema_html.path.has_value()) ||
           directory_html.path.has_value()) {
@@ -165,7 +159,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/actions/action_dependency_tree_v1.h
+++ b/src/actions/action_dependency_tree_v1.h
@@ -53,7 +53,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, std::string_view view,
+            const sourcemeta::one::Authentication::Caller &caller,
             sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
@@ -83,8 +83,7 @@ public:
 
     const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{this->artifact_resolve_path(
-        view, {.bearer = credential, .cookies = cookies}, matches.front(),
-        this->tree_, this->metapack_)};
+        caller, matches.front(), this->tree_, this->metapack_)};
     if (!resolution.path.has_value()) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
@@ -101,7 +100,7 @@ public:
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
            const sourcemeta::core::JSON &arguments,
-           const sourcemeta::one::Credentials &credentials)
+           const sourcemeta::one::Authentication::Caller &caller)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
         this->structural_evaluate(this->rpc_request_schema_, arguments,
@@ -114,10 +113,9 @@ public:
 
     // A tool call reaches one artifact, so placing the caller here is still
     // once for the request that carried them
-    const auto view{this->dispatcher().authentication().view(credentials)};
-    const auto resolution{this->artifact_resolve_path(
-        view, credentials, arguments.at("schema").to_string(), this->tree_,
-        this->metapack_)};
+    const auto resolution{
+        this->artifact_resolve_path(caller, arguments.at("schema").to_string(),
+                                    this->tree_, this->metapack_)};
     if (!resolution.path.has_value()) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");

--- a/src/actions/action_health_check_v1.h
+++ b/src/actions/action_health_check_v1.h
@@ -37,8 +37,9 @@ public:
         });
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",
@@ -67,7 +68,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/actions/action_jsonschema_evaluate_v1.h
+++ b/src/actions/action_jsonschema_evaluate_v1.h
@@ -232,11 +232,7 @@ public:
         // handler
         // NOLINTNEXTLINE(bugprone-exception-escape)
         [response_schema, error_schema, schema_uri = std::move(schema_uri),
-         &self, request_schema,
-         bearer = std::string{sourcemeta::core::http_parse_bearer(
-             request.header("authorization"))},
-         cookies = sourcemeta::one::owned_cookies(request),
-         perform = std::move(perform)](
+         &self, request_schema, perform = std::move(perform)](
             sourcemeta::one::HTTPRequest &callback_request,
             sourcemeta::one::HTTPResponse &callback_response,
             std::string &&body, bool too_big) -> void {

--- a/src/actions/action_jsonschema_evaluate_v1.h
+++ b/src/actions/action_jsonschema_evaluate_v1.h
@@ -51,25 +51,29 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, std::string_view,
+            const sourcemeta::one::Authentication::Caller &caller,
             sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
-    const sourcemeta::one::RequestCookies cookies{request};
     ActionJSONSchemaEvaluate_v1::serve_post(
-        matches, {.bearer = credential, .cookies = cookies}, request, response,
-        *this, this->response_schema_, this->error_schema_,
-        this->request_schema_,
+        matches, caller, request, response, *this, this->response_schema_,
+        this->error_schema_, this->request_schema_,
         // A throw here is intended and caught by the surrounding request
         // handler
         // NOLINTNEXTLINE(bugprone-exception-escape)
-        [this, bearer = std::string{credential},
+        [this,
+         bearer = std::string{sourcemeta::core::http_parse_bearer(
+             request.header("authorization"))},
          cookies = sourcemeta::one::owned_cookies(request)](
             const std::string_view schema_uri,
             const std::string &body) -> sourcemeta::core::JSON {
           const sourcemeta::one::RequestCookies fields{cookies};
+          // Placed again rather than captured, since the caller this action
+          // was handed points at a request that is gone by now
+          const auto deferred_caller{
+              this->caller_from({.bearer = bearer, .cookies = fields})};
           return this
-              ->schema_evaluate({.bearer = bearer, .cookies = fields},
-                                schema_uri, sourcemeta::core::parse_json(body),
+              ->schema_evaluate(deferred_caller, schema_uri,
+                                sourcemeta::core::parse_json(body),
                                 sourcemeta::blaze::Mode::Exhaustive)
               .second;
         });
@@ -78,7 +82,7 @@ public:
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
            const sourcemeta::core::JSON &arguments,
-           const sourcemeta::one::Credentials &credentials)
+           const sourcemeta::one::Authentication::Caller &caller)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
         this->structural_evaluate(this->rpc_request_schema_, arguments,
@@ -90,12 +94,10 @@ public:
     }
 
     const auto &schema_uri{arguments.at("schema").to_string()};
-    const auto schema_present{
-        this->artifact_resolve_path(sourcemeta::one::VIEW_PUBLIC, credentials,
-                                    schema_uri, Tree::Schemas, "schema")};
+    const auto schema_present{this->artifact_resolve_path(
+        caller, schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
-        sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri, Tree::Schemas,
-        "blaze-exhaustive")};
+        caller, schema_uri, Tree::Schemas, "blaze-exhaustive")};
     if (!schema_present.path.has_value()) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");
@@ -120,14 +122,14 @@ public:
 
     return sourcemeta::core::mcp_make_tool_success(
         version, request_id,
-        this->schema_evaluate(credentials, schema_uri, parsed_instance,
+        this->schema_evaluate(caller, schema_uri, parsed_instance,
                               sourcemeta::blaze::Mode::Exhaustive)
             .second);
   }
 
   template <typename Perform>
   static auto serve_post(const std::span<std::string_view> matches,
-                         const sourcemeta::one::Credentials credentials,
+                         const sourcemeta::one::Authentication::Caller &caller,
                          sourcemeta::one::HTTPRequest &request,
                          sourcemeta::one::HTTPResponse &response,
                          const sourcemeta::one::RouterAction &self,
@@ -177,11 +179,11 @@ public:
     schema_uri.push_back('/');
     schema_uri.append(path);
     const auto schema_present{self.artifact_resolve_path(
-        sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri,
-        sourcemeta::one::RouterAction::Tree::Schemas, "schema")};
+        caller, schema_uri, sourcemeta::one::RouterAction::Tree::Schemas,
+        "schema")};
     const auto evaluation_enabled{self.artifact_resolve_path(
-        sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri,
-        sourcemeta::one::RouterAction::Tree::Schemas, "blaze-exhaustive")};
+        caller, schema_uri, sourcemeta::one::RouterAction::Tree::Schemas,
+        "blaze-exhaustive")};
     if (!schema_present.path.has_value()) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
@@ -230,9 +232,10 @@ public:
         // handler
         // NOLINTNEXTLINE(bugprone-exception-escape)
         [response_schema, error_schema, schema_uri = std::move(schema_uri),
-         &self, request_schema, bearer = std::string{credentials.bearer},
-         cookies = std::vector<std::string>{credentials.cookies.begin(),
-                                            credentials.cookies.end()},
+         &self, request_schema,
+         bearer = std::string{sourcemeta::core::http_parse_bearer(
+             request.header("authorization"))},
+         cookies = sourcemeta::one::owned_cookies(request),
          perform = std::move(perform)](
             sourcemeta::one::HTTPRequest &callback_request,
             sourcemeta::one::HTTPResponse &callback_response,
@@ -268,7 +271,6 @@ public:
             return;
           }
 
-          const sourcemeta::one::RequestCookies fields{cookies};
           if (!self.structural_evaluate_fast(request_schema, instance)) {
             sourcemeta::one::json_error(
                 callback_request, callback_response,

--- a/src/actions/action_jsonschema_rdf_v1.h
+++ b/src/actions/action_jsonschema_rdf_v1.h
@@ -46,8 +46,9 @@ public:
         });
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);
@@ -86,7 +87,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/actions/action_jsonschema_serve_v1.h
+++ b/src/actions/action_jsonschema_serve_v1.h
@@ -32,7 +32,8 @@ public:
   }
 
   static auto serve(const sourcemeta::one::RouterAction &self,
-                    std::string_view credential, std::string_view schema_path,
+                    const sourcemeta::one::Authentication::Caller &caller,
+                    std::string_view schema_path,
                     sourcemeta::one::HTTPRequest &request,
                     sourcemeta::one::HTTPResponse &response,
                     std::string_view error_schema) -> void {
@@ -60,9 +61,8 @@ public:
                                         : std::string_view{"schema"}};
     const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{self.artifact_resolve_path(
-        sourcemeta::one::VIEW_PUBLIC,
-        {.bearer = credential, .cookies = cookies}, schema_path,
-        sourcemeta::one::RouterAction::Tree::Schemas, artifact)};
+        caller, schema_path, sourcemeta::one::RouterAction::Tree::Schemas,
+        artifact)};
     if (!resolution.path.has_value()) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
@@ -85,7 +85,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, std::string_view,
+            const sourcemeta::one::Authentication::Caller &caller,
             sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
@@ -94,13 +94,13 @@ public:
                                       "If-Modified-Since");
       return;
     }
-    serve(*this, credential, matches.front(), request, response,
+    serve(*this, caller, matches.front(), request, response,
           this->error_schema_);
   }
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/actions/action_jsonschema_trace_v1.h
+++ b/src/actions/action_jsonschema_trace_v1.h
@@ -62,18 +62,19 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, std::string_view,
+            const sourcemeta::one::Authentication::Caller &caller,
             sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     const sourcemeta::one::RequestCookies cookies{request};
     ActionJSONSchemaEvaluate_v1::serve_post(
-        matches, {.bearer = credential, .cookies = cookies}, request, response,
-        *this, this->response_schema_, this->error_schema_,
-        this->request_schema_,
+        matches, caller, request, response, *this, this->response_schema_,
+        this->error_schema_, this->request_schema_,
         // A throw here is intended and caught by the surrounding request
         // handler
         // NOLINTNEXTLINE(bugprone-exception-escape)
-        [this, bearer = std::string{credential},
+        [this,
+         bearer = std::string{sourcemeta::core::http_parse_bearer(
+             request.header("authorization"))},
          cookies = sourcemeta::one::owned_cookies(request)](
             const std::string_view schema_uri,
             const std::string &body) -> sourcemeta::core::JSON {
@@ -81,16 +82,19 @@ public:
           sourcemeta::core::JSON instance_json{nullptr};
           sourcemeta::core::parse_json(body, instance_json, std::ref(tracker));
           const sourcemeta::one::RequestCookies fields{cookies};
-          return this->trace({.bearer = bearer, .cookies = fields}, schema_uri,
-                             instance_json, &tracker,
-                             sourcemeta::core::Pointer{});
+          // Placed again rather than captured, since the caller this action
+          // was handed points at a request that is gone by now
+          const auto deferred_caller{
+              this->caller_from({.bearer = bearer, .cookies = fields})};
+          return this->trace(deferred_caller, schema_uri, instance_json,
+                             &tracker, sourcemeta::core::Pointer{});
         });
   }
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
            const sourcemeta::core::JSON &arguments,
-           const sourcemeta::one::Credentials &credentials)
+           const sourcemeta::one::Authentication::Caller &caller)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
         this->structural_evaluate(this->rpc_request_schema_, arguments,
@@ -102,12 +106,10 @@ public:
     }
 
     const auto &schema_uri{arguments.at("schema").to_string()};
-    const auto schema_present{
-        this->artifact_resolve_path(sourcemeta::one::VIEW_PUBLIC, credentials,
-                                    schema_uri, Tree::Schemas, "schema")};
+    const auto schema_present{this->artifact_resolve_path(
+        caller, schema_uri, Tree::Schemas, "schema")};
     const auto evaluation_enabled{this->artifact_resolve_path(
-        sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri, Tree::Schemas,
-        "blaze-exhaustive")};
+        caller, schema_uri, Tree::Schemas, "blaze-exhaustive")};
     if (!schema_present.path.has_value()) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");
@@ -134,13 +136,13 @@ public:
 
     return sourcemeta::core::mcp_make_tool_success(
         version, request_id,
-        this->trace(credentials, schema_uri, parsed_instance, &tracker,
+        this->trace(caller, schema_uri, parsed_instance, &tracker,
                     sourcemeta::core::Pointer{}));
   }
 
 private:
   auto
-  resolve_vocabulary(const sourcemeta::one::Credentials credentials,
+  resolve_vocabulary(const sourcemeta::one::Authentication::Caller &caller,
                      const std::string_view keyword_location,
                      const sourcemeta::core::WeakPointer &evaluate_path,
                      const sourcemeta::core::JSON &static_locations,
@@ -158,8 +160,7 @@ private:
       auto cached{referenced_locations.find(schema_uri)};
       if (cached == referenced_locations.end()) {
         const auto locations_resolution{this->artifact_resolve_path(
-            sourcemeta::one::VIEW_PUBLIC, credentials, keyword_location_string,
-            Tree::Schemas, "locations")};
+            caller, keyword_location_string, Tree::Schemas, "locations")};
         if (locations_resolution.path.has_value()) {
           auto locations{
               this->artifact_read_json(locations_resolution.path.value())};
@@ -204,7 +205,7 @@ private:
     return sourcemeta::core::JSON{nullptr};
   }
 
-  auto trace(const sourcemeta::one::Credentials credentials,
+  auto trace(const sourcemeta::one::Authentication::Caller &caller,
              const std::string_view schema_uri,
              const sourcemeta::core::JSON &instance_json,
              const sourcemeta::core::PointerPositionTracker *tracker,
@@ -212,9 +213,8 @@ private:
       -> sourcemeta::core::JSON {
     auto steps{sourcemeta::core::JSON::make_array()};
 
-    const auto locations_resolution{
-        this->artifact_resolve_path(sourcemeta::one::VIEW_PUBLIC, credentials,
-                                    schema_uri, Tree::Schemas, "locations")};
+    const auto locations_resolution{this->artifact_resolve_path(
+        caller, schema_uri, Tree::Schemas, "locations")};
     if (!locations_resolution.path.has_value()) {
       throw std::runtime_error{"Failed to read schema locations metadata"};
     }
@@ -237,9 +237,9 @@ private:
         referenced_locations;
 
     const auto result{this->schema_evaluate_with_tracing(
-        credentials, schema_uri, instance_json,
-        [this, &credentials, &steps, tracker, &instance_prefix,
-         &static_locations, &instance_json, &referenced_locations](
+        caller, schema_uri, instance_json,
+        [this, &caller, &steps, tracker, &instance_prefix, &static_locations,
+         &instance_json, &referenced_locations](
             const sourcemeta::blaze::EvaluationType type, const bool valid,
             const sourcemeta::blaze::Instruction &instruction,
             const sourcemeta::blaze::InstructionExtra &extra,
@@ -293,9 +293,9 @@ private:
           }
 
           step.assign("vocabulary",
-                      this->resolve_vocabulary(
-                          credentials, extra.keyword_location, evaluate_path,
-                          static_locations, referenced_locations));
+                      this->resolve_vocabulary(caller, extra.keyword_location,
+                                               evaluate_path, static_locations,
+                                               referenced_locations));
 
           steps.push_back(std::move(step));
         })};

--- a/src/actions/action_list_directory_v1.h
+++ b/src/actions/action_list_directory_v1.h
@@ -49,7 +49,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, std::string_view view,
+            const sourcemeta::one::Authentication::Caller &caller,
             sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
@@ -62,8 +62,7 @@ public:
                                                       : matches.front()};
     const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{this->artifact_resolve_path(
-        view, {.bearer = credential, .cookies = cookies}, path_match,
-        Tree::Explorer, "directory")};
+        caller, path_match, Tree::Explorer, "directory")};
     if (!resolution.path.has_value()) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
@@ -80,7 +79,7 @@ public:
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
            const sourcemeta::core::JSON &arguments,
-           const sourcemeta::one::Credentials &credentials)
+           const sourcemeta::one::Authentication::Caller &caller)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
         this->structural_evaluate(this->rpc_request_schema_, arguments,
@@ -95,9 +94,8 @@ public:
     const auto &path_arg{arguments.at_or("path", EMPTY_STRING).to_string()};
     // A tool call reaches one artifact, so placing the caller here is still
     // once for the request that carried them
-    const auto view{this->dispatcher().authentication().view(credentials)};
     const auto resolution{this->artifact_resolve_path(
-        view, credentials, path_arg, Tree::Explorer, "directory")};
+        caller, path_arg, Tree::Explorer, "directory")};
     if (!resolution.path.has_value()) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Directory not found");

--- a/src/actions/action_mcp_prm_v1.h
+++ b/src/actions/action_mcp_prm_v1.h
@@ -52,8 +52,9 @@ public:
     return true;
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",
@@ -79,7 +80,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/actions/action_mcp_v1.h
+++ b/src/actions/action_mcp_v1.h
@@ -61,8 +61,9 @@ public:
     this->allowed_origin_ = this->mcp_metadata_.at("origin").to_string();
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       response.write_status(sourcemeta::core::HTTP_STATUS_NO_CONTENT);
@@ -320,7 +321,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/actions/action_not_found_v1.h
+++ b/src/actions/action_not_found_v1.h
@@ -37,8 +37,9 @@ public:
         });
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     sourcemeta::one::json_error(
         request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
@@ -48,7 +49,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/actions/action_schema_search_v1.h
+++ b/src/actions/action_schema_search_v1.h
@@ -79,8 +79,9 @@ public:
         });
   }
 
-  auto rest(const std::span<std::string_view>, std::string_view,
-            std::string_view view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view>,
+            const sourcemeta::one::Authentication::Caller &caller,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",
@@ -202,7 +203,8 @@ public:
       }
     }
 
-    auto result{this->search_view_for(view).search(query, limit, scope)};
+    auto result{
+        this->search_view_for(caller.view()).search(query, limit, scope)};
     response.write_status(sourcemeta::core::HTTP_STATUS_OK);
     response.write_header("Access-Control-Allow-Origin", "*");
     response.write_header("Access-Control-Expose-Headers", "Link, ETag");
@@ -213,9 +215,10 @@ public:
     // bursts without serving stale ranking long-term. What comes back
     // is whatever the caller's view holds, so only the anonymous one
     // answers the same to everybody and may enter a shared cache
-    response.write_header("Cache-Control", view == sourcemeta::one::VIEW_PUBLIC
-                                               ? "public, max-age=60"
-                                               : "private, max-age=60");
+    response.write_header("Cache-Control",
+                          caller.view() == sourcemeta::one::VIEW_PUBLIC
+                              ? "public, max-age=60"
+                              : "private, max-age=60");
     // RFC 9110 §12.5.5: the gzip negotiation axis applies, and so does whatever
     // places a caller in a view, since one URL answers differently per view.
     // Every other content surface revalidates on each hit, which re-resolves
@@ -233,7 +236,7 @@ public:
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
            const sourcemeta::core::JSON &arguments,
-           const sourcemeta::one::Credentials &credentials)
+           const sourcemeta::one::Authentication::Caller &caller)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
         this->structural_evaluate(this->rpc_request_schema_, arguments,
@@ -305,8 +308,7 @@ public:
       }
     }
 
-    auto results{this->search_view_for(
-                         this->dispatcher().authentication().view(credentials))
+    auto results{this->search_view_for(caller.view())
                      .search(arguments.at("q").to_string(), limit, scope)};
     auto envelope{sourcemeta::core::JSON::make_object()};
     envelope.assign_assume_new("results", std::move(results));

--- a/src/actions/action_serve_explorer_artifact_v1.h
+++ b/src/actions/action_serve_explorer_artifact_v1.h
@@ -48,7 +48,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, std::string_view view,
+            const sourcemeta::one::Authentication::Caller &caller,
             sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
@@ -72,8 +72,7 @@ public:
                                                       : matches.front()};
     const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{this->artifact_resolve_path(
-        view, {.bearer = credential, .cookies = cookies}, path_match,
-        Tree::Explorer, this->artifact_)};
+        caller, path_match, Tree::Explorer, this->artifact_)};
     if (!resolution.path.has_value()) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
@@ -90,7 +89,7 @@ public:
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
            const sourcemeta::core::JSON &arguments,
-           const sourcemeta::one::Credentials &credentials)
+           const sourcemeta::one::Authentication::Caller &caller)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
         this->structural_evaluate(this->rpc_request_schema_, arguments,
@@ -103,10 +102,9 @@ public:
 
     // A tool call reaches one artifact, so placing the caller here is still
     // once for the request that carried them
-    const auto view{this->dispatcher().authentication().view(credentials)};
-    const auto resolution{this->artifact_resolve_path(
-        view, credentials, arguments.at("schema").to_string(), Tree::Explorer,
-        this->artifact_)};
+    const auto resolution{
+        this->artifact_resolve_path(caller, arguments.at("schema").to_string(),
+                                    Tree::Explorer, this->artifact_)};
     if (!resolution.path.has_value()) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");

--- a/src/actions/action_serve_schema_artifact_v1.h
+++ b/src/actions/action_serve_schema_artifact_v1.h
@@ -49,7 +49,7 @@ public:
   }
 
   auto rest(const std::span<std::string_view> matches,
-            std::string_view credential, std::string_view,
+            const sourcemeta::one::Authentication::Caller &caller,
             sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
@@ -79,9 +79,7 @@ public:
 
     const sourcemeta::one::RequestCookies cookies{request};
     const auto resolution{this->artifact_resolve_path(
-        sourcemeta::one::VIEW_PUBLIC,
-        {.bearer = credential, .cookies = cookies}, matches.front(),
-        Tree::Schemas, this->artifact_)};
+        caller, matches.front(), Tree::Schemas, this->artifact_)};
     if (!resolution.path.has_value()) {
       sourcemeta::one::json_error(
           request, response, sourcemeta::core::HTTP_STATUS_NOT_FOUND,
@@ -98,7 +96,7 @@ public:
   auto mcp(const sourcemeta::core::MCPProtocolVersion version,
            const sourcemeta::core::JSON &request_id,
            const sourcemeta::core::JSON &arguments,
-           const sourcemeta::one::Credentials &credentials)
+           const sourcemeta::one::Authentication::Caller &caller)
       -> sourcemeta::core::JSON override {
     auto [request_valid, request_output]{
         this->structural_evaluate(this->rpc_request_schema_, arguments,
@@ -109,9 +107,9 @@ public:
           std::move(request_output));
     }
 
-    const auto resolution{this->artifact_resolve_path(
-        sourcemeta::one::VIEW_PUBLIC, credentials,
-        arguments.at("schema").to_string(), Tree::Schemas, this->artifact_)};
+    const auto resolution{
+        this->artifact_resolve_path(caller, arguments.at("schema").to_string(),
+                                    Tree::Schemas, this->artifact_)};
     if (!resolution.path.has_value()) {
       return sourcemeta::core::mcp_make_tool_error(request_id,
                                                    "Schema not found");

--- a/src/actions/action_serve_static_v1.h
+++ b/src/actions/action_serve_static_v1.h
@@ -39,8 +39,9 @@ public:
         });
   }
 
-  auto rest(const std::span<std::string_view> matches, std::string_view,
-            std::string_view, sourcemeta::one::HTTPRequest &request,
+  auto rest(const std::span<std::string_view> matches,
+            const sourcemeta::one::Authentication::Caller &,
+            sourcemeta::one::HTTPRequest &request,
             sourcemeta::one::HTTPResponse &response) -> void override {
     if (request.method() == "options") {
       sourcemeta::one::cors_preflight(request, response, "GET, HEAD, OPTIONS",
@@ -97,7 +98,7 @@ public:
 
   auto mcp(const sourcemeta::core::MCPProtocolVersion,
            const sourcemeta::core::JSON &id, const sourcemeta::core::JSON &,
-           const sourcemeta::one::Credentials &)
+           const sourcemeta::one::Authentication::Caller &)
       -> sourcemeta::core::JSON override {
     return sourcemeta::core::jsonrpc_make_error_method_not_found(id);
   }

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -30,50 +30,85 @@ auto Authentication::views(const std::span<const Authentication::Policy>)
   return result;
 }
 
-auto Authentication::save(
+auto Authentication::compile(
     const std::span<const Authentication::Policy> policies,
     const std::filesystem::path &configuration,
-    const std::filesystem::path &destination, const Authentication::PathGuard &)
-    -> void {
+    const Authentication::PathGuard &) -> std::vector<std::byte> {
   if (!policies.empty()) {
     throw EnterpriseOnlyFeatureError(
         configuration,
         "Authentication is only available on the enterprise edition");
   }
 
-  sourcemeta::core::write_file(destination, std::vector<std::byte>{});
+  return {};
+}
+
+auto Authentication::write(const std::span<const std::byte> bytes,
+                           const std::filesystem::path &destination) -> void {
+  sourcemeta::core::write_file(destination, bytes);
 }
 
 // NOLINTBEGIN(performance-unnecessary-value-param)
 Authentication::Authentication(const std::filesystem::path &,
-                               sourcemeta::core::JWKSProvider::Fetcher) {}
+                               Authentication::Fetcher) {}
+
+Authentication::Authentication(const std::span<const std::byte>,
+                               Authentication::Fetcher) {}
 // NOLINTEND(performance-unnecessary-value-param)
 
 Authentication::~Authentication() = default;
 
-auto Authentication::admits(const Authentication::Path &,
-                            const Credentials &) const
-    -> Authentication::Verdict {
-  return {.allowed = true, .principal = std::nullopt};
-}
-
-auto Authentication::admits_route(const std::string_view, const Credentials &,
-                                  const std::string_view) const
-    -> Authentication::Verdict {
-  return {.allowed = true, .principal = std::nullopt};
-}
-
 // This edition declares no policies, so there is nobody to be other than
-// anonymous and every caller is classified the same way
-auto Authentication::classify(const Credentials &) const
-    -> Authentication::PolicySet {
-  return 0;
+// anonymous and every caller is placed the same way. The view is still named
+// rather than implied, which keeps the output one shape across editions
+// This edition signs nobody in, so there is no login to start and no session
+// to end, and both answer as the endpoints that reach them already do
+auto Authentication::login(const std::string_view, const std::string_view,
+                           const std::string_view, const bool,
+                           const std::string_view) const
+    -> Authentication::Outcome {
+  return {.result = Authentication::Outcome::Result::Missing};
 }
 
-// One way to see the registry means one view, which is still named rather than
-// implied so that the output is one shape across editions
-auto Authentication::view(const Credentials &) const -> std::string_view {
-  return VIEW_PUBLIC;
+// This edition signs nobody in, so no marker it could carry names a policy
+auto Authentication::renewal(const Authentication::Path &,
+                             const Credentials &) const
+    -> std::optional<std::string_view> {
+  return std::nullopt;
+}
+
+auto Authentication::callback(const std::string_view, const std::string_view,
+                              const std::string_view,
+                              const Authentication::CallbackRequest &,
+                              const Credentials &) const
+    -> Authentication::Outcome {
+  return {.result = Authentication::Outcome::Result::Missing};
+}
+
+auto Authentication::logout(const Credentials &, const std::string_view,
+                            const std::string_view) const
+    -> Authentication::Outcome {
+  return {.result = Authentication::Outcome::Result::Missing};
+}
+
+auto Authentication::caller(const Credentials &) const
+    -> Authentication::Caller {
+  Authentication::Caller result;
+  result.view_ = VIEW_PUBLIC;
+  return result;
+}
+
+// Nothing is governed here, so every location is part of what the one view
+// shows
+auto Authentication::permits(const Authentication::Path &,
+                             const Authentication::Caller &) const -> bool {
+  return true;
+}
+
+auto Authentication::permits(const RouteTarget &,
+                             const Authentication::Caller &,
+                             const std::string_view) const -> bool {
+  return true;
 }
 
 // One way to see the registry means one view, and nothing governs anything, so
@@ -98,87 +133,10 @@ auto Authentication::governing(const Authentication::Path &) const
   return {};
 }
 
-auto Authentication::interactive(const std::string_view) const
-    -> std::optional<Authentication::InteractivePolicy> {
-  return std::nullopt;
-}
-
-auto Authentication::interactive(const Authentication::Path &,
-                                 const std::string_view) const
-    -> std::optional<Authentication::InteractivePolicy> {
-  return std::nullopt;
-}
-
-auto Authentication::client_secret(const std::string_view) const
-    -> std::optional<sourcemeta::core::SecureString> {
-  return std::nullopt;
-}
-
-auto Authentication::endpoints(const std::string_view) const
-    -> std::optional<Authentication::ProviderEndpoints> {
-  return std::nullopt;
-}
-
-auto Authentication::open_session(const std::string_view) const
-    -> std::optional<std::string> {
-  return std::nullopt;
-}
-
-// Only an interactive login ever answers for a claim, and this edition
-// establishes none, so there is never a shape to report
-auto Authentication::object_shaped_claims(const std::string_view,
-                                          const sourcemeta::core::JSON &) const
-    -> std::vector<std::string_view> {
-  return {};
-}
-
-// Only an interactive login ever has two answers to combine, and this edition
-// establishes none, so nothing here reaches this
-auto Authentication::combine_claims(const sourcemeta::core::JSON &token,
-                                    const sourcemeta::core::JSON &)
-    -> sourcemeta::core::JSON {
-  return token;
-}
-
-auto Authentication::admits_identity(const std::string_view,
-                                     const sourcemeta::core::JSON &) const
-    -> Authentication::Admission {
-  return Authentication::Admission::Refused;
-}
-
-auto Authentication::seal(const std::string_view, const Purpose,
-                          const std::string_view,
-                          const std::chrono::sys_seconds) const
-    -> std::optional<std::string> {
-  return std::nullopt;
-}
-
-auto Authentication::open(const std::string_view, const Purpose,
-                          const std::string_view) const
-    -> std::optional<std::string> {
-  return std::nullopt;
-}
-
 auto Authentication::reference_permitted(const Authentication::Path &,
                                          const Authentication::Path &) const
     -> bool {
   return true;
-}
-
-// Sessions only arise from interactive authentication, which is an enterprise
-// feature, so this edition never produces a sealed value and never accepts one
-auto Authentication::seal_value(const std::string_view, const Purpose,
-                                const std::string_view,
-                                const std::chrono::sys_seconds,
-                                const std::chrono::sys_seconds) -> std::string {
-  return {};
-}
-
-auto Authentication::open_value(const std::string_view, const Purpose,
-                                const std::span<const std::string_view>,
-                                const std::chrono::sys_seconds)
-    -> std::optional<std::string> {
-  return std::nullopt;
 }
 
 } // namespace sourcemeta::one

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -7,6 +7,7 @@
 
 #include <sourcemeta/one/authentication_error.h>
 
+#include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/jose.h>
 
 #include <chrono>      // std::chrono::sys_seconds
@@ -20,6 +21,7 @@
 #include <string>      // std::string
 #include <string_view> // std::string_view
 #include <utility>     // std::move
+#include <variant>     // std::variant, std::get_if, std::holds_alternative
 #include <vector>      // std::vector
 
 namespace sourcemeta::one {
@@ -29,6 +31,22 @@ namespace sourcemeta::one {
 // already means public. Spelled once so that what a build writes and what a
 // server reads cannot disagree
 inline constexpr std::string_view VIEW_PUBLIC{"public"};
+
+// A route as the router matched it, taken by the spelling it arrived in rather
+// than by where it resolves to. A target reaching past a governed prefix is
+// still governed by it, which is why it is not canonicalised, and why it is not
+// a registry path
+class RouteTarget {
+public:
+  explicit RouteTarget(const std::string_view value) noexcept : value_{value} {}
+
+  [[nodiscard]] auto value() const noexcept -> std::string_view {
+    return this->value_;
+  }
+
+private:
+  std::string_view value_;
+};
 
 // Everything a request presented for authentication: the bearer value from
 // the authorization header and every cookie field it carried, either of which
@@ -106,75 +124,164 @@ public:
   // secret, so one kind of value cannot be presented as the other
   enum class Purpose : std::uint8_t { Session = 0, Transaction = 1 };
 
-  // A browser holds one session, whichever policy established it, and the
-  // policy travels inside the sealed value rather than in the name. One name
-  // means logging out has a single thing to end, and means a caller cannot
-  // choose which policy a value is read as by choosing what to call it
-  static constexpr std::string_view SESSION_COOKIE{"sourcemeta_one_session"};
-
-  // A login transaction follows the same shape for the short window between
-  // the login redirect and the callback
-  static constexpr std::string_view TRANSACTION_COOKIE{
-      "sourcemeta_one_transaction"};
-
-  // Names the policy a browser last signed in under, so that a denial can ask
-  // the provider whether that sign-in still stands rather than asking the
-  // person again. It outlives a session, since it is only of use once one has
-  // expired, and it carries no credential: whoever holds it can start a login
-  // they were free to start anyway
-  static constexpr std::string_view RENEWAL_COOKIE{"sourcemeta_one_renewal"};
-
-  // An instance names an origin and nothing more, so every location it serves
-  // is below the root, and a cookie scoped there travels to all of them
-  static constexpr std::string_view COOKIE_PATH{"/"};
-
   // A policy gates a set of path prefixes. A path covered by no policy is
-  // public
+  // public.
+  //
+  // What a policy needs depends entirely on what it authenticates, and the
+  // three have almost nothing in common beyond where they apply and what they
+  // are called. Keeping them apart is what stops a key policy carrying a key
+  // set location, or a machine policy carrying a client secret: a configuration
+  // that means nothing cannot be written down here at all
   struct Policy {
+    // A credential presented verbatim and compared against what an operator
+    // configured, which authenticates a program rather than a person
+    struct ApiKey {
+      // The environment variable names holding the keys this admits
+      std::span<const std::string_view> keys{};
+      Algorithm algorithm{Algorithm::Identity};
+    };
+
+    // A token obtained elsewhere and presented in an authorization header,
+    // which this validates without ever helping to obtain one
+    struct Token {
+      std::string_view issuer{};
+      std::string_view audience{};
+      // Pinning this bypasses discovery entirely
+      std::string_view jwks_uri{};
+      std::span<const sourcemeta::core::JWSAlgorithm> algorithms{};
+      // The `typ` header a presented token must carry, empty to accept any
+      std::string_view token_type{};
+      // The claims a credential must carry, serialised as the member map of an
+      // OpenID Connect claims request parameter. It arrives canonical, so that
+      // two policies admitting the same callers carry identical bytes. Empty
+      // where a policy names no rule
+      std::string_view claims{};
+      // The email domains that admit a person, beyond whatever the claims
+      // require. A domain cannot be written as a claim value, since it matches
+      // the part of an address after its last separator rather than the whole
+      std::span<const std::string_view> email_domains{};
+    };
+
+    // A person who signs in through an identity provider, which is the only
+    // kind that establishes a session
+    struct Interactive {
+      std::string_view issuer{};
+      std::string_view client_id{};
+      // The environment variable name holding the client secret
+      std::string_view client_secret_variable{};
+      std::string_view claims{};
+      std::span<const std::string_view> email_domains{};
+      // The environment variable names holding the secrets that sign this
+      // policy's session and transaction cookies, newest first. A value is
+      // signed under the first and accepted under any, so a secret can be
+      // replaced without ending the sessions signed under the one before it
+      std::span<const std::string_view> session_secrets{};
+    };
+
     std::span<const std::string_view> paths{};
-    std::span<const std::string_view> keys{};
-    Algorithm algorithm{Algorithm::Identity};
-    Type type{Type::ApiKey};
-    std::string_view issuer{};
-    std::string_view audience{};
-    std::string_view jwks_uri{};
-    std::span<const sourcemeta::core::JWSAlgorithm> algorithms{};
-    // The `typ` header a presented token must carry, empty to accept any
-    std::string_view token_type{};
-    // The claims a credential must carry, serialised as the member map of an
-    // OpenID Connect claims request parameter. It arrives canonical, so that
-    // two policies admitting the same callers carry identical bytes. Empty
-    // where a policy names no rule
-    std::string_view claims{};
-    // The email domains that admit a person, beyond whatever the claims
-    // require. A domain cannot be written as a claim value, since it matches
-    // the part of an address after its last separator rather than the whole
-    std::span<const std::string_view> email_domains{};
-    std::string_view client_id{};
-    // The environment variable name holding the client secret
-    std::string_view client_secret_variable{};
     // The policy name, which interactive policies carry so their session
-    // cookies can be recognised at the gate
+    // cookies can be recognised at the gate, and which every policy carries so
+    // that a view can be named after what it comprises
     std::string_view name{};
-    // The environment variable names holding the secrets that sign this
-    // policy's session and transaction cookies, newest first. A value is
-    // signed under the first and accepted under any, so a secret can be
-    // replaced without ending the sessions signed under the one before it
-    std::span<const std::string_view> session_secrets{};
+    std::variant<ApiKey, Token, Interactive> credential{ApiKey{}};
+
+    // Which of the three this is, which the artifact records so that reading a
+    // policy back does not depend on reading its parameters first
+    [[nodiscard]] auto type() const noexcept -> Type {
+      switch (this->credential.index()) {
+        case 1:
+          return Type::JWT;
+        case 2:
+          return Type::OIDC;
+        default:
+          return Type::ApiKey;
+      }
+    }
   };
 
-  // The identity of an admitted caller: the type of credential it presented
-  // and the declaration index of the policy that admitted it
-  struct Principal {
-    Type type{Type::ApiKey};
-    std::size_t policy{0};
+  // What this asks a provider for. Every outbound call goes through one of
+  // these, so whoever constructs an instance decides what reaches a network,
+  // and a test answers without one
+  struct ProviderRequest {
+    std::string_view url{};
+    // Empty for a retrieval. Otherwise the form body to post, which carries a
+    // client secret and so never leaves wiping storage
+    sourcemeta::core::SecureString body{};
+    // Empty where the request authenticates by other means, or not at all
+    sourcemeta::core::SecureString authorization{};
   };
 
-  struct Verdict {
-    bool allowed;
-    // Present only when a policy admitted the caller. An anonymous caller on
-    // a public path and a denied caller both carry none
-    std::optional<Principal> principal;
+  struct ProviderResponse {
+    std::uint32_t status{0};
+    std::string body{};
+    // What the response said about how long it stays fresh, where it said
+    // anything
+    std::optional<std::chrono::seconds> max_age{};
+  };
+
+  // The one way this reaches a provider, for discovery, for a key set, for
+  // redeeming an authorization code, and for asking who somebody is. Answering
+  // nothing is how a caller says the provider could not be reached
+  using Fetcher =
+      std::function<std::optional<ProviderResponse>(ProviderRequest &&)>;
+
+  // Who is asking, read from what a request presented exactly once. Everything
+  // decided afterwards is a comparison against what this holds rather than a
+  // second reading of a credential
+  class SOURCEMETA_ONE_AUTHENTICATION_EXPORT Caller {
+  public:
+    // The view this caller is served, which is the directory their artifacts
+    // were written under
+    [[nodiscard]] auto view() const noexcept -> std::string_view {
+      return this->view_;
+    }
+
+  private:
+    friend class Authentication;
+    std::string_view view_{};
+    PolicySet policies_{0};
+    // What was presented in the authorization header, kept so that a route
+    // requiring an audience can read one more claim from a token already
+    // verified. It points at the request, as the credentials it came from do
+    std::string_view bearer_{};
+  };
+
+  // What an interactive operation came to. A refusal says nothing beyond
+  // having failed, since both endpoints answer uniformly whatever went wrong,
+  // so what happened reaches the log and never a response
+  struct Outcome {
+    enum class Result : std::uint8_t {
+      // The browser is sent onwards, carrying whatever cookies came with it.
+      // A silent attempt that came to nothing ends here too, put back where it
+      // started rather than shown any of it
+      Redirect,
+      // Nothing here answers to that name, which is the same answer a typo
+      // gets
+      Missing,
+      // A login could not be started. Every reason reads alike, since telling
+      // them apart would say how this deployment is doing to whoever asked
+      Unavailable,
+      // What came back does not belong to a login this instance started
+      Invalid,
+      // The provider refused, which it named itself
+      Declined,
+      // A callback that belongs to a real login, which could not end in a
+      // session. Every reason reads alike, for the reason above
+      Incomplete,
+      // Somebody the provider vouched for, whom this policy does not admit.
+      // That is the end of the road rather than something to try again
+      NotAdmitted
+    };
+
+    Result result{Result::Unavailable};
+    // Where to send the browser afterwards
+    std::string location{};
+    // Serialised, ready to be written as they are. Whoever measures a value
+    // against what a browser will keep is whoever knows the attributes, so they
+    // are composed here rather than by the surface that writes them
+    std::vector<std::string> cookies{};
+    // What an operator would want to know, which never reaches a response
+    std::vector<std::string> log{};
   };
 
   // Whether a path is one this instance could gate. A policy scoped to
@@ -224,15 +331,22 @@ public:
   // built rather than where they are named
   static constexpr std::size_t MAXIMUM_COMBINABLE_POLICIES{16};
 
-  // Write the policies to the artifact the gate reads, refusing any policy
-  // scoped to a path the guard does not recognise
-  static auto save(std::span<const Policy> policies,
-                   const std::filesystem::path &configuration,
-                   const std::filesystem::path &destination,
-                   const PathGuard &gateable) -> void;
+  // Build the artifact the gate reads, refusing any policy scoped to a path the
+  // guard does not recognise. The configuration names where a refusal came from
+  [[nodiscard]] static auto compile(std::span<const Policy> policies,
+                                    const std::filesystem::path &configuration,
+                                    const PathGuard &gateable)
+      -> std::vector<std::byte>;
 
-  Authentication(const std::filesystem::path &path,
-                 sourcemeta::core::JWKSProvider::Fetcher fetcher);
+  // Persist what was compiled, so that a later process can map it back
+  static auto write(std::span<const std::byte> bytes,
+                    const std::filesystem::path &destination) -> void;
+
+  Authentication(const std::filesystem::path &path, Fetcher fetcher);
+
+  // Read a table compiled in this process rather than mapped from a file, so
+  // that what reads a policy set never depends on a filesystem to do it
+  Authentication(std::span<const std::byte> bytes, Fetcher fetcher);
 
   ~Authentication();
 
@@ -242,49 +356,124 @@ public:
   auto operator=(const Authentication &) -> Authentication & = delete;
   auto operator=(Authentication &&) -> Authentication & = delete;
 
-  // Whether what a request presented admits it to a path. The path arrives
-  // canonical, so every caller asks about the same location rather than about
-  // whichever spelling it happened to receive
-  [[nodiscard]] auto admits(const Path &path,
-                            const Credentials &credentials) const -> Verdict;
-
-  // Whether what a request presented admits it to an explicit route, which the
-  // router matched on the request target literally rather than on the location
-  // that target resolves to. The spelling is taken as matched, so a target
-  // reaching past a governed prefix is still governed by it
-  // A route may additionally require that a presented token names the route
-  // itself, rather than only whatever wider audience the policy admitting the
-  // caller was configured with. An empty requirement asks for nothing extra,
-  // and a credential that is not a token is unaffected, since only a token
-  // carries an audience to check
-  [[nodiscard]] auto admits_route(std::string_view target,
-                                  const Credentials &credentials,
-                                  std::string_view required_audience = {}) const
-      -> Verdict;
-
-  /// Which policies a caller satisfies, asked of the caller alone rather than
-  /// of a path, so that one answer describes the whole registry. The gate
-  /// answers whether a door opens, and this answers who is knocking.
+  /// Who is asking, read from what a request presented. This is the one place a
+  /// credential is verified, so every question asked of the result afterwards
+  /// is a comparison rather than a second verification.
   ///
   /// A caller presenting nothing satisfies nothing, which is the anonymous
   /// answer and costs nothing to reach.
   ///
-  /// Token policies naming one issuer are reported together, since a token
+  /// Token policies naming one issuer are satisfied together, since a token
   /// carrying several claims satisfies several of them at once and each is an
-  /// area its holder reaches. Every other policy is reported alone, and where a
+  /// area its holder reaches. Every other policy stands alone, and where a
   /// credential satisfies more than one, the first declared is the one read.
-  [[nodiscard]] auto classify(const Credentials &credentials) const
-      -> PolicySet;
+  [[nodiscard]] auto caller(const Credentials &credentials) const -> Caller;
 
-  /// The name of the view a caller is served, which is the directory their
-  /// artifacts were written under. A caller presenting nothing is served the
-  /// anonymous view.
+  /// Whether a caller is shown a registry path, which is whether the view they
+  /// were placed in holds it. A path nobody governs is shown to everybody, and
+  /// a governed one to a view satisfying any policy governing it.
   ///
-  /// The name comes from the table the build recorded rather than from a rule
-  /// applied again here, so what a build wrote and what a server serves cannot
-  /// disagree. The value stays valid for the lifetime of this instance.
-  [[nodiscard]] auto view(const Credentials &credentials) const
-      -> std::string_view;
+  /// The path arrives canonical, so every surface asks about the same location
+  /// rather than about whichever spelling it happened to receive.
+  [[nodiscard]] auto permits(const Path &path, const Caller &caller) const
+      -> bool;
+
+  /// The same question asked of an explicit route, which the router matched on
+  /// the request target literally rather than on the location that target
+  /// resolves to. The spelling is taken as matched, so a target reaching past a
+  /// governed prefix is still governed by it.
+  ///
+  /// A route may additionally require that a presented token names the route
+  /// itself, rather than only whatever wider audience the policy admitting the
+  /// caller was configured with. An empty requirement asks for nothing extra,
+  /// and a caller that presented no token is unaffected, since only a token
+  /// carries an audience to check.
+  [[nodiscard]] auto permits(const RouteTarget &target, const Caller &caller,
+                             std::string_view required_audience = {}) const
+      -> bool;
+
+  /// End the browser's session, and the provider's where it named a policy
+  /// whose provider offers to end one.
+  ///
+  /// Every cookie this instance mints expires on every path this can take,
+  /// including the one where nothing opened at all. A cookie is withheld on
+  /// plenty of navigations while the browser still holds it, so clearing only
+  /// what arrived would leave a session behind while telling the person they
+  /// are signed out.
+  /// Where the browser lands afterwards is named by whoever asked, since a
+  /// route is a fact about the surface that received the request rather than
+  /// about authentication. Nothing here composes a URL of its own.
+  [[nodiscard]] auto logout(const Credentials &credentials,
+                            std::string_view instance_url,
+                            std::string_view return_to) const -> Outcome;
+
+  /// Start a login, sealing the transaction the callback will complete and
+  /// naming where the provider should send the browser.
+  ///
+  /// A silent attempt asks the provider whether an existing sign-in still
+  /// stands, and is answered either way without the person seeing anything.
+  /// The transaction carries which kind it is, since a provider refusing to
+  /// answer without interaction is an ordinary outcome for one and a failure
+  /// for the other.
+  ///
+  /// The return target is where the browser goes once this completes. It
+  /// arrives already checked against what this instance serves, since only the
+  /// surface that received the request knows what it asked for. Where it is
+  /// empty, what the policy governs stands in.
+  /// The redirect URI is passed in rather than composed, for the same reason:
+  /// it names a route, and which routes exist is not something this knows. It
+  /// is what the provider is told to come back to, and what the callback will
+  /// be checked against.
+  [[nodiscard]] auto login(std::string_view policy,
+                           std::string_view instance_url,
+                           std::string_view redirect_uri, bool silent,
+                           std::string_view return_to) const -> Outcome;
+
+  /// Which interactive policy should be asked whether a lapsed sign-in still
+  /// stands, for a caller that reached this path and nothing else.
+  ///
+  /// Two things have to hold, and both matter. The caller must carry the marker
+  /// a previous sign-in left, or every stranger would be sent to a provider
+  /// they have no account with. And the policy that marker names must govern
+  /// the path they reached, or a stale marker would send somebody to a provider
+  /// whose answer could not admit them here, leaving them where they started
+  /// and going round again.
+  ///
+  /// The name is answered rather than a URL, since where a login begins is a
+  /// route and this does not know any.
+  [[nodiscard]] auto renewal(const Path &path,
+                             const Credentials &credentials) const
+      -> std::optional<std::string_view>;
+
+  // What a provider sent back, read from wherever the surface found it
+  struct CallbackRequest {
+    std::string_view state{};
+    std::string_view code{};
+    // A decline names itself with an error code, so one that is present and
+    // empty is a different thing from one that is absent
+    bool has_error{false};
+    std::string_view error{};
+    // A provider naming no issuer cannot be checked against the one addressed,
+    // so the check runs only when one arrived
+    bool has_issuer{false};
+    std::string_view issuer{};
+  };
+
+  /// Complete a login, minting the session when everything holds.
+  ///
+  /// The transaction the browser carries is the only proof that this belongs
+  /// to a login this instance started, and it is opened before either a
+  /// success or a decline is honoured, so a cross-site callback cannot trigger
+  /// an error on somebody's behalf.
+  ///
+  /// The redirect URI must be the one the login was started with, since the
+  /// provider checks it and so does this. It is passed in for the same reason
+  /// it is passed to `login`: it names a route.
+  [[nodiscard]] auto callback(std::string_view policy,
+                              std::string_view instance_url,
+                              std::string_view redirect_uri,
+                              const CallbackRequest &incoming,
+                              const Credentials &credentials) const -> Outcome;
 
   // One view as the artifact records it: the directory its artifacts live
   // under, and the policies a caller satisfies to be served from it
@@ -337,167 +526,6 @@ public:
     // nobody
     std::vector<std::string_view> email_domains{};
   };
-
-  // The interactive policy declared under the given name, if any
-  [[nodiscard]] auto interactive(std::string_view name) const
-      -> std::optional<InteractivePolicy>;
-
-  // The same, narrowed to a policy that governs the given path. A name that
-  // gates somewhere else answers nothing, so a browser carrying a stale one is
-  // never sent to a provider whose answer could not admit it here
-  [[nodiscard]] auto interactive(const Path &path, std::string_view name) const
-      -> std::optional<InteractivePolicy>;
-
-  // Where a provider says its endpoints are. The values are copies, so they
-  // stay usable across a refresh of what the provider last said
-  struct ProviderEndpoints {
-    std::string authorization{};
-    std::string token{};
-    std::string jwks_uri{};
-    // Absent from a provider that does not offer to end its own session
-    std::string end_session{};
-    // Where a provider answers for the claims a scope requested, which under
-    // the authorization code flow is where they arrive by default rather than
-    // in the token itself
-    std::string userinfo{};
-    // Whether the provider takes the client secret in an authorization header
-    // rather than in the request body
-    bool token_endpoint_basic_auth{true};
-    // Whether the provider honours the claims request parameter, which is the
-    // standard way to ask for a claim no standard scope carries
-    bool claims_parameter_supported{false};
-    // The claims the provider says it may be able to supply. OpenID Connect
-    // Discovery Section 3 calls this list non-exhaustive, so a claim missing
-    // from it is worth reporting and never worth refusing over, and a provider
-    // publishing none says nothing at all
-    std::vector<std::string> claims_supported{};
-  };
-
-  // What the named interactive policy's provider says about itself, retrieved
-  // once and refreshed on the freshness its own response advertises rather
-  // than on every request. Nothing is returned when the policy is unknown,
-  // the provider cannot be reached, or what it returned is not a description
-  // this instance can act on
-  [[nodiscard]] auto endpoints(std::string_view policy) const
-      -> std::optional<ProviderEndpoints>;
-
-  // The client secret the named interactive policy authenticates to its
-  // provider with, if the policy is known and its secret is configured in the
-  // environment. Every secret this system holds is read here rather than by
-  // whoever needs it, so no caller is in a position to read one differently
-  [[nodiscard]] auto client_secret(std::string_view policy) const
-      -> std::optional<sourcemeta::core::SecureString>;
-
-  // Recover the payload of a session value, whichever interactive policy
-  // minted it, returning nothing when no policy accepts it. A value is only
-  // accepted under the policy its payload names, so a caller learns which
-  // policy established the session rather than choosing one to try
-  [[nodiscard]] auto open_session(std::string_view value) const
-      -> std::optional<std::string>;
-
-  // Two answers from one provider about one person, read together. A rule may
-  // name a claim the identity token carried and another only the UserInfo
-  // endpoint answers for, and either answer alone would refuse somebody both
-  // together admit.
-  //
-  // The token wins wherever both speak, since it arrives signed and verified
-  // while a UserInfo response is protected only by the transport that carried
-  // it, so the second fills gaps rather than overruling a signature.
-  //
-  // An address and the assertion that it was verified are the exception: they
-  // travel as a pair, from whichever answer carried the address. OpenID
-  // Connect Core Section 5.1 has `email_verified` speak for the `email`
-  // delivered alongside it and no other, so letting one answer's assertion
-  // vouch for the other answer's address would admit an address the provider
-  // never verified
-  [[nodiscard]] static auto combine_claims(const sourcemeta::core::JSON &token,
-                                           const sourcemeta::core::JSON &extra)
-      -> sourcemeta::core::JSON;
-
-  // What a policy's rules make of the claims a provider asserted
-  enum class Admission : std::uint8_t {
-    // Every rule holds
-    Admitted,
-    // A rule names values that what arrived does not carry
-    Refused,
-    // A rule names a claim absent altogether. A provider answering the
-    // authorization code flow returns a scope's claims from its UserInfo
-    // endpoint rather than in the token by default, so this is the one
-    // outcome worth asking a second question about
-    Incomplete
-  };
-
-  // The claims this policy's rules name that arrived carrying objects rather
-  // than strings. Such a claim is compared on its `value` sub-attribute alone,
-  // which RFC 9068 gives group, role, and entitlement claims by way of RFC
-  // 7643, so a rule naming what a person sees rather than what identifies them
-  // matches nothing and says nothing about why.
-  //
-  // A denial cannot show this, and the token it concerns is sealed inside a
-  // cookie, so an operator has no way to see it for themselves. Empty where
-  // every named claim arrived in a shape the rules compare directly.
-  //
-  // A rule on `scope` is never named here. That claim is read as one
-  // space-delimited string rather than compared member by member, so one
-  // arriving as anything else is refused outright, and calling it an
-  // identifier mismatch would describe a mistake nobody made
-  [[nodiscard]] auto
-  object_shaped_claims(std::string_view policy,
-                       const sourcemeta::core::JSON &claims) const
-      -> std::vector<std::string_view>;
-
-  // What the claims a provider asserted about a person make of what the named
-  // interactive policy requires. The claims are the payload of an identity
-  // token this instance has already validated, so this decides admission
-  // rather than authenticity, and a policy naming no rule admits whoever its
-  // provider vouched for.
-  //
-  // A login asks this before a session is minted rather than the gate asking
-  // it afterwards, so that somebody a policy will never admit is told once,
-  // rather than being sent back to their provider on every request
-  [[nodiscard]] auto admits_identity(std::string_view policy,
-                                     const sourcemeta::core::JSON &claims) const
-      -> Admission;
-
-  // Sealing is an edition-dependent capability. Where an instance does not
-  // offer it, nothing seals and no value opens, so a caller that treats an
-  // absent seal as unusable and an unopened value as a denial reaches the same
-  // outcome under either edition
-
-  // Seal a payload for one purpose under the named interactive policy's
-  // session secret, producing a value that the gate and this instance's
-  // replicas accept until the expiry. Nothing is produced when the policy is
-  // unknown or its session secret is not configured in the environment
-  [[nodiscard]] auto seal(std::string_view policy, Purpose purpose,
-                          std::string_view payload,
-                          std::chrono::sys_seconds expiry) const
-      -> std::optional<std::string>;
-
-  // Recover the payload of a value sealed for that purpose under the named
-  // policy by this instance or one of its replicas, returning nothing for a
-  // value that does not verify, was sealed for another purpose, or has expired
-  [[nodiscard]] auto open(std::string_view policy, Purpose purpose,
-                          std::string_view value) const
-      -> std::optional<std::string>;
-
-  // Bind a payload and an expiry under a key derived from the secret and the
-  // purpose, producing a value that is safe to transport as a cookie. Only a
-  // holder of the secret can produce or alter such a value, though anyone can
-  // read its contents
-  [[nodiscard]] static auto
-  seal_value(std::string_view payload, Purpose purpose, std::string_view secret,
-             std::chrono::sys_seconds issued, std::chrono::sys_seconds expiry)
-      -> std::string;
-
-  // Recover the payload of a sealed value, returning nothing for a value that
-  // was not produced for that purpose under one of the given secrets, was
-  // altered in any way, or has expired. Accepting several secrets lets a newly
-  // introduced secret coexist with the one it replaces until every value
-  // sealed under the old secret has expired
-  [[nodiscard]] static auto
-  open_value(std::string_view value, Purpose purpose,
-             std::span<const std::string_view> secrets,
-             std::chrono::sys_seconds now) -> std::optional<std::string>;
 
   [[nodiscard]] auto reference_permitted(const Path &referrer,
                                          const Path &referent) const -> bool;

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -156,10 +156,6 @@ public:
       // two policies admitting the same callers carry identical bytes. Empty
       // where a policy names no rule
       std::string_view claims{};
-      // The email domains that admit a person, beyond whatever the claims
-      // require. A domain cannot be written as a claim value, since it matches
-      // the part of an address after its last separator rather than the whole
-      std::span<const std::string_view> email_domains{};
     };
 
     // A person who signs in through an identity provider, which is the only

--- a/src/index/generators.h
+++ b/src/index/generators.h
@@ -1029,16 +1029,16 @@ struct GENERATE_AUTHENTICATION {
         policy_claims.push_back(claims.str());
         policies.push_back(
             {.paths = policy_paths.back(),
-             .type = sourcemeta::one::Authentication::Type::JWT,
-             .issuer = entry.issuer,
-             .audience = entry.audience,
-             .jwks_uri = entry.jwks_uri.has_value()
-                             ? std::string_view{entry.jwks_uri.value()}
-                             : std::string_view{},
-             .algorithms = entry.algorithms,
-             .token_type = entry.token_type,
-             .claims = policy_claims.back(),
-             .name = entry.name});
+             .name = entry.name,
+             .credential = sourcemeta::one::Authentication::Policy::Token{
+                 .issuer = entry.issuer,
+                 .audience = entry.audience,
+                 .jwks_uri = entry.jwks_uri.has_value()
+                                 ? std::string_view{entry.jwks_uri.value()}
+                                 : std::string_view{},
+                 .algorithms = entry.algorithms,
+                 .token_type = entry.token_type,
+                 .claims = policy_claims.back()}});
       } else if (entry.type == Entry::Type::OIDC) {
         std::vector<std::string_view> session_secrets;
         session_secrets.reserve(entry.session_secret_variables.size());
@@ -1064,14 +1064,14 @@ struct GENERATE_AUTHENTICATION {
         policy_email_domains.push_back(std::move(domains));
         policies.push_back(
             {.paths = policy_paths.back(),
-             .type = sourcemeta::one::Authentication::Type::OIDC,
-             .issuer = entry.issuer,
-             .claims = policy_claims.back(),
-             .email_domains = policy_email_domains.back(),
-             .client_id = entry.client_id,
-             .client_secret_variable = entry.client_secret_variable,
              .name = entry.name,
-             .session_secrets = policy_session_secrets.back()});
+             .credential = sourcemeta::one::Authentication::Policy::Interactive{
+                 .issuer = entry.issuer,
+                 .client_id = entry.client_id,
+                 .client_secret_variable = entry.client_secret_variable,
+                 .claims = policy_claims.back(),
+                 .email_domains = policy_email_domains.back(),
+                 .session_secrets = policy_session_secrets.back()}});
       } else {
         std::vector<std::string_view> keys;
         keys.reserve(entry.keys.size());
@@ -1084,10 +1084,11 @@ struct GENERATE_AUTHENTICATION {
             entry.algorithm == Entry::Algorithm::Sha256
                 ? sourcemeta::one::Authentication::Algorithm::Sha256
                 : sourcemeta::one::Authentication::Algorithm::Identity};
-        policies.push_back({.paths = policy_paths.back(),
-                            .keys = policy_keys.back(),
-                            .algorithm = algorithm,
-                            .name = entry.name});
+        policies.push_back(
+            {.paths = policy_paths.back(),
+             .name = entry.name,
+             .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+                 .keys = policy_keys.back(), .algorithm = algorithm}});
       }
     }
 
@@ -1116,21 +1117,23 @@ struct GENERATE_AUTHENTICATION {
     // begins rather than at some expansion of it: a scope reaching into a
     // template would be honoured where the route is matched literally and
     // nowhere else, which is a gate that holds on one surface and not the next
-    sourcemeta::one::Authentication::save(
-        policies, configuration.path, action.destination,
-        [&routes, &configuration](const std::string_view path) {
-          for (std::size_t index{0}; index < routes.size(); index++) {
-            const auto route{routes.path(routes.at(index))};
-            const auto scope{sourcemeta::one::route_scope(route)};
-            if (scope == path ||
-                (scope.size() > path.size() && scope.starts_with(path) &&
-                 scope[path.size()] == '/')) {
-              return true;
-            }
-          }
+    sourcemeta::one::Authentication::write(
+        sourcemeta::one::Authentication::compile(
+            policies, configuration.path,
+            [&routes, &configuration](const std::string_view path) {
+              for (std::size_t index{0}; index < routes.size(); index++) {
+                const auto route{routes.path(routes.at(index))};
+                const auto scope{sourcemeta::one::route_scope(route)};
+                if (scope == path ||
+                    (scope.size() > path.size() && scope.starts_with(path) &&
+                     scope[path.size()] == '/')) {
+                  return true;
+                }
+              }
 
-          return configuration.covers_entry(path);
-        });
+              return configuration.covers_entry(path);
+            }),
+        action.destination);
   }
 };
 

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -656,10 +656,13 @@ static auto index_main(const std::string_view &program,
   }
 
   const auto authentication_path{canonical_output / "authentication.bin"};
-  sourcemeta::one::Authentication::save(
-      view_policies, configuration.path, authentication_path,
-      [](const std::string_view) { return true; });
-  const sourcemeta::one::Authentication gate{authentication_path, {}};
+  // The table this build just compiled is what the plan is filtered against, so
+  // it is read from memory rather than through the file it is also written to
+  const auto compiled{sourcemeta::one::Authentication::compile(
+      view_policies, configuration.path,
+      [](const std::string_view) { return true; })};
+  sourcemeta::one::Authentication::write(compiled, authentication_path);
+  const sourcemeta::one::Authentication gate{compiled, {}};
   const auto visible{view_filter_from(gate)};
 
   auto produce_plan{sourcemeta::one::delta<sourcemeta::one::INDEX_RULES>(

--- a/src/router/artifact.cc
+++ b/src/router/artifact.cc
@@ -65,10 +65,15 @@ auto RouterAction::artifact_locate(const Authentication::Path &path,
   return canonical;
 }
 
+auto RouterAction::caller_from(const Credentials &credentials) const
+    -> Authentication::Caller {
+  return this->dispatcher_.authentication().caller(credentials);
+}
+
 auto RouterAction::artifact_resolve_path(
-    const std::string_view view, const Credentials credentials,
-    const std::string_view input, const Tree tree,
-    const std::string_view artifact_name) const -> ArtifactResolution {
+    const Authentication::Caller &caller, const std::string_view input,
+    const Tree tree, const std::string_view artifact_name) const
+    -> ArtifactResolution {
   // The gate and the locator have to agree on where a request points, so both
   // read the one canonical path rather than each deriving its own. A path that
   // names nowhere in this instance is refused without consulting the gate,
@@ -82,11 +87,12 @@ auto RouterAction::artifact_resolve_path(
   // the existence check, so a path held back from this caller and a path that
   // was never here are indistinguishable from the outside
   const auto &authentication{this->dispatcher_.authentication()};
-  if (!authentication.admits(path.value(), credentials).allowed) {
+  if (!authentication.permits(path.value(), caller)) {
     return {.path = std::nullopt, .is_public = false};
   }
 
-  auto located{this->artifact_locate(path.value(), tree, view, artifact_name)};
+  auto located{
+      this->artifact_locate(path.value(), tree, caller.view(), artifact_name)};
   if (!located.has_value()) {
     // Nothing is served on a miss, so report the path as not public and let a
     // caller that skips the check fall back to a private caching directive
@@ -94,11 +100,6 @@ auto RouterAction::artifact_resolve_path(
     return {.path = std::nullopt, .is_public = false};
   }
 
-  // A caller that presented nothing and was admitted means the path is open
-  // to anonymous callers, otherwise its public reach is checked with nothing
-  // presented, so a response admitted through a session is never marked
-  // public for shared caches
-  //
   // Reaching a location anonymously is not the same as every caller being
   // served the same thing there. A shared cache keys on the URL, and one URL in
   // the view tree answers differently per view, so storing one caller's copy
@@ -107,13 +108,17 @@ auto RouterAction::artifact_resolve_path(
   //
   // Only the anonymous answer may be stored for reuse, since what it holds is
   // what anybody may read by construction, and it is the answer any other
-  // anonymous caller would have been given anyway. The unit tree holds one
-  // answer whoever asks, so nothing there turns on this
-  const auto shareable{tree == Tree::Schemas || view == VIEW_PUBLIC};
+  // anonymous caller would have been given anyway.
+  //
+  // The two trees answer this differently because they are shaped differently.
+  // A view tree answer is shareable exactly when it came from the anonymous
+  // view, since reaching one at all means the location is ungoverned. The unit
+  // tree holds one answer whoever asks, so what decides it there is whether
+  // anybody at all may read the location, asked of the anonymous view
   const auto is_public{
-      shareable &&
-      ((credentials.bearer.empty() && credentials.cookies.empty()) ||
-       authentication.admits(path.value(), {}).allowed)};
+      tree == Tree::Schemas
+          ? authentication.permits(path.value(), authentication.caller({}))
+          : caller.view() == VIEW_PUBLIC};
   return {.path = ResolvedArtifact{std::move(located).value()},
           .is_public = is_public};
 }

--- a/src/router/evaluate.cc
+++ b/src/router/evaluate.cc
@@ -60,7 +60,7 @@ auto RouterAction::structural_evaluate_fast(
   return evaluator.validate(*schema_template, instance);
 }
 
-auto RouterAction::blaze_template(const Credentials credentials,
+auto RouterAction::blaze_template(const Authentication::Caller &caller,
                                   const std::string_view schema_uri,
                                   const sourcemeta::blaze::Mode mode) const
     -> std::shared_ptr<const sourcemeta::blaze::Template> {
@@ -68,7 +68,7 @@ auto RouterAction::blaze_template(const Credentials credentials,
   // asks and carries no segment naming a view, so what is named here reaches
   // no path and the anonymous one stands for every caller
   const auto resolution{this->artifact_resolve_path(
-      sourcemeta::one::VIEW_PUBLIC, credentials, schema_uri, Tree::Schemas,
+      caller, schema_uri, Tree::Schemas,
       mode == sourcemeta::blaze::Mode::FastValidation ? "blaze-fast"
                                                       : "blaze-exhaustive")};
   assert(resolution.path.has_value());
@@ -76,21 +76,20 @@ auto RouterAction::blaze_template(const Credentials credentials,
 }
 
 auto RouterAction::schema_evaluate_fast(
-    const Credentials credentials, const std::string_view schema_uri,
+    const Authentication::Caller &caller, const std::string_view schema_uri,
     const sourcemeta::core::JSON &instance) const -> bool {
   const auto schema_template{this->blaze_template(
-      credentials, schema_uri, sourcemeta::blaze::Mode::FastValidation)};
+      caller, schema_uri, sourcemeta::blaze::Mode::FastValidation)};
   sourcemeta::blaze::Evaluator evaluator;
   return evaluator.validate(*schema_template, instance);
 }
 
-auto RouterAction::schema_evaluate(const Credentials credentials,
+auto RouterAction::schema_evaluate(const Authentication::Caller &caller,
                                    const std::string_view schema_uri,
                                    const sourcemeta::core::JSON &instance,
                                    const sourcemeta::blaze::Mode mode) const
     -> std::pair<bool, sourcemeta::core::JSON> {
-  const auto schema_template{
-      this->blaze_template(credentials, schema_uri, mode)};
+  const auto schema_template{this->blaze_template(caller, schema_uri, mode)};
   sourcemeta::blaze::Evaluator evaluator;
   auto result{
       sourcemeta::blaze::standard(evaluator, *schema_template, instance,
@@ -102,11 +101,11 @@ auto RouterAction::schema_evaluate(const Credentials credentials,
 }
 
 auto RouterAction::schema_evaluate_with_tracing(
-    const Credentials credentials, const std::string_view schema_uri,
+    const Authentication::Caller &caller, const std::string_view schema_uri,
     const sourcemeta::core::JSON &instance,
     const sourcemeta::blaze::Callback &callback) const -> bool {
   const auto schema_template{this->blaze_template(
-      credentials, schema_uri, sourcemeta::blaze::Mode::Exhaustive)};
+      caller, schema_uri, sourcemeta::blaze::Mode::Exhaustive)};
   sourcemeta::blaze::Evaluator evaluator;
   return evaluator.validate(*schema_template, instance, callback);
 }

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -126,21 +126,21 @@ public:
   auto operator=(const RouterAction &) -> RouterAction & = delete;
   auto operator=(RouterAction &&) -> RouterAction & = delete;
 
-  // The view a caller is served arrives alongside what they presented, because
-  // it follows from the same reading and a request resolves several artifacts.
-  // Working it out where a path is built would place the same caller once per
-  // artifact rather than once per request
+  // Who is asking arrives already read, because a request resolves several
+  // artifacts and every one of them asks the same question about the same
+  // caller. Reading it where a path is built would place the same caller once
+  // per artifact rather than once per request
   virtual auto rest(const std::span<std::string_view> matches,
-                    std::string_view credential, std::string_view view,
-                    HTTPRequest &request, HTTPResponse &response) -> void = 0;
+                    const Authentication::Caller &caller, HTTPRequest &request,
+                    HTTPResponse &response) -> void = 0;
 
-  // The whole credential rather than the bearer alone, since a browser reaching
-  // a tool is admitted by its session cookie and would otherwise pass the gate
-  // and then be refused by whatever the tool resolves on its behalf
+  // The caller rather than the bearer alone, since a browser reaching a tool is
+  // admitted by its session cookie and would otherwise pass the gate and then
+  // be refused by whatever the tool resolves on its behalf
   virtual auto mcp(const sourcemeta::core::MCPProtocolVersion version,
                    const sourcemeta::core::JSON &id,
                    const sourcemeta::core::JSON &arguments,
-                   const Credentials &credentials)
+                   const Authentication::Caller &caller)
       -> sourcemeta::core::JSON = 0;
 
   // Whether this route stays reachable no matter which policies cover its path.
@@ -237,11 +237,18 @@ public:
       .x_frame_options = "DENY",
   };
 
-  [[nodiscard]] auto artifact_resolve_path(std::string_view view,
-                                           Credentials credentials,
+  // The tree decides whether a view applies, since the unit tree holds one
+  // answer whoever asks, so a caller names who they are and nothing else
+  [[nodiscard]] auto artifact_resolve_path(const Authentication::Caller &caller,
                                            std::string_view input, Tree tree,
                                            std::string_view artifact_name) const
       -> ArtifactResolution;
+
+  // Place a caller from credentials this action is holding rather than from the
+  // request it arrived on. A deferred body outlives its request, so what it
+  // presented has to be owned and read again once the body is there
+  [[nodiscard]] auto caller_from(const Credentials &credentials) const
+      -> Authentication::Caller;
 
   // The caching directive for served registry content. A response admitted
   // only via a credential must not be stored by shared caches, so it is
@@ -282,17 +289,18 @@ public:
       -> bool;
 
   [[nodiscard]] auto
-  schema_evaluate_fast(Credentials credentials, std::string_view schema_uri,
+  schema_evaluate_fast(const Authentication::Caller &caller,
+                       std::string_view schema_uri,
                        const sourcemeta::core::JSON &instance) const -> bool;
 
-  [[nodiscard]] auto schema_evaluate(Credentials credentials,
+  [[nodiscard]] auto schema_evaluate(const Authentication::Caller &caller,
                                      std::string_view schema_uri,
                                      const sourcemeta::core::JSON &instance,
                                      sourcemeta::blaze::Mode mode) const
       -> std::pair<bool, sourcemeta::core::JSON>;
 
   [[nodiscard]] auto schema_evaluate_with_tracing(
-      Credentials credentials, std::string_view schema_uri,
+      const Authentication::Caller &caller, std::string_view schema_uri,
       const sourcemeta::core::JSON &instance,
       const sourcemeta::blaze::Callback &callback) const -> bool;
 
@@ -333,7 +341,7 @@ private:
                                          sourcemeta::blaze::Mode mode) const
       -> std::shared_ptr<const sourcemeta::blaze::Template>;
 
-  [[nodiscard]] auto blaze_template(Credentials credentials,
+  [[nodiscard]] auto blaze_template(const Authentication::Caller &caller,
                                     std::string_view schema_uri,
                                     sourcemeta::blaze::Mode mode) const
       -> std::shared_ptr<const sourcemeta::blaze::Template>;

--- a/src/router/router.cc
+++ b/src/router/router.cc
@@ -15,20 +15,32 @@ namespace sourcemeta::one {
 
 namespace {
 
-auto default_jwks_fetcher() -> sourcemeta::core::JWKSProvider::Fetcher {
-  return [](const std::string_view url)
-             -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
+// The one way authentication reaches a provider from a running server. It is
+// composed here rather than inside the module, so what may touch a network is
+// decided by whoever stands the server up
+auto provider_fetcher() -> Authentication::Fetcher {
+  return [](Authentication::ProviderRequest &&incoming)
+             -> std::optional<Authentication::ProviderResponse> {
     try {
-      sourcemeta::core::HTTPSystemRequest request{std::string{url}};
+      const auto posting{!incoming.body.empty()};
+      sourcemeta::core::HTTPSystemRequest request{
+          std::string{incoming.url}, posting
+                                         ? sourcemeta::core::HTTPMethod::POST
+                                         : sourcemeta::core::HTTPMethod::GET};
       request.connect_timeout(std::chrono::seconds{2});
       request.timeout(std::chrono::seconds{5});
       request.maximum_response_size(1024UL * 1024UL);
       request.follow_redirects(false);
-      const auto response{request.send()};
-      if (response.status.code < 200 || response.status.code >= 300) {
-        return std::nullopt;
+      if (!incoming.authorization.empty()) {
+        request.header("authorization", std::move(incoming.authorization));
       }
 
+      if (posting) {
+        request.body(std::move(incoming.body),
+                     "application/x-www-form-urlencoded");
+      }
+
+      const auto response{request.send()};
       std::optional<std::chrono::seconds> max_age;
       const auto header{sourcemeta::core::http_header_find(response.headers,
                                                            "cache-control")};
@@ -36,8 +48,10 @@ auto default_jwks_fetcher() -> sourcemeta::core::JWKSProvider::Fetcher {
         max_age = sourcemeta::core::http_cache_control_max_age(header.value());
       }
 
-      return sourcemeta::core::JWKSProvider::FetchResult{.body = response.body,
-                                                         .max_age = max_age};
+      return Authentication::ProviderResponse{
+          .status = static_cast<std::uint32_t>(response.status.code),
+          .body = response.body,
+          .max_age = max_age};
     } catch (...) {
       return std::nullopt;
     }
@@ -53,7 +67,7 @@ Router::Router(const std::filesystem::path &base,
       // NOLINTNEXTLINE(modernize-avoid-c-arrays)
       slots_{std::make_unique<Slot[]>(router.size() + 1)},
       slots_size_{router.size() + 1},
-      authentication_{base / "authentication.bin", default_jwks_fetcher()} {
+      authentication_{base / "authentication.bin", provider_fetcher()} {
   router.arguments(0, [this](const auto &key, const auto &value) -> void {
     if (key == "errorSchema") {
       this->default_error_schema_ = std::get<std::string_view>(value);
@@ -128,13 +142,15 @@ auto Router::dispatch(
   // target reaching past a governed prefix is therefore still governed by it,
   // while one that merely addresses content relative to its own route is not
   const RequestCookies cookies{request};
+  // Read once here, since the same caller is served every artifact this request
+  // reaches and every gate question asked of them afterwards is a comparison
+  // against this rather than another reading of what they presented
+  const auto caller{
+      this->authentication_.caller({.bearer = credential, .cookies = cookies})};
   if (identifier != 0 && request.method() != "options" &&
       !instance->is_authentication_exempt() &&
-      !this->authentication_
-           .admits_route(request.path(),
-                         {.bearer = credential, .cookies = cookies},
-                         instance->required_audience())
-           .allowed) {
+      !this->authentication_.permits(RouteTarget{request.path()}, caller,
+                                     instance->required_audience())) {
     if (instance->serve_renewal_page(request, response)) {
       return;
     }
@@ -145,12 +161,7 @@ auto Router::dispatch(
     return;
   }
 
-  // Resolved once here, since the same caller is served every artifact this
-  // request reaches and placing them again for each of them would repeat the
-  // reading rather than the lookup
-  const auto view{
-      this->authentication_.view({.bearer = credential, .cookies = cookies})};
-  instance->rest(matches, credential, view, request, response);
+  instance->rest(matches, caller, request, response);
 }
 
 // A dead end only becomes a silent renewal when the browser carries the marker
@@ -163,49 +174,33 @@ auto RouterAction::serve_renewal(sourcemeta::one::HTTPRequest &request,
                                  sourcemeta::one::HTTPResponse &response) const
     -> bool {
   const RequestCookies cookies{request};
-  if (cookies.empty()) {
-    return false;
-  }
-
-  std::vector<std::string_view> candidates;
-  for (const auto field : std::span<const std::string_view>{cookies}) {
-    sourcemeta::core::http_cookie_values(field, Authentication::RENEWAL_COOKIE,
-                                         candidates);
-  }
-
-  if (candidates.empty()) {
-    return false;
-  }
-
   const auto path{
       Authentication::Path::parse(request.path(), this->server_uri())};
   if (!path.has_value()) {
     return false;
   }
 
-  const auto &authentication{this->dispatcher().authentication()};
-  for (const auto candidate : candidates) {
-    if (!authentication.interactive(path.value(), candidate).has_value()) {
-      continue;
-    }
-
-    // The denied page is named outright rather than left to a referrer, which
-    // a redirect carries from wherever the browser came from rather than from
-    // the page it is being sent away from
-    std::string location{""};
-    location += "/self/v1/auth/login/";
-    location += candidate;
-    location += "?silent=1&to=";
-    sourcemeta::core::URI::escape(request.path(), location);
-    response.write_status(sourcemeta::core::HTTP_STATUS_SEE_OTHER);
-    response.write_header("Location", location);
-    response.write_header("Cache-Control", "no-store");
-    sourcemeta::one::send_response(sourcemeta::core::HTTP_STATUS_SEE_OTHER,
-                                   request, response);
-    return true;
+  const auto policy{this->dispatcher().authentication().renewal(
+      path.value(), {.cookies = cookies})};
+  if (!policy.has_value()) {
+    return false;
   }
 
-  return false;
+  // Where a login begins is this instance's own layout, so it is composed here
+  // rather than answered from elsewhere. The denied page is named outright
+  // rather than left to a referrer, which a redirect carries from wherever the
+  // browser came from rather than from the page it is being sent away from
+  std::string location{""};
+  location += "/self/v1/auth/login/";
+  location += policy.value();
+  location += "?silent=1&to=";
+  sourcemeta::core::URI::escape(request.path(), location);
+  response.write_status(sourcemeta::core::HTTP_STATUS_SEE_OTHER);
+  response.write_header("Location", location);
+  response.write_header("Cache-Control", "no-store");
+  sourcemeta::one::send_response(sourcemeta::core::HTTP_STATUS_SEE_OTHER,
+                                 request, response);
+  return true;
 }
 
 auto RouterAction::serve_renewal_page(

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -22,6 +22,19 @@ static auto at(const std::string_view input)
 // serves, so every path a policy is scoped to is one to gate
 static auto anywhere(const std::string_view) -> bool { return true; }
 
+// The artifact is compiled and then persisted, which the tests below do
+// together because they read it back through a file
+static auto
+save(const std::span<const sourcemeta::one::Authentication::Policy> policies,
+     const std::filesystem::path &configuration,
+     const std::filesystem::path &destination,
+     const sourcemeta::one::Authentication::PathGuard &gateable) -> void {
+  sourcemeta::one::Authentication::write(
+      sourcemeta::one::Authentication::compile(policies, configuration,
+                                               gateable),
+      destination);
+}
+
 static auto test_path(const std::string &name) -> std::filesystem::path {
   return std::filesystem::path{AUTHENTICATION_TEST_DIRECTORY} / name;
 }
@@ -29,38 +42,41 @@ static auto test_path(const std::string &name) -> std::filesystem::path {
 TEST(admits_every_path_without_a_credential) {
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_TRUE(authentication.admits(at("/"), {.bearer = ""}).allowed);
-  EXPECT_TRUE(authentication.admits(at(""), {.bearer = ""}).allowed);
   EXPECT_TRUE(
-      authentication.admits(at("/acme/foo/bar"), {.bearer = ""}).allowed);
+      authentication.permits(at("/"), authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(
+      authentication.permits(at(""), authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(at("/acme/foo/bar"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(admits_every_path_with_any_credential) {
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_TRUE(
-      authentication.admits(at("/internal"), {.bearer = "anything"}).allowed);
-  EXPECT_TRUE(authentication.admits(at("/internal/foo"), {.bearer = "another"})
-                  .allowed);
+  EXPECT_TRUE(authentication.permits(
+      at("/internal"), authentication.caller({.bearer = "anything"})));
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "another"})));
 }
 
 TEST(save_emits_an_empty_artifact_that_admits_everything) {
   const auto path{test_path("community_public_root.bin")};
-  sourcemeta::one::Authentication::save({}, path, path, anywhere);
+  save({}, path, path, anywhere);
 
   EXPECT_TRUE(std::filesystem::exists(path));
   EXPECT_EQ(std::filesystem::file_size(path), 0);
 
   const sourcemeta::one::Authentication authentication{path, {}};
-  EXPECT_TRUE(authentication.admits(at("/"), {.bearer = ""}).allowed);
   EXPECT_TRUE(
-      authentication.admits(at("/internal/foo"), {.bearer = ""}).allowed);
+      authentication.permits(at("/"), authentication.caller({.bearer = ""})));
+  EXPECT_TRUE(authentication.permits(at("/internal/foo"),
+                                     authentication.caller({.bearer = ""})));
 }
 
 TEST(save_creates_the_directory_it_writes_into) {
   const auto path{test_path("nested") / "deeper" / "authentication.bin"};
   std::filesystem::remove_all(test_path("nested"));
-  sourcemeta::one::Authentication::save({}, path, path, anywhere);
+  save({}, path, path, anywhere);
 
   EXPECT_TRUE(std::filesystem::exists(path));
   EXPECT_EQ(std::filesystem::file_size(path), 0);
@@ -72,7 +88,7 @@ TEST(save_rejects_any_policy) {
       {{paths, {}}}};
   const auto path{test_path("community_policy.bin")};
   try {
-    sourcemeta::one::Authentication::save(policies, path, path, anywhere);
+    save(policies, path, path, anywhere);
     FAIL();
   } catch (const sourcemeta::one::EnterpriseOnlyFeatureError &error) {
     EXPECT_STREQ(error.what(),
@@ -120,29 +136,35 @@ TEST(serves_every_caller_the_anonymous_view) {
       {"sourcemeta_one_session=whatever"}};
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_EQ(authentication.view({.bearer = ""}), "public");
-  EXPECT_EQ(authentication.view({.bearer = "anything"}), "public");
-  EXPECT_EQ(authentication.view({.bearer = "", .cookies = cookies}), "public");
+  EXPECT_EQ(authentication.caller({.bearer = ""}).view(), "public");
+  EXPECT_EQ(authentication.caller({.bearer = "anything"}).view(), "public");
+  EXPECT_EQ(authentication.caller({.bearer = "", .cookies = cookies}).view(),
+            "public");
 }
 
-TEST(classifies_a_caller_presenting_nothing_as_anonymous) {
+// Nothing is governed here, so a caller presenting anything at all reaches
+// everywhere, which is the same answer they get for presenting nothing
+TEST(admits_a_caller_presenting_nothing_everywhere) {
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_EQ(authentication.classify({.bearer = ""}),
-            sourcemeta::one::Authentication::PolicySet{0});
+  EXPECT_TRUE(authentication.permits(at("/"), authentication.caller({})));
+  EXPECT_TRUE(
+      authentication.permits(at("/internal/foo"), authentication.caller({})));
 }
 
-TEST(classifies_a_caller_presenting_a_credential_as_anonymous) {
+TEST(admits_a_caller_presenting_a_credential_everywhere) {
   const std::array<std::string_view, 1> cookies{
       {"sourcemeta_one_session=whatever"}};
   const sourcemeta::one::Authentication authentication{
       std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_EQ(authentication.classify({.bearer = "anything"}),
-            sourcemeta::one::Authentication::PolicySet{0});
-  EXPECT_EQ(authentication.classify({.bearer = "", .cookies = cookies}),
-            sourcemeta::one::Authentication::PolicySet{0});
-  EXPECT_EQ(authentication.classify({.bearer = "another", .cookies = cookies}),
-            sourcemeta::one::Authentication::PolicySet{0});
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/foo"), authentication.caller({.bearer = "anything"})));
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/foo"),
+      authentication.caller({.bearer = "", .cookies = cookies})));
+  EXPECT_TRUE(authentication.permits(
+      at("/internal/foo"),
+      authentication.caller({.bearer = "another", .cookies = cookies})));
 }
 
 TEST(views_of_nothing_are_the_public_one_alone) {
@@ -156,9 +178,9 @@ TEST(views_of_a_static_key_policy_are_the_public_one_alone) {
   const std::array<std::string_view, 1> keys{{"secret"}};
   const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
       {{.paths = paths,
-        .keys = keys,
-        .type = sourcemeta::one::Authentication::Type::ApiKey,
-        .name = "vault"}}};
+        .name = "vault",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
@@ -170,13 +192,14 @@ TEST(views_of_several_policies_are_the_public_one_alone) {
   const std::array<std::string_view, 1> second_paths{{"/tech"}};
   const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
       {{.paths = first_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "legal"},
+        .name = "legal",
+        .credential =
+            sourcemeta::one::Authentication::Policy::Token{
+                .issuer = "https://idp.example.com/realms/staff"}},
        {.paths = second_paths,
-        .type = sourcemeta::one::Authentication::Type::JWT,
-        .issuer = "https://idp.example.com/realms/staff",
-        .name = "tech"}}};
+        .name = "tech",
+        .credential = sourcemeta::one::Authentication::Policy::Token{
+            .issuer = "https://idp.example.com/realms/staff"}}}};
 
   const auto views{sourcemeta::one::Authentication::views(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

