### PR TITLE
Split the compiled policy table out of `Authentication`

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -345,7 +345,7 @@ auto structurally_valid(const std::span<const std::byte> bytes) noexcept
   // shift past the width of a PolicySet, which is undefined behavior
   if (header->magic != AUTHENTICATION_MAGIC ||
       header->version != AUTHENTICATION_VERSION || header->node_count == 0 ||
-      header->policy_count > Authentication::MAXIMUM_POLICIES) {
+      header->policy_count > AUTHENTICATION_MAXIMUM_POLICIES) {
     return false;
   }
 
@@ -401,7 +401,7 @@ auto structurally_valid(const std::span<const std::byte> bytes) noexcept
 
     // A view naming a policy the artifact does not carry could never be
     // resolved to, and on a full mask would shift past the width of a set
-    if (header->policy_count < Authentication::MAXIMUM_POLICIES &&
+    if (header->policy_count < AUTHENTICATION_MAXIMUM_POLICIES &&
         (entry.policies >> header->policy_count) != 0) {
       return false;
     }
@@ -434,7 +434,8 @@ auto structurally_valid(const std::span<const std::byte> bytes) noexcept
           entry.name_length > strings_length - entry.name_offset ||
           entry.algorithm >
               static_cast<std::uint8_t>(Authentication::Algorithm::Sha256) ||
-          entry.type > static_cast<std::uint8_t>(Authentication::Type::OIDC)) {
+          entry.type >
+              static_cast<std::uint8_t>(AuthenticationPolicyType::OIDC)) {
         return false;
       }
 
@@ -1121,9 +1122,9 @@ struct Authentication::Table::Impl {
         at_offset<AuthenticationPolicyEntry>(bytes, header->policies_offset)};
     for (std::uint32_t index{0}; index < header->policy_count; index += 1) {
       const auto &entry{policies[index]};
-      const auto type{static_cast<Authentication::Type>(entry.type)};
-      if ((type != Authentication::Type::JWT &&
-           type != Authentication::Type::OIDC) ||
+      const auto type{static_cast<AuthenticationPolicyType>(entry.type)};
+      if ((type != AuthenticationPolicyType::JWT &&
+           type != AuthenticationPolicyType::OIDC) ||
           entry.metadata_length == 0) {
         continue;
       }
@@ -1132,7 +1133,7 @@ struct Authentication::Table::Impl {
           at_offset<std::byte>(bytes, entry.metadata_offset),
           entry.metadata_length};
       std::string_view serialized;
-      if (type == Authentication::Type::JWT) {
+      if (type == AuthenticationPolicyType::JWT) {
         if (!read_jwt_claims(metadata, serialized)) {
           return false;
         }
@@ -1207,8 +1208,7 @@ struct Authentication::Table::Impl {
     }
 
     for (const auto sealed : candidates) {
-      auto opened{this->open(policy_name, Authentication::Purpose::Transaction,
-                             sealed)};
+      auto opened{this->open(policy_name, SealPurpose::Transaction, sealed)};
       if (!opened.has_value()) {
         continue;
       }
@@ -1263,7 +1263,7 @@ struct Authentication::Table::Impl {
 
     std::ostringstream payload_text;
     sourcemeta::core::stringify(payload, payload_text);
-    const auto sealed{this->seal(policy_name, Authentication::Purpose::Session,
+    const auto sealed{this->seal(policy_name, SealPurpose::Session,
                                  payload_text.str(), expiry)};
     if (!sealed.has_value()) {
       log.emplace_back("No session secret is set for the policy");
@@ -1414,8 +1414,8 @@ struct Authentication::Table::Impl {
                   entry.metadata_length};
     }
 
-    const auto type{static_cast<Authentication::Type>(entry.type)};
-    if (type == Authentication::Type::JWT) {
+    const auto type{static_cast<AuthenticationPolicyType>(entry.type)};
+    if (type == AuthenticationPolicyType::JWT) {
       return token.has_value() &&
              this->admits_jwt(metadata, token.value(), required_audience,
                               this->claims_[index]);
@@ -1425,7 +1425,7 @@ struct Authentication::Table::Impl {
     // browser login established, never a presented credential. A request that
     // presented one is asking to be read as that credential, so its session is
     // not consulted at all rather than quietly widening what it reaches
-    if (type == Authentication::Type::OIDC) {
+    if (type == AuthenticationPolicyType::OIDC) {
       return credential.empty() && this->admits_session(metadata, cookies);
     }
 
@@ -1457,8 +1457,8 @@ struct Authentication::Table::Impl {
 
       // Only token policies combine, so anything else stands for the caller on
       // its own and the first one reached is the one read
-      if (static_cast<Authentication::Type>(policies[index].type) !=
-          Authentication::Type::JWT) {
+      if (static_cast<AuthenticationPolicyType>(policies[index].type) !=
+          AuthenticationPolicyType::JWT) {
         if (result == 0) {
           return Authentication::PolicySet{1} << index;
         }
@@ -1573,8 +1573,8 @@ struct Authentication::Table::Impl {
       sourcemeta::core::http_cookie_values(field, SESSION_COOKIE, candidates);
     }
     for (const auto sealed : candidates) {
-      const auto payload{this->session_open(
-          decoded.session_secrets, Authentication::Purpose::Session, sealed)};
+      const auto payload{this->session_open(decoded.session_secrets,
+                                            SealPurpose::Session, sealed)};
       if (!payload.has_value()) {
         continue;
       }
@@ -1616,8 +1616,8 @@ struct Authentication::Table::Impl {
         static_cast<const AuthenticationPolicyEntry *>(this->policies_)};
     for (std::uint32_t index{0}; index < this->policy_count_; index += 1) {
       const auto &entry{policies[index]};
-      if (static_cast<Authentication::Type>(entry.type) !=
-              Authentication::Type::OIDC ||
+      if (static_cast<AuthenticationPolicyType>(entry.type) !=
+              AuthenticationPolicyType::OIDC ||
           entry.metadata_length == 0) {
         continue;
       }
@@ -1630,8 +1630,8 @@ struct Authentication::Table::Impl {
         continue;
       }
 
-      const auto payload{this->session_open(
-          decoded.session_secrets, Authentication::Purpose::Session, value)};
+      const auto payload{this->session_open(decoded.session_secrets,
+                                            SealPurpose::Session, value)};
       if (!payload.has_value()) {
         continue;
       }
@@ -1666,8 +1666,8 @@ struct Authentication::Table::Impl {
         static_cast<const AuthenticationPolicyEntry *>(this->policies_)};
     for (std::uint32_t index{0}; index < this->policy_count_; index += 1) {
       const auto &entry{policies[index]};
-      if (static_cast<Authentication::Type>(entry.type) !=
-              Authentication::Type::OIDC ||
+      if (static_cast<AuthenticationPolicyType>(entry.type) !=
+              AuthenticationPolicyType::OIDC ||
           entry.metadata_length == 0) {
         continue;
       }
@@ -1702,8 +1702,8 @@ struct Authentication::Table::Impl {
         static_cast<const AuthenticationPolicyEntry *>(this->policies_)};
     for (std::uint32_t index{0}; index < this->policy_count_; index += 1) {
       const auto &entry{policies[index]};
-      if (static_cast<Authentication::Type>(entry.type) !=
-              Authentication::Type::OIDC ||
+      if (static_cast<AuthenticationPolicyType>(entry.type) !=
+              AuthenticationPolicyType::OIDC ||
           entry.metadata_length == 0) {
         continue;
       }
@@ -1750,8 +1750,8 @@ struct Authentication::Table::Impl {
         static_cast<const AuthenticationPolicyEntry *>(this->policies_)};
     for (std::uint32_t index{0}; index < this->policy_count_; index += 1) {
       const auto &entry{policies[index]};
-      if (static_cast<Authentication::Type>(entry.type) !=
-              Authentication::Type::OIDC ||
+      if (static_cast<AuthenticationPolicyType>(entry.type) !=
+              AuthenticationPolicyType::OIDC ||
           entry.metadata_length == 0) {
         continue;
       }
@@ -1810,8 +1810,8 @@ struct Authentication::Table::Impl {
       }
 
       const auto &entry{policies[index]};
-      if (static_cast<Authentication::Type>(entry.type) !=
-              Authentication::Type::OIDC ||
+      if (static_cast<AuthenticationPolicyType>(entry.type) !=
+              AuthenticationPolicyType::OIDC ||
           entry.metadata_length == 0) {
         continue;
       }
@@ -1861,7 +1861,7 @@ struct Authentication::Table::Impl {
   // so a secret can be replaced by putting the new one first and dropping the
   // old once every value signed under it has expired
   [[nodiscard]] auto session_seal(const std::span<const std::byte> variables,
-                                  const Authentication::Purpose purpose,
+                                  const SealPurpose purpose,
                                   const std::string_view payload,
                                   const std::chrono::sys_seconds expiry) const
       -> std::optional<std::string> {
@@ -1876,7 +1876,7 @@ struct Authentication::Table::Impl {
   }
 
   [[nodiscard]] auto session_open(const std::span<const std::byte> variables,
-                                  const Authentication::Purpose purpose,
+                                  const SealPurpose purpose,
                                   const std::string_view value) const
       -> std::optional<std::string> {
     const auto resolved{session_secrets(variables)};
@@ -1897,7 +1897,7 @@ struct Authentication::Table::Impl {
   }
 
   [[nodiscard]] auto seal(const std::string_view policy,
-                          const Authentication::Purpose purpose,
+                          const SealPurpose purpose,
                           const std::string_view payload,
                           const std::chrono::sys_seconds expiry) const
       -> std::optional<std::string> {
@@ -1911,7 +1911,7 @@ struct Authentication::Table::Impl {
   }
 
   [[nodiscard]] auto open(const std::string_view policy,
-                          const Authentication::Purpose purpose,
+                          const SealPurpose purpose,
                           const std::string_view value) const
       -> std::optional<std::string> {
     OIDCPolicyMetadata decoded;
@@ -2129,10 +2129,10 @@ struct Authentication::Table::Impl {
         const std::span<const std::byte> metadata{
             at_offset<std::byte>(this->bytes_, entry.metadata_offset),
             entry.metadata_length};
-        const auto type{static_cast<Authentication::Type>(entry.type)};
-        if (type == Authentication::Type::JWT) {
+        const auto type{static_cast<AuthenticationPolicyType>(entry.type)};
+        if (type == AuthenticationPolicyType::JWT) {
           collect_jwt_identifiers(metadata, result.keys);
-        } else if (type == Authentication::Type::OIDC) {
+        } else if (type == AuthenticationPolicyType::OIDC) {
           collect_oidc_identifiers(metadata, result.keys);
         } else {
           collect_keys(metadata, result.keys);
@@ -2314,8 +2314,8 @@ auto view_name(const std::span<const Authentication::Policy> policies,
 
 auto Authentication::Table::enumerate(
     const std::span<const Authentication::Policy> policies)
-    -> std::vector<Authentication::View> {
-  std::vector<Authentication::View> result;
+    -> std::vector<Authentication::Table::View> {
+  std::vector<Authentication::Table::View> result;
   // Always present, and the only entry when nothing is declared. A registry
   // whose every path is governed still has one, since it is what a caller
   // holding nothing is shown and what a lookup falls back to
@@ -2340,7 +2340,7 @@ auto Authentication::Table::enumerate(
 
   std::vector<std::string_view> issuers;
   std::vector<std::vector<std::size_t>> groups;
-  std::vector<Authentication::View> named;
+  std::vector<Authentication::Table::View> named;
 
   for (std::size_t index{0}; index < policies.size(); index++) {
     const auto &policy{policies[index]};
@@ -2623,8 +2623,7 @@ auto Authentication::login(const std::string_view policy_name,
                         std::chrono::system_clock::now()) +
                     TRANSACTION_LIFETIME};
   const auto sealed{this->table_.impl_->seal(
-      policy_name, Authentication::Purpose::Transaction, payload_text.str(),
-      expiry)};
+      policy_name, SealPurpose::Transaction, payload_text.str(), expiry)};
   if (!sealed.has_value()) {
     result.log.emplace_back("No session secret is set for the policy");
     return result;
@@ -3119,7 +3118,7 @@ auto Authentication::Table::visible(
   // this answers rather than whoever asks. Otherwise what nobody governs would
   // be shown by an instance knowing nothing about who governs what, which is
   // the one way this could disclose more than the gate admits
-  return this->impl_->permits(path.value(), view.policies());
+  return this->impl_->permits(path.value(), view.policies_);
 }
 
 auto Authentication::Table::governing(const Authentication::Path &path) const

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -1481,8 +1481,10 @@ struct Authentication::Table::Impl {
     assert(index < this->view_count_);
     const auto &entry{
         static_cast<const AuthenticationViewEntry *>(this->views_)[index]};
-    return {.name = {this->strings_ + entry.name_offset, entry.name_length},
-            .policies = entry.policies};
+    Authentication::RecordedView result;
+    result.name_ = {this->strings_ + entry.name_offset, entry.name_length};
+    result.policies_ = entry.policies;
+    return result;
   }
 
   // The name a set of policies is served under, read from the recorded table
@@ -3100,12 +3102,14 @@ auto Authentication::Table::view(const std::string_view name) const
     -> Authentication::RecordedView {
   for (std::size_t index{0}; index < this->impl_->view_count(); index += 1) {
     const auto candidate{this->impl_->view_at(index)};
-    if (candidate.name == name) {
+    if (candidate.name() == name) {
       return candidate;
     }
   }
 
-  return {.name = VIEW_PUBLIC, .policies = 0};
+  Authentication::RecordedView result;
+  result.name_ = VIEW_PUBLIC;
+  return result;
 }
 
 auto Authentication::Table::visible(
@@ -3115,7 +3119,7 @@ auto Authentication::Table::visible(
   // this answers rather than whoever asks. Otherwise what nobody governs would
   // be shown by an instance knowing nothing about who governs what, which is
   // the one way this could disclose more than the gate admits
-  return this->impl_->permits(path.value(), view.policies);
+  return this->impl_->permits(path.value(), view.policies());
 }
 
 auto Authentication::Table::governing(const Authentication::Path &path) const

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -170,13 +170,29 @@ enum class Admission : std::uint8_t {
 // stops opening
 constexpr std::chrono::seconds TRANSACTION_LIFETIME{std::chrono::minutes{10}};
 
+// What an interactive policy declares about its provider client. The views
+// point into the artifact and remain valid for as long as it is mapped
+struct InteractivePolicy {
+  std::string_view issuer{};
+  std::string_view client_id{};
+  // The first registry path the policy governs
+  std::string_view default_path{};
+  // The claims a person must carry to be admitted, serialised as the member map
+  // of an OpenID Connect claims request parameter. Empty where the policy names
+  // no rule
+  std::string_view claims{};
+  // The email domains that admit a person. A login asks its provider for an
+  // address whenever this is non-empty, since a rule it cannot read admits
+  // nobody
+  std::vector<std::string_view> email_domains{};
+};
+
 // The claims a policy's rules speak about, each asked for as essential, so that
 // a provider is told what is actually needed rather than being left to guess
 // from a scope. A domain rule reads an address, so it asks for the pair OpenID
 // Connect Core Section 5.1 defines for one
-auto wanted_claims(
-    const sourcemeta::one::Authentication::InteractivePolicy &policy,
-    const std::optional<sourcemeta::core::JSON> &rules)
+auto wanted_claims(const InteractivePolicy &policy,
+                   const std::optional<sourcemeta::core::JSON> &rules)
     -> std::vector<sourcemeta::core::OIDCClaimRequest> {
   std::vector<sourcemeta::core::OIDCClaimRequest> result;
   if (!policy.email_domains.empty()) {
@@ -942,8 +958,8 @@ auto decode_oidc_metadata(const std::span<const std::byte> metadata,
 // is stored as. The domains are copied out, since a caller matching an address
 // against them should not have to know how they are laid out
 auto interactive_policy(const OIDCPolicyMetadata &decoded)
-    -> sourcemeta::one::Authentication::InteractivePolicy {
-  sourcemeta::one::Authentication::InteractivePolicy result;
+    -> InteractivePolicy {
+  InteractivePolicy result;
   result.issuer = decoded.issuer;
   result.client_id = decoded.client_id;
   result.default_path = decoded.default_path;
@@ -1049,7 +1065,7 @@ namespace sourcemeta::one {
 // a governing set is a single machine word
 using PolicySet = std::uint64_t;
 
-struct Authentication::Impl {
+struct Authentication::Table::Impl {
   // The indexer always emits this artifact. A missing, unreadable, or
   // malformed file means it was deleted, corrupted, or produced by an older
   // indexer. Rather than failing open and serving every path publicly, or
@@ -1057,8 +1073,7 @@ struct Authentication::Impl {
   // everything: the section pointers below stay null, so matching yields the
   // empty set and admits no one. Opening the file covers the missing and
   // unreadable cases without a separate, throwing existence check
-  Impl(const std::filesystem::path &path, Authentication::Fetcher fetcher)
-      : fetcher_{std::move(fetcher)} {
+  explicit Impl(const std::filesystem::path &path) {
     std::unique_ptr<sourcemeta::core::FileView> view;
     try {
       view = std::make_unique<sourcemeta::core::FileView>(path);
@@ -1074,8 +1089,7 @@ struct Authentication::Impl {
   // A table compiled in this process is held rather than mapped, so the bytes
   // are copied once and never move again, which is what keeps every section
   // pointer below valid for as long as this exists
-  Impl(const std::span<const std::byte> bytes, Authentication::Fetcher fetcher)
-      : fetcher_{std::move(fetcher)} {
+  explicit Impl(const std::span<const std::byte> bytes) {
     this->owned_.assign(bytes.begin(), bytes.end());
     if (!this->adopt(this->owned_)) {
       this->owned_.clear();
@@ -1668,7 +1682,7 @@ struct Authentication::Impl {
   }
 
   [[nodiscard]] auto interactive(const std::string_view name) const
-      -> std::optional<Authentication::InteractivePolicy> {
+      -> std::optional<InteractivePolicy> {
     OIDCPolicyMetadata decoded;
     if (!this->find_interactive(name, decoded)) {
       return std::nullopt;
@@ -1780,7 +1794,7 @@ struct Authentication::Impl {
 
   [[nodiscard]] auto interactive(const std::string_view path,
                                  const std::string_view name) const
-      -> std::optional<Authentication::InteractivePolicy> {
+      -> std::optional<InteractivePolicy> {
     const auto mask{this->match(path)};
     if (mask == 0 || this->policy_count_ == 0 || name.empty()) {
       return std::nullopt;
@@ -2241,13 +2255,31 @@ struct Authentication::Impl {
   mutable std::map<std::string, ResolvedEndpoints> endpoints_;
 };
 
-Authentication::Authentication(const std::filesystem::path &path,
-                               Authentication::Fetcher fetcher)
-    : impl_{std::make_unique<Impl>(path, std::move(fetcher))} {}
+Authentication::Table::Table(const std::filesystem::path &path)
+    : impl_{std::make_unique<Impl>(path)} {}
 
-Authentication::Authentication(const std::span<const std::byte> bytes,
+Authentication::Table::Table(const std::span<const std::byte> bytes)
+    : impl_{std::make_unique<Impl>(bytes)} {}
+
+Authentication::Table::~Table() = default;
+
+Authentication::Table::Table(Authentication::Table &&) noexcept = default;
+
+auto Authentication::Table::operator=(Authentication::Table &&) noexcept
+    -> Authentication::Table & = default;
+
+// The table is taken rather than borrowed, and the fetcher is installed on it,
+// so that what performs the protocol and what the protocol reads cannot come
+// apart for as long as either exists
+Authentication::Authentication(Authentication::Table &&table,
                                Authentication::Fetcher fetcher)
-    : impl_{std::make_unique<Impl>(bytes, std::move(fetcher))} {}
+    : table_{std::move(table)} {
+  this->table_.impl_->fetcher_ = std::move(fetcher);
+}
+
+auto Authentication::table() const noexcept -> const Authentication::Table & {
+  return this->table_;
+}
 
 Authentication::~Authentication() = default;
 
@@ -2278,7 +2310,7 @@ auto view_name(const std::span<const Authentication::Policy> policies,
 
 } // namespace
 
-auto Authentication::views(
+auto Authentication::Table::enumerate(
     const std::span<const Authentication::Policy> policies)
     -> std::vector<Authentication::View> {
   std::vector<Authentication::View> result;
@@ -2291,8 +2323,14 @@ auto Authentication::views(
   // is read, so only token policies declared against the same issuer can ever
   // be satisfied together. Every other policy stands alone, since a caller
   // presents one key or holds one session
-  // One view takes another's name if two policies share one, which the
-  // configuration refuses long before this is reached
+  // A view is spelled from the names of the policies it comprises, so a policy
+  // without a name leaves a view naming nowhere, and one sharing a name with
+  // another, or taking the name a caller holding nothing is served under,
+  // leaves two views under one name. A configuration is refused for all three
+  // before any of this is reached, so these say what has been established
+  assert(std::ranges::none_of(policies, [](const auto &policy) -> bool {
+    return policy.name.empty() || policy.name == VIEW_PUBLIC;
+  }));
   assert(std::ranges::all_of(policies, [&policies](const auto &policy) -> bool {
     return std::ranges::count(policies, policy.name,
                               &Authentication::Policy::name) == 1;
@@ -2323,7 +2361,7 @@ auto Authentication::views(
 
   for (std::size_t group{0}; group < groups.size(); group++) {
     const auto &members{groups[group]};
-    if (members.size() > Authentication::MAXIMUM_COMBINABLE_POLICIES) {
+    if (members.size() > Authentication::Table::MAXIMUM_COMBINABLE_POLICIES) {
       throw AuthenticationTooManyViewsError(std::string{issuers[group]},
                                             members.size());
     }
@@ -2523,7 +2561,7 @@ auto Authentication::login(const std::string_view policy_name,
   Authentication::Outcome result;
 
   // An unknown or non-interactive policy name reveals nothing
-  const auto policy{this->impl_->interactive(policy_name)};
+  const auto policy{this->table_.impl_->interactive(policy_name)};
   if (!policy.has_value()) {
     result.result = Authentication::Outcome::Result::Missing;
     return result;
@@ -2531,12 +2569,12 @@ auto Authentication::login(const std::string_view policy_name,
 
   // Starting a login that cannot be completed only strands the person at the
   // provider, so the secret the exchange will need is required up front
-  if (!this->impl_->client_secret(policy_name).has_value()) {
+  if (!this->table_.impl_->client_secret(policy_name).has_value()) {
     result.log.emplace_back("No client secret is set for the policy");
     return result;
   }
 
-  const auto endpoints{this->impl_->endpoints(policy_name)};
+  const auto endpoints{this->table_.impl_->endpoints(policy_name)};
   if (!endpoints.has_value() || endpoints.value().authorization.empty()) {
     result.log.emplace_back("The provider named no authorization endpoint, or "
                             "could not be reached, for the policy");
@@ -2582,9 +2620,9 @@ auto Authentication::login(const std::string_view policy_name,
   const auto expiry{std::chrono::time_point_cast<std::chrono::seconds>(
                         std::chrono::system_clock::now()) +
                     TRANSACTION_LIFETIME};
-  const auto sealed{this->impl_->seal(policy_name,
-                                      Authentication::Purpose::Transaction,
-                                      payload_text.str(), expiry)};
+  const auto sealed{this->table_.impl_->seal(
+      policy_name, Authentication::Purpose::Transaction, payload_text.str(),
+      expiry)};
   if (!sealed.has_value()) {
     result.log.emplace_back("No session secret is set for the policy");
     return result;
@@ -2674,7 +2712,7 @@ auto Authentication::renewal(const Authentication::Path &path,
   }
 
   for (const auto candidate : candidates) {
-    const auto policy{this->impl_->interactive(path.value(), candidate)};
+    const auto policy{this->table_.impl_->interactive(path.value(), candidate)};
     if (policy.has_value()) {
       return candidate;
     }
@@ -2699,8 +2737,8 @@ auto Authentication::callback(const std::string_view policy_name,
   // provider echoes back. This runs before either the success or the decline is
   // honoured, so a cross-site callback cannot even trigger an error on a
   // person's behalf, per RFC 6749 Section 4.1.2.1
-  const auto transaction{this->impl_->transaction(policy_name, incoming.state,
-                                                  redirect_uri, credentials)};
+  const auto transaction{this->table_.impl_->transaction(
+      policy_name, incoming.state, redirect_uri, credentials)};
   if (!transaction.has_value()) {
     return result;
   }
@@ -2745,7 +2783,7 @@ auto Authentication::callback(const std::string_view policy_name,
 
   // Which policy a callback belongs to is settled by opening its transaction,
   // so nothing reaching here names one this instance does not serve
-  const auto policy{this->impl_->interactive(policy_name)};
+  const auto policy{this->table_.impl_->interactive(policy_name)};
   if (!policy.has_value()) {
     return abandon(Authentication::Outcome::Result::Invalid);
   }
@@ -2775,23 +2813,23 @@ auto Authentication::callback(const std::string_view policy_name,
     return abandon(Authentication::Outcome::Result::Invalid);
   }
 
-  const auto client_secret{this->impl_->client_secret(policy_name)};
+  const auto client_secret{this->table_.impl_->client_secret(policy_name)};
   if (!client_secret.has_value()) {
     result.log.emplace_back("No client secret is set for the policy");
     return abandon(Authentication::Outcome::Result::Incomplete);
   }
 
-  const auto endpoints{this->impl_->endpoints(policy_name)};
+  const auto endpoints{this->table_.impl_->endpoints(policy_name)};
   if (!endpoints.has_value() || endpoints.value().token.empty()) {
     result.log.emplace_back("The provider named no token endpoint, or could "
                             "not be reached, for the policy");
     return abandon(Authentication::Outcome::Result::Incomplete);
   }
 
-  const auto grant{exchange(this->impl_->fetcher(), endpoints.value().token,
-                            policy->client_id, client_secret.value(),
-                            redirect_uri, incoming.code, verifier->to_string(),
-                            endpoints.value().token_endpoint_basic_auth)};
+  const auto grant{exchange(
+      this->table_.impl_->fetcher(), endpoints.value().token, policy->client_id,
+      client_secret.value(), redirect_uri, incoming.code, verifier->to_string(),
+      endpoints.value().token_endpoint_basic_auth)};
   if (!grant.has_value()) {
     result.log.emplace_back(
         "The authorization code could not be redeemed for the policy");
@@ -2805,8 +2843,8 @@ auto Authentication::callback(const std::string_view policy_name,
     return abandon(Authentication::Outcome::Result::Incomplete);
   }
 
-  auto provider{
-      id_token_keys(endpoints.value().jwks_uri, this->impl_->key_fetcher())};
+  auto provider{id_token_keys(endpoints.value().jwks_uri,
+                              this->table_.impl_->key_fetcher())};
   sourcemeta::core::OIDCValidationOptions options;
   options.nonce = nonce->to_string();
   const auto identity{sourcemeta::core::oidc_validate_id_token(
@@ -2823,8 +2861,8 @@ auto Authentication::callback(const std::string_view policy_name,
   // afterwards would leave a valid session denied on every request, and a
   // denial asks the provider again, which is a loop rather than an answer
   std::optional<sourcemeta::core::JSON> combined;
-  auto admission{
-      this->impl_->admits_identity(policy_name, token.value().payload())};
+  auto admission{this->table_.impl_->admits_identity(policy_name,
+                                                     token.value().payload())};
 
   // OpenID Connect Core Section 5.4 has a provider answer for the claims a
   // scope requested at its UserInfo endpoint rather than in the token, by
@@ -2834,11 +2872,12 @@ auto Authentication::callback(const std::string_view policy_name,
   if (admission == Admission::Incomplete &&
       !endpoints.value().userinfo.empty()) {
     const auto extra{userinfo(
-        this->impl_->fetcher(), endpoints.value().userinfo,
+        this->table_.impl_->fetcher(), endpoints.value().userinfo,
         grant.value().access_token, identity.value().subject, result.log)};
     if (extra.has_value()) {
       combined = combine_claims(token.value().payload(), extra.value());
-      admission = this->impl_->admits_identity(policy_name, combined.value());
+      admission =
+          this->table_.impl_->admits_identity(policy_name, combined.value());
     }
   }
 
@@ -2850,7 +2889,8 @@ auto Authentication::callback(const std::string_view policy_name,
     // token alone would miss a claim the UserInfo endpoint supplied
     const auto &asserted{combined.has_value() ? combined.value()
                                               : token.value().payload()};
-    this->impl_->report_object_shaped_claims(policy_name, asserted, result.log);
+    this->table_.impl_->report_object_shaped_claims(policy_name, asserted,
+                                                    result.log);
     return abandon(Authentication::Outcome::Result::NotAdmitted);
   }
 
@@ -2865,12 +2905,12 @@ auto Authentication::callback(const std::string_view policy_name,
   // without saying so, which would look like signing in and then not being
   // signed in. So the whole cookie is measured, and the token is left out when
   // it does not fit, which costs the confirmation page and nothing else
-  auto session{this->impl_->session_cookie(
+  auto session{this->table_.impl_->session_cookie(
       policy_name, identity.value().subject, grant.value().id_token, expiry,
       secure, result.log)};
   if (session.has_value() && session.value().size() > MAXIMUM_COOKIE_LENGTH) {
-    session = this->impl_->session_cookie(policy_name, identity.value().subject,
-                                          "", expiry, secure, result.log);
+    session = this->table_.impl_->session_cookie(
+        policy_name, identity.value().subject, "", expiry, secure, result.log);
   }
 
   // Without the token there is very little left, so exceeding the limit here
@@ -2956,7 +2996,7 @@ auto Authentication::logout(const Credentials &credentials,
   }
 
   for (const auto sealed : candidates) {
-    const auto payload{this->impl_->open_session(sealed)};
+    const auto payload{this->table_.impl_->open_session(sealed)};
     if (!payload.has_value()) {
       continue;
     }
@@ -2972,7 +3012,7 @@ auto Authentication::logout(const Credentials &credentials,
       continue;
     }
 
-    const auto endpoints{this->impl_->endpoints(policy->to_string())};
+    const auto endpoints{this->table_.impl_->endpoints(policy->to_string())};
     if (!endpoints.has_value() || endpoints.value().end_session.empty()) {
       continue;
     }
@@ -3000,8 +3040,8 @@ auto Authentication::caller(const Credentials &credentials) const
     -> Authentication::Caller {
   Authentication::Caller result;
   result.policies_ =
-      this->impl_->classify(credentials.bearer, credentials.cookies);
-  result.view_ = this->impl_->view_name(result.policies_);
+      this->table_.impl_->classify(credentials.bearer, credentials.cookies);
+  result.view_ = this->table_.impl_->view_name(result.policies_);
   result.bearer_ = credentials.bearer;
   return result;
 }
@@ -3009,14 +3049,14 @@ auto Authentication::caller(const Credentials &credentials) const
 auto Authentication::permits(const Authentication::Path &path,
                              const Authentication::Caller &caller) const
     -> bool {
-  return this->impl_->permits(path.value(), caller.policies_);
+  return this->table_.impl_->permits(path.value(), caller.policies_);
 }
 
 auto Authentication::permits(const RouteTarget &target,
                              const Authentication::Caller &caller,
                              const std::string_view required_audience) const
     -> bool {
-  const auto governing{this->impl_->governing_mask(target.value())};
+  const auto governing{this->table_.impl_->governing_mask(target.value())};
   if (!governing.has_value()) {
     return false;
   }
@@ -3045,44 +3085,55 @@ auto Authentication::permits(const RouteTarget &target,
   return !token.has_value() || token.value().has_audience(required_audience);
 }
 
-auto Authentication::view_count() const -> std::size_t {
-  return this->impl_->view_count();
-}
-
-auto Authentication::view_at(const std::size_t index) const
-    -> Authentication::RecordedView {
-  return this->impl_->view_at(index);
-}
-
-auto Authentication::visible(const Authentication::Path &path,
-                             const std::size_t view) const -> bool {
-  // An index naming no view is one nothing can be shown under, and an instance
-  // that could not read its artifact names none at all. Both answer here rather
-  // than below, since what nobody governs would otherwise be shown by an
-  // instance that knows nothing about who governs what, which is the one way
-  // this could disclose more than the gate admits
-  if (view >= this->impl_->view_count()) {
-    return false;
+auto Authentication::Table::views() const
+    -> std::vector<Authentication::RecordedView> {
+  std::vector<Authentication::RecordedView> result;
+  result.reserve(this->impl_->view_count());
+  for (std::size_t index{0}; index < this->impl_->view_count(); index += 1) {
+    result.push_back(this->impl_->view_at(index));
   }
 
-  const auto governing{this->impl_->match(path.value())};
-  return governing == 0 ||
-         (governing & this->impl_->view_at(view).policies) != 0;
+  return result;
 }
 
-auto Authentication::governing(const Authentication::Path &path) const
-    -> std::vector<std::size_t> {
+auto Authentication::Table::view(const std::string_view name) const
+    -> Authentication::RecordedView {
+  for (std::size_t index{0}; index < this->impl_->view_count(); index += 1) {
+    const auto candidate{this->impl_->view_at(index)};
+    if (candidate.name == name) {
+      return candidate;
+    }
+  }
+
+  return {.name = VIEW_PUBLIC, .policies = 0};
+}
+
+auto Authentication::Table::visible(
+    const Authentication::Path &path,
+    const Authentication::RecordedView &view) const -> bool {
+  // An instance that could not read its artifact shows nothing at all, which
+  // this answers rather than whoever asks. Otherwise what nobody governs would
+  // be shown by an instance knowing nothing about who governs what, which is
+  // the one way this could disclose more than the gate admits
+  return this->impl_->permits(path.value(), view.policies);
+}
+
+auto Authentication::Table::governing(const Authentication::Path &path) const
+    -> std::vector<std::string_view> {
   auto mask{this->impl_->match(path.value())};
-  std::vector<std::size_t> result;
+  std::vector<std::string_view> result;
   while (mask != 0) {
-    result.push_back(static_cast<std::size_t>(std::countr_zero(mask)));
+    // A policy standing on its own is a view, and the table names every one, so
+    // what a policy is called is read from there rather than stored twice
+    const auto policy{Authentication::PolicySet{1} << std::countr_zero(mask)};
+    result.push_back(this->impl_->view_name(policy));
     mask &= mask - 1;
   }
 
   return result;
 }
 
-auto Authentication::reference_permitted(
+auto Authentication::Table::reference_permitted(
     const Authentication::Path &referrer,
     const Authentication::Path &referent) const -> bool {
   return this->impl_->reference_permitted(referrer.value(), referent.value());

--- a/enterprise/authentication/authentication_format.h
+++ b/enterprise/authentication/authentication_format.h
@@ -7,6 +7,18 @@
 
 namespace sourcemeta::one {
 
+// What a policy authenticates, stored as one byte per entry, so these values
+// are the artifact's rather than a matter of taste
+enum class AuthenticationPolicyType : std::uint8_t {
+  ApiKey = 0,
+  JWT = 1,
+  OIDC = 2
+};
+
+// How many policies one artifact can name. Each occupies a bit of the node
+// masks, so this is what a mask has room for rather than a matter of taste
+constexpr std::size_t AUTHENTICATION_MAXIMUM_POLICIES{64};
+
 constexpr std::uint32_t AUTHENTICATION_MAGIC{0x48545541};
 constexpr std::uint32_t AUTHENTICATION_VERSION{14};
 

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -14,7 +14,6 @@
 #include <cstring>     // std::memcpy
 #include <filesystem>  // std::filesystem::path
 #include <span>        // std::span
-#include <stdexcept>   // std::runtime_error
 #include <string>      // std::string
 #include <string_view> // std::string_view
 #include <utility>     // std::pair
@@ -186,14 +185,14 @@ auto encode_jwt_metadata(
 namespace sourcemeta::one {
 
 auto Authentication::Table::compile(
-    std::span<const Authentication::Policy> policies,
+    const std::span<const Authentication::Policy> policies,
     const std::filesystem::path &configuration,
     const Authentication::PathGuard &gateable) -> std::vector<std::byte> {
   assert(gateable);
   // Each policy occupies one bit of the node masks, so exceeding the ceiling
   // would shift past the width of a PolicySet
   if (policies.size() > Authentication::MAXIMUM_POLICIES) {
-    throw std::runtime_error("Too many authentication policies");
+    throw AuthenticationTooManyPoliciesError(configuration, policies.size());
   }
 
   // A typo, a stray extension, or a scope this instance does not serve names
@@ -204,6 +203,24 @@ auto Authentication::Table::compile(
       if (!gateable(policy_path)) {
         throw AuthenticationUnknownPathError(configuration,
                                              std::string{policy_path});
+      }
+    }
+  }
+
+  // A view is spelled from the names of the policies it comprises, so a policy
+  // without one, or sharing one, or taking the name every caller holding
+  // nothing is served under, yields a view that names somewhere else or
+  // nowhere. A configuration is refused for all three long before this is
+  // reached, and this is what makes that a guarantee rather than a convention
+  for (std::size_t index{0}; index < policies.size(); index += 1) {
+    const auto name{policies[index].name};
+    if (name.empty() || name == VIEW_PUBLIC) {
+      throw AuthenticationPolicyNameError(configuration, std::string{name});
+    }
+
+    for (std::size_t other{0}; other < index; other += 1) {
+      if (policies[other].name == name) {
+        throw AuthenticationPolicyNameError(configuration, std::string{name});
       }
     }
   }
@@ -358,8 +375,8 @@ auto Authentication::Table::compile(
       // verify one, so it fails loudly here rather than silently denying every
       // login at runtime
       if (interactive->session_secrets.empty()) {
-        throw std::runtime_error(
-            "Interactive authentication policies require a session secret");
+        throw AuthenticationMissingSecretError(configuration,
+                                               std::string{policy.name});
       }
 
       policy_metadata = encode_oidc_metadata(

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -41,6 +41,18 @@ auto find_or_create_child(std::vector<BuildNode> &nodes,
   return child;
 }
 
+auto policy_type(const sourcemeta::one::Authentication::Policy &policy)
+    -> sourcemeta::one::AuthenticationPolicyType {
+  switch (policy.credential.index()) {
+    case 1:
+      return sourcemeta::one::AuthenticationPolicyType::JWT;
+    case 2:
+      return sourcemeta::one::AuthenticationPolicyType::OIDC;
+    default:
+      return sourcemeta::one::AuthenticationPolicyType::ApiKey;
+  }
+}
+
 auto align_to_word(const std::uint32_t offset) -> std::uint32_t {
   return (offset + 7U) & ~static_cast<std::uint32_t>(7U);
 }
@@ -191,7 +203,7 @@ auto Authentication::Table::compile(
   assert(gateable);
   // Each policy occupies one bit of the node masks, so exceeding the ceiling
   // would shift past the width of a PolicySet
-  if (policies.size() > Authentication::MAXIMUM_POLICIES) {
+  if (policies.size() > AUTHENTICATION_MAXIMUM_POLICIES) {
     throw AuthenticationTooManyPoliciesError(configuration, policies.size());
   }
 
@@ -400,7 +412,7 @@ auto Authentication::Table::compile(
     entry.name_offset = policy_names[index].first;
     entry.name_length = policy_names[index].second;
     entry.algorithm = static_cast<std::uint8_t>(algorithm);
-    entry.type = static_cast<std::uint8_t>(policy.type());
+    entry.type = static_cast<std::uint8_t>(policy_type(policy));
     policy_table.push_back(entry);
     metadata.insert(metadata.end(), policy_metadata.begin(),
                     policy_metadata.end());

--- a/enterprise/authentication/authentication_save.cc
+++ b/enterprise/authentication/authentication_save.cc
@@ -185,10 +185,10 @@ auto encode_jwt_metadata(
 
 namespace sourcemeta::one {
 
-auto Authentication::compile(std::span<const Authentication::Policy> policies,
-                             const std::filesystem::path &configuration,
-                             const Authentication::PathGuard &gateable)
-    -> std::vector<std::byte> {
+auto Authentication::Table::compile(
+    std::span<const Authentication::Policy> policies,
+    const std::filesystem::path &configuration,
+    const Authentication::PathGuard &gateable) -> std::vector<std::byte> {
   assert(gateable);
   // Each policy occupies one bit of the node masks, so exceeding the ceiling
   // would shift past the width of a PolicySet
@@ -204,24 +204,6 @@ auto Authentication::compile(std::span<const Authentication::Policy> policies,
       if (!gateable(policy_path)) {
         throw AuthenticationUnknownPathError(configuration,
                                              std::string{policy_path});
-      }
-    }
-  }
-
-  // A view is spelled from the names of the policies it comprises, so a policy
-  // without one, or sharing one, or taking the name every caller holding
-  // nothing is served under, yields a view that names somewhere else or
-  // nowhere. The configuration refuses all three long before this is reached,
-  // and this is what makes that a guarantee rather than a convention
-  for (std::size_t index{0}; index < policies.size(); index += 1) {
-    const auto name{policies[index].name};
-    if (name.empty() || name == VIEW_PUBLIC) {
-      throw AuthenticationPolicyNameError(configuration, std::string{name});
-    }
-
-    for (std::size_t other{0}; other < index; other += 1) {
-      if (policies[other].name == name) {
-        throw AuthenticationPolicyNameError(configuration, std::string{name});
       }
     }
   }
@@ -258,7 +240,7 @@ auto Authentication::compile(std::span<const Authentication::Policy> policies,
 
   // The table is computed once here, so that the naming rule is applied where
   // the policies are read rather than by every server that later serves them
-  const auto table{Authentication::views(policies)};
+  const auto table{Authentication::Table::enumerate(policies)};
 
   // Distinct policy names do not by themselves make distinct view names, since
   // a view naming several is spelled by joining theirs, which a single policy
@@ -442,8 +424,9 @@ auto Authentication::compile(std::span<const Authentication::Policy> policies,
   return buffer;
 }
 
-auto Authentication::write(const std::span<const std::byte> bytes,
-                           const std::filesystem::path &destination) -> void {
+auto Authentication::Table::write(const std::span<const std::byte> bytes,
+                                  const std::filesystem::path &destination)
+    -> void {
   sourcemeta::core::write_file(destination, bytes);
 }
 

--- a/enterprise/authentication/session.cc
+++ b/enterprise/authentication/session.cc
@@ -2,8 +2,6 @@
 
 #include "session.h"
 
-#include "session.h"
-
 #include <sourcemeta/core/crypto.h>
 
 #include <algorithm>   // std::max
@@ -48,12 +46,12 @@ constexpr std::size_t SESSION_SIGNATURE_ENCODED_LENGTH{
 // signature where a client chooses it. So the purpose picks the key rather
 // than being asserted alongside it: a value sealed for one purpose cannot
 // verify under another's key, whether or not a caller remembers to check
-auto purpose_label(const sourcemeta::one::Authentication::Purpose purpose)
+auto purpose_label(const sourcemeta::one::SealPurpose purpose)
     -> std::string_view {
   switch (purpose) {
-    case sourcemeta::one::Authentication::Purpose::Session:
+    case sourcemeta::one::SealPurpose::Session:
       return "sourcemeta/one/session";
-    case sourcemeta::one::Authentication::Purpose::Transaction:
+    case sourcemeta::one::SealPurpose::Transaction:
       return "sourcemeta/one/transaction";
   }
 
@@ -61,7 +59,7 @@ auto purpose_label(const sourcemeta::one::Authentication::Purpose purpose)
 }
 
 auto derive_key(const std::string_view secret,
-                const sourcemeta::one::Authentication::Purpose purpose)
+                const sourcemeta::one::SealPurpose purpose)
     -> std::array<std::uint8_t, 32> {
   return sourcemeta::core::hmac_sha256_digest(secret, purpose_label(purpose));
 }
@@ -96,8 +94,7 @@ auto parse_expiry(const std::string_view input)
 
 namespace sourcemeta::one {
 
-auto seal_value(const std::string_view payload,
-                const Authentication::Purpose purpose,
+auto seal_value(const std::string_view payload, const SealPurpose purpose,
                 const std::string_view secret,
                 const std::chrono::sys_seconds issued,
                 const std::chrono::sys_seconds expiry) -> std::string {
@@ -120,8 +117,7 @@ auto seal_value(const std::string_view payload,
   return result;
 }
 
-auto open_value(const std::string_view value,
-                const Authentication::Purpose purpose,
+auto open_value(const std::string_view value, const SealPurpose purpose,
                 const std::span<const std::string_view> secrets,
                 const std::chrono::sys_seconds now)
     -> std::optional<std::string> {

--- a/enterprise/authentication/session.h
+++ b/enterprise/authentication/session.h
@@ -4,6 +4,7 @@
 #include <sourcemeta/one/authentication.h>
 
 #include <chrono>      // std::chrono::sys_seconds
+#include <cstdint>     // std::uint8_t
 #include <optional>    // std::optional
 #include <span>        // std::span
 #include <string>      // std::string
@@ -15,12 +16,16 @@
 // interface next door stays what a consumer may call
 namespace sourcemeta::one {
 
+// What a sealed value is for. A value is only ever opened for the purpose it
+// was sealed under, because the two derive different keys from the policy's
+// secret, so one kind of value cannot be presented as the other
+enum class SealPurpose : std::uint8_t { Session = 0, Transaction = 1 };
+
 // Bind a payload and an expiry under a key derived from the secret and the
 // purpose, producing a value that is safe to transport as a cookie. Only a
 // holder of the secret can produce or alter such a value, though anyone can
 // read its contents
-[[nodiscard]] auto seal_value(std::string_view payload,
-                              Authentication::Purpose purpose,
+[[nodiscard]] auto seal_value(std::string_view payload, SealPurpose purpose,
                               std::string_view secret,
                               std::chrono::sys_seconds issued,
                               std::chrono::sys_seconds expiry) -> std::string;
@@ -30,8 +35,7 @@ namespace sourcemeta::one {
 // any way, or has expired. Accepting several secrets lets a newly introduced
 // secret coexist with the one it replaces until every value sealed under the
 // old secret has expired
-[[nodiscard]] auto open_value(std::string_view value,
-                              Authentication::Purpose purpose,
+[[nodiscard]] auto open_value(std::string_view value, SealPurpose purpose,
                               std::span<const std::string_view> secrets,
                               std::chrono::sys_seconds now)
     -> std::optional<std::string>;

--- a/enterprise/index/enterprise_index.cc
+++ b/enterprise/index/enterprise_index.cc
@@ -240,7 +240,13 @@ auto generate_protected_resource_metadata(
     const auto match{std::ranges::find(
         configuration.authentication, name,
         &sourcemeta::one::Configuration::AuthenticationEntry::name)};
-    assert(match != configuration.authentication.cend());
+    // A policy the artifact records but this configuration no longer declares
+    // is one a build behind this one wrote. It names no client anybody could
+    // ask for a token, so it is passed over rather than reported
+    if (match == configuration.authentication.cend()) {
+      continue;
+    }
+
     const auto &entry{*match};
     if (entry.type !=
             sourcemeta::one::Configuration::AuthenticationEntry::Type::JWT ||

--- a/enterprise/index/enterprise_index.cc
+++ b/enterprise/index/enterprise_index.cc
@@ -217,7 +217,7 @@ auto mcp_resource_identifier(
 }
 
 auto generate_protected_resource_metadata(
-    const sourcemeta::one::Authentication &authentication,
+    const sourcemeta::one::Authentication::Table &authentication,
     const sourcemeta::one::Configuration &configuration,
     const std::string_view endpoint, sourcemeta::core::JSON &result) -> void {
   const auto resource{mcp_resource_identifier(configuration, endpoint)};
@@ -232,10 +232,16 @@ auto generate_protected_resource_metadata(
   // client reading them learns what to ask its provider for, rather than
   // discovering it by being refused
   std::vector<std::string_view> scopes;
-  for (const auto index : authentication.governing(
+  for (const auto name : authentication.governing(
            sourcemeta::one::Authentication::Path::relative(endpoint))) {
-    assert(index < configuration.authentication.size());
-    const auto &entry{configuration.authentication[index]};
+    // What a policy declares is read from the configuration that declared it,
+    // which is where the claim rules are already parsed, and the name is what
+    // the two agree on
+    const auto match{std::ranges::find(
+        configuration.authentication, name,
+        &sourcemeta::one::Configuration::AuthenticationEntry::name)};
+    assert(match != configuration.authentication.cend());
+    const auto &entry{*match};
     if (entry.type !=
             sourcemeta::one::Configuration::AuthenticationEntry::Type::JWT ||
         entry.audience != resource) {

--- a/enterprise/index/include/sourcemeta/one/enterprise_index.h
+++ b/enterprise/index/include/sourcemeta/one/enterprise_index.h
@@ -50,7 +50,7 @@ auto mcp_resource_identifier(
 // untouched when no policy can honestly answer that
 // https://datatracker.ietf.org/doc/html/rfc9728
 auto generate_protected_resource_metadata(
-    const sourcemeta::one::Authentication &authentication,
+    const sourcemeta::one::Authentication::Table &authentication,
     const sourcemeta::one::Configuration &configuration,
     std::string_view endpoint, sourcemeta::core::JSON &result) -> void;
 

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
@@ -90,14 +90,14 @@ public:
     const auto &authentication{dispatcher.authentication()};
     for (const auto &recorded : authentication.table().views()) {
       const auto path{this->artifact_resolve_path_unauthenticated(
-          recorded.name, "", Tree::Explorer, "mcp")};
+          recorded.name(), "", Tree::Explorer, "mcp")};
       if (!path.has_value()) {
         continue;
       }
 
       auto metadata{this->artifact_read_json(path.value())};
       if (metadata.has_value()) {
-        this->metadata_views_.emplace(recorded.name,
+        this->metadata_views_.emplace(recorded.name(),
                                       std::move(metadata).value());
       }
     }

--- a/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
+++ b/enterprise/server/include/sourcemeta/one/enterprise_server_action_mcp_v1.h
@@ -88,8 +88,7 @@ public:
     // credential is known, which is the origin a preflight is checked against
     // and the metadata a refusal points at
     const auto &authentication{dispatcher.authentication()};
-    for (std::size_t index{0}; index < authentication.view_count(); index++) {
-      const auto recorded{authentication.view_at(index)};
+    for (const auto &recorded : authentication.table().views()) {
       const auto path{this->artifact_resolve_path_unauthenticated(
           recorded.name, "", Tree::Explorer, "mcp")};
       if (!path.has_value()) {

--- a/enterprise/unit/authentication/authentication_session_test.cc
+++ b/enterprise/unit/authentication/authentication_session_test.cc
@@ -92,8 +92,9 @@ static auto instance(const std::string &name,
             .client_secret_variable = "ONE_TEST_SEAL_CLIENT",
             .session_secrets = secrets}}}};
   return sourcemeta::one::Authentication{
-      sourcemeta::one::Authentication::compile(policies, test_path(name),
-                                               anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path(name), anywhere)},
       provider()};
 }
 

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -279,6 +279,30 @@ static_assert(names_an_audience<TokenPolicy>);
 static_assert(names_session_secrets<InteractivePolicy>);
 static_assert(names_a_client_secret<InteractivePolicy>);
 
+template <typename T>
+concept assembled_from_a_set = requires {
+  T{std::string_view{}, sourcemeta::one::Authentication::PolicySet{}};
+};
+template <typename T>
+concept states_a_set = requires(T value) {
+  value.policies = sourcemeta::one::Authentication::PolicySet{};
+};
+
+// What the two above detect, so that the pair below says something
+struct AssembledView {
+  std::string_view name;
+  sourcemeta::one::Authentication::PolicySet policies;
+};
+static_assert(assembled_from_a_set<AssembledView>);
+static_assert(states_a_set<AssembledView>);
+
+// A view is what a table answers with rather than something a caller states.
+// A set assembled anywhere else names a view no build ever wrote, and would be
+// read as admitting whatever it happened to hold
+static_assert(
+    !assembled_from_a_set<sourcemeta::one::Authentication::RecordedView>);
+static_assert(!states_a_set<sourcemeta::one::Authentication::RecordedView>);
+
 // A provider a case has control of, and what it says. Everything this module
 // reaches goes through one function, so a case configures what the provider
 // advertises and answers with, and then reads what was made of it. Nothing
@@ -974,19 +998,19 @@ TEST(an_explicit_route_is_gated_on_the_target_as_it_arrived) {
   const sourcemeta::one::Authentication authentication{
       sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(
-      sourcemeta::one::RouteTarget{"/private/secret"},
+      sourcemeta::one::Authentication::RouteTarget{"/private/secret"},
       authentication.caller({.bearer = "", .cookies = {}})));
   EXPECT_TRUE(authentication.permits(
-      sourcemeta::one::RouteTarget{"/private/secret"},
+      sourcemeta::one::Authentication::RouteTarget{"/private/secret"},
       authentication.caller({.bearer = "route-secret", .cookies = {}})));
 
   // A target covered by no policy is admitted, including one whose spelling
   // only resembles a governed prefix
   EXPECT_TRUE(authentication.permits(
-      sourcemeta::one::RouteTarget{"/public/string"},
+      sourcemeta::one::Authentication::RouteTarget{"/public/string"},
       authentication.caller({.bearer = "", .cookies = {}})));
   EXPECT_TRUE(authentication.permits(
-      sourcemeta::one::RouteTarget{"/privateextra/secret"},
+      sourcemeta::one::Authentication::RouteTarget{"/privateextra/secret"},
       authentication.caller({.bearer = "", .cookies = {}})));
 }
 
@@ -2919,6 +2943,84 @@ TEST(an_artifact_whose_table_omits_the_anonymous_view_is_refused) {
       at("/machine/x"), authentication.caller({.bearer = "table-secret"})));
   EXPECT_FALSE(authentication.permits(at("/anywhere"),
                                       authentication.caller({.bearer = ""})));
+}
+
+TEST(save_rejects_a_nameless_policy) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "acme",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_NAMELESS"}}}};
+  const auto path{test_path("oidc_nameless.bin")};
+  try {
+    save(policies, path, path, anywhere);
+    FAIL();
+  } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "An authentication policy requires a name of its own");
+  }
+}
+
+TEST(save_rejects_a_nameless_key_policy) {
+  const std::array<std::string_view, 1> paths{{"/machine"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_NAMELESS"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
+  const auto path{test_path("key_nameless.bin")};
+  try {
+    save(policies, path, path, anywhere);
+    FAIL();
+  } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "An authentication policy requires a name of its own");
+  }
+}
+
+TEST(save_rejects_two_policies_sharing_a_name) {
+  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
+  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
+  const std::array<std::string_view, 1> alpha_keys{{"ONE_TEST_KEY_SAME_A"}};
+  const std::array<std::string_view, 1> beta_keys{{"ONE_TEST_KEY_SAME_B"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
+      {{.paths = alpha_paths,
+        .name = "shared",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys =
+                                                                alpha_keys}},
+       {.paths = beta_paths,
+        .name = "shared",
+        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+            .keys = beta_keys}}}};
+  const auto path{test_path("name_shared.bin")};
+  try {
+    save(policies, path, path, anywhere);
+    FAIL();
+  } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "An authentication policy requires a name of its own");
+  }
+}
+
+TEST(save_rejects_a_policy_taking_the_anonymous_name) {
+  const std::array<std::string_view, 1> paths{{"/machine"}};
+  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_RESERVED"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "public",
+        .credential =
+            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
+  const auto path{test_path("name_reserved.bin")};
+  try {
+    save(policies, path, path, anywhere);
+    FAIL();
+  } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
+    EXPECT_STREQ(error.what(),
+                 "An authentication policy requires a name of its own");
+  }
 }
 
 TEST(save_writes_the_largest_table_a_configuration_can_declare) {
@@ -5476,17 +5578,17 @@ TEST(the_recorded_table_names_every_view_it_serves) {
   // fans its actions out in
   const auto table{gate.views()};
   EXPECT_EQ(table.size(), std::size_t{4});
-  EXPECT_EQ(table.at(0).name, "public");
-  EXPECT_EQ(table.at(0).policies,
+  EXPECT_EQ(table.at(0).name(), "public");
+  EXPECT_EQ(table.at(0).policies(),
             sourcemeta::one::Authentication::PolicySet{0});
-  EXPECT_EQ(table.at(1).name, "oncall");
-  EXPECT_EQ(table.at(1).policies,
+  EXPECT_EQ(table.at(1).name(), "oncall");
+  EXPECT_EQ(table.at(1).policies(),
             sourcemeta::one::Authentication::PolicySet{0b10});
-  EXPECT_EQ(table.at(2).name, "oncall+platform");
-  EXPECT_EQ(table.at(2).policies,
+  EXPECT_EQ(table.at(2).name(), "oncall+platform");
+  EXPECT_EQ(table.at(2).policies(),
             sourcemeta::one::Authentication::PolicySet{0b11});
-  EXPECT_EQ(table.at(3).name, "platform");
-  EXPECT_EQ(table.at(3).policies,
+  EXPECT_EQ(table.at(3).name(), "platform");
+  EXPECT_EQ(table.at(3).policies(),
             sourcemeta::one::Authentication::PolicySet{0b01});
 }
 
@@ -5591,7 +5693,7 @@ TEST(a_name_no_view_holds_is_served_as_anonymous) {
   // withdrawn since leaves a name this no longer holds. It is served what a
   // caller holding nothing is served, rather than what the name used to reach
   const auto withdrawn{gate.view("retired")};
-  EXPECT_EQ(withdrawn.name, "public");
+  EXPECT_EQ(withdrawn.name(), "public");
   EXPECT_TRUE(gate.visible(at("/open/x"), withdrawn));
   EXPECT_FALSE(gate.visible(at("/machine/x"), withdrawn));
 }
@@ -5896,7 +5998,7 @@ TEST(an_ungoverned_route_ignores_the_audience_it_requires) {
               policies, test_path("ungoverned_route"), anywhere)},
       stub_fetcher({}, nullptr)};
 
-  const sourcemeta::one::RouteTarget target{"/self/v1/mcp"};
+  const sourcemeta::one::Authentication::RouteTarget target{"/self/v1/mcp"};
 
   // Nobody governs it, so it opens whatever the caller brought
   EXPECT_TRUE(authentication.permits(target, authentication.caller({}),
@@ -5961,4 +6063,57 @@ TEST(a_session_never_opens_as_a_transaction) {
   EXPECT_TRUE(authentication.permits(
       at("/portal/x"),
       authentication.caller({.cookies = fields(as_a_session)})));
+}
+
+// A ceiling and a missing secret are refusals a caller earns the same way, and
+// both used to answer with an error naming no policy at all
+TEST(save_rejects_more_policies_than_a_set_can_name) {
+  std::vector<std::vector<std::string_view>> paths;
+  std::vector<std::vector<std::string_view>> keys;
+  std::vector<std::string> names;
+  constexpr auto total{sourcemeta::one::Authentication::MAXIMUM_POLICIES + 1};
+  for (std::size_t index{0}; index < total; index += 1) {
+    names.push_back("policy-" + std::to_string(index));
+    paths.push_back({"/scope"});
+    keys.push_back({"ONE_TEST_KEY_CEILING"});
+  }
+
+  std::vector<sourcemeta::one::Authentication::Policy> policies;
+  for (std::size_t index{0}; index < total; index += 1) {
+    policies.push_back(
+        {.paths = paths[index],
+         .name = names[index],
+         .credential = sourcemeta::one::Authentication::Policy::ApiKey{
+             .keys = keys[index]}});
+  }
+
+  const auto path{test_path("ceiling.bin")};
+  try {
+    save(policies, path, path, anywhere);
+    FAIL();
+  } catch (const sourcemeta::one::AuthenticationTooManyPoliciesError &error) {
+    EXPECT_STREQ(error.what(), "Too many authentication policies");
+    EXPECT_EQ(error.count(), total);
+  }
+}
+
+TEST(save_rejects_an_interactive_policy_without_a_session_secret) {
+  const std::array<std::string_view, 1> paths{{"/portal"}};
+  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
+      {{.paths = paths,
+        .name = "okta",
+        .credential = sourcemeta::one::Authentication::Policy::Interactive{
+            .issuer = "https://acme.test",
+            .client_id = "client",
+            .client_secret_variable = "ONE_TEST_OIDC_NO_SECRET"}}}};
+  const auto path{test_path("no_session_secret.bin")};
+  try {
+    save(policies, path, path, anywhere);
+    FAIL();
+  } catch (const sourcemeta::one::AuthenticationMissingSecretError &error) {
+    EXPECT_STREQ(error.what(),
+                 "An interactive authentication policy requires a session "
+                 "secret");
+    EXPECT_EQ(error.name(), "okta");
+  }
 }

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -57,6 +57,23 @@ save(const std::span<const sourcemeta::one::Authentication::Policy> policies,
       destination);
 }
 
+// The names a table serves, which is what the naming rule below decides. What
+// each name stands for is read from what its view reaches rather than from the
+// set behind it, since that set is the artifact's own business
+static auto view_names(const sourcemeta::one::Authentication::Table &table)
+    -> std::vector<std::string_view> {
+  std::vector<std::string_view> result;
+  for (const auto &view : table.views()) {
+    result.push_back(view.name());
+  }
+
+  return result;
+}
+
+// How many policies naming one issuer a table will combine, which the artifact
+// decides rather than these cases
+static constexpr std::size_t COMBINABLE_CEILING{16};
+
 static auto test_path(const std::string &name) -> std::filesystem::path {
   return std::filesystem::path{AUTHENTICATION_TEST_DIRECTORY} / name;
 }
@@ -280,18 +297,15 @@ static_assert(names_session_secrets<InteractivePolicy>);
 static_assert(names_a_client_secret<InteractivePolicy>);
 
 template <typename T>
-concept assembled_from_a_set = requires {
-  T{std::string_view{}, sourcemeta::one::Authentication::PolicySet{}};
-};
+concept assembled_from_a_set =
+    requires { T{std::string_view{}, std::uint64_t{}}; };
 template <typename T>
-concept states_a_set = requires(T value) {
-  value.policies = sourcemeta::one::Authentication::PolicySet{};
-};
+concept states_a_set = requires(T value) { value.policies = std::uint64_t{}; };
 
 // What the two above detect, so that the pair below says something
 struct AssembledView {
   std::string_view name;
-  sourcemeta::one::Authentication::PolicySet policies;
+  std::uint64_t policies;
 };
 static_assert(assembled_from_a_set<AssembledView>);
 static_assert(states_a_set<AssembledView>);
@@ -640,8 +654,8 @@ TEST(artifact_exceeding_the_policy_ceiling_denies_everything) {
   header[2] = 'T';
   header[3] = 'H';
   header[4] = 4;
-  header[8] =
-      static_cast<char>(sourcemeta::one::Authentication::MAXIMUM_POLICIES + 1);
+  // One past what a 64 bit mask has room to name
+  header[8] = static_cast<char>(65);
   header[12] = 1;
   stream.write(header.data(), header.size());
   stream.close();
@@ -1251,7 +1265,9 @@ TEST(mixed_algorithms_admit_either_key_with_sha256_first) {
 }
 
 TEST(supports_the_maximum_number_of_policies) {
-  constexpr auto maximum{sourcemeta::one::Authentication::MAXIMUM_POLICIES};
+  // One bit per policy in a 64 bit mask, which is what an artifact has room
+  // to name
+  constexpr std::size_t maximum{64};
   std::vector<std::string> path_storage;
   path_storage.reserve(maximum);
   for (std::size_t index{0}; index < maximum; index += 1) {
@@ -3025,8 +3041,7 @@ TEST(save_rejects_a_policy_taking_the_anonymous_name) {
 
 TEST(save_writes_the_largest_table_a_configuration_can_declare) {
   constexpr std::size_t groups{4};
-  constexpr auto per_group{
-      sourcemeta::one::Authentication::Table::MAXIMUM_COMBINABLE_POLICIES};
+  constexpr auto per_group{COMBINABLE_CEILING};
   constexpr auto total{groups * per_group};
   std::vector<std::string> path_storage;
   std::vector<std::string> name_storage;
@@ -4998,9 +5013,11 @@ TEST(a_policy_path_carrying_a_repeated_separator_gates_its_location) {
 }
 
 TEST(views_of_nothing_are_the_public_one_alone) {
-  const auto views{sourcemeta::one::Authentication::Table::enumerate({})};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}}}));
+  const auto path{test_path("views_of_nothing_are_the_public_one_alone.bin")};
+  save(std::span<const sourcemeta::one::Authentication::Policy>{}, path, path,
+       anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate), (std::vector<std::string_view>{"public"}));
 }
 
 TEST(views_name_a_static_key_policy_on_its_own) {
@@ -5012,10 +5029,11 @@ TEST(views_name_a_static_key_policy_on_its_own) {
         .credential =
             sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
 
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "vault", .policies = {0}}}));
+  const auto path{test_path("views_name_a_static_key_policy_on_its_own.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate),
+            (std::vector<std::string_view>{"public", "vault"}));
 }
 
 TEST(views_name_an_interactive_policy_on_its_own) {
@@ -5024,12 +5042,14 @@ TEST(views_name_an_interactive_policy_on_its_own) {
       {{.paths = paths,
         .name = "desk",
         .credential = sourcemeta::one::Authentication::Policy::Interactive{
-            .issuer = "https://idp.example.com/realms/staff"}}}};
+            .issuer = "https://idp.example.com/realms/staff",
+            .session_secrets = SESSION_SECRETS}}}};
 
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "desk", .policies = {0}}}));
+  const auto path{test_path("views_name_an_interactive_policy_on_its_own.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate),
+            (std::vector<std::string_view>{"public", "desk"}));
 }
 
 TEST(views_name_a_token_policy_on_its_own) {
@@ -5040,10 +5060,11 @@ TEST(views_name_a_token_policy_on_its_own) {
         .credential = sourcemeta::one::Authentication::Policy::Token{
             .issuer = "https://idp.example.com/realms/staff"}}}};
 
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "machine", .policies = {0}}}));
+  const auto path{test_path("views_name_a_token_policy_on_its_own.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate),
+            (std::vector<std::string_view>{"public", "machine"}));
 }
 
 TEST(views_combine_token_policies_that_name_one_issuer) {
@@ -5062,12 +5083,12 @@ TEST(views_combine_token_policies_that_name_one_issuer) {
 
   // A claim is a list and a rule is met by any of its values, so one token can
   // satisfy both
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "legal", .policies = {0}},
-                       {.name = "legal+tech", .policies = {0, 1}},
-                       {.name = "tech", .policies = {1}}}));
+  const auto path{
+      test_path("views_combine_token_policies_that_name_one_issuer.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate), (std::vector<std::string_view>{
+                                  "public", "legal", "legal+tech", "tech"}));
 }
 
 TEST(views_never_combine_token_policies_across_issuers) {
@@ -5086,11 +5107,12 @@ TEST(views_never_combine_token_policies_across_issuers) {
 
   // A token carries one issuer and is verified against it before any rule is
   // read, so nobody can ever hold both
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "partner", .policies = {1}},
-                       {.name = "staff", .policies = {0}}}));
+  const auto path{
+      test_path("views_never_combine_token_policies_across_issuers.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate),
+            (std::vector<std::string_view>{"public", "partner", "staff"}));
 }
 
 TEST(views_never_combine_token_policies_testing_one_claim_across_issuers) {
@@ -5111,11 +5133,12 @@ TEST(views_never_combine_token_policies_testing_one_claim_across_issuers) {
 
   // The issuer is decisive and is read first, so testing the same claim for the
   // same value means nothing across them
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "legal", .policies = {0}},
-                       {.name = "partner-legal", .policies = {1}}}));
+  const auto path{test_path("views_never_combine_token_policies_testing_one_"
+                            "claim_across_issuers.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate), (std::vector<std::string_view>{"public", "legal",
+                                                             "partner-legal"}));
 }
 
 TEST(views_never_combine_interactive_policies_under_one_issuer) {
@@ -5126,19 +5149,22 @@ TEST(views_never_combine_interactive_policies_under_one_issuer) {
         .name = "first",
         .credential =
             sourcemeta::one::Authentication::Policy::Interactive{
-                .issuer = "https://idp.example.com/realms/staff"}},
+                .issuer = "https://idp.example.com/realms/staff",
+                .session_secrets = SESSION_SECRETS}},
        {.paths = second_paths,
         .name = "second",
         .credential = sourcemeta::one::Authentication::Policy::Interactive{
-            .issuer = "https://idp.example.com/realms/staff"}}}};
+            .issuer = "https://idp.example.com/realms/staff",
+            .session_secrets = SESSION_SECRETS}}}};
 
   // A browser holds one session naming one policy, so sharing an issuer buys an
   // interactive caller nothing
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "first", .policies = {0}},
-                       {.name = "second", .policies = {1}}}));
+  const auto path{test_path(
+      "views_never_combine_interactive_policies_under_one_issuer.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate),
+            (std::vector<std::string_view>{"public", "first", "second"}));
 }
 
 TEST(views_never_combine_static_key_policies) {
@@ -5158,11 +5184,11 @@ TEST(views_never_combine_static_key_policies) {
             .keys = second_keys}}}};
 
   // A caller presents one key, so it satisfies one of these whatever it holds
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "first", .policies = {0}},
-                       {.name = "second", .policies = {1}}}));
+  const auto path{test_path("views_never_combine_static_key_policies.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate),
+            (std::vector<std::string_view>{"public", "first", "second"}));
 }
 
 TEST(views_spell_a_combination_the_same_however_it_was_declared) {
@@ -5179,12 +5205,12 @@ TEST(views_spell_a_combination_the_same_however_it_was_declared) {
         .credential = sourcemeta::one::Authentication::Policy::Token{
             .issuer = "https://idp.example.com/realms/staff"}}}};
 
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "legal", .policies = {1}},
-                       {.name = "legal+tech", .policies = {0, 1}},
-                       {.name = "tech", .policies = {0}}}));
+  const auto path{test_path(
+      "views_spell_a_combination_the_same_however_it_was_declared.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate), (std::vector<std::string_view>{
+                                  "public", "legal", "legal+tech", "tech"}));
 }
 
 TEST(views_of_three_token_policies_under_one_issuer_are_every_combination) {
@@ -5205,16 +5231,13 @@ TEST(views_of_three_token_policies_under_one_issuer_are_every_combination) {
         .credential = sourcemeta::one::Authentication::Policy::Token{
             .issuer = "https://idp.example.com/realms/staff"}}}};
 
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "a", .policies = {0}},
-                       {.name = "a+b", .policies = {0, 1}},
-                       {.name = "a+b+c", .policies = {0, 1, 2}},
-                       {.name = "a+c", .policies = {0, 2}},
-                       {.name = "b", .policies = {1}},
-                       {.name = "b+c", .policies = {1, 2}},
-                       {.name = "c", .policies = {2}}}));
+  const auto path{test_path("views_of_three_token_policies_under_one_issuer_"
+                            "are_every_combination.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate),
+            (std::vector<std::string_view>{"public", "a", "a+b", "a+b+c", "a+c",
+                                           "b", "b+c", "c"}));
 }
 
 TEST(views_mix_a_combining_group_with_policies_that_stand_alone) {
@@ -5235,13 +5258,13 @@ TEST(views_mix_a_combining_group_with_policies_that_stand_alone) {
         .credential = sourcemeta::one::Authentication::Policy::Token{
             .issuer = "https://idp.example.com/realms/staff"}}}};
 
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "legal", .policies = {1}},
-                       {.name = "legal+tech", .policies = {1, 2}},
-                       {.name = "tech", .policies = {2}},
-                       {.name = "vault", .policies = {0}}}));
+  const auto path{test_path(
+      "views_mix_a_combining_group_with_policies_that_stand_alone.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate),
+            (std::vector<std::string_view>{"public", "legal", "legal+tech",
+                                           "tech", "vault"}));
 }
 
 TEST(views_hold_the_public_one_even_when_every_path_is_governed) {
@@ -5253,10 +5276,12 @@ TEST(views_hold_the_public_one_even_when_every_path_is_governed) {
         .credential =
             sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
 
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}},
-                       {.name = "everything", .policies = {0}}}));
+  const auto path{test_path(
+      "views_hold_the_public_one_even_when_every_path_is_governed.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate),
+            (std::vector<std::string_view>{"public", "everything"}));
 }
 
 TEST(views_of_six_token_policies_under_one_issuer_are_every_combination) {
@@ -5272,8 +5297,11 @@ TEST(views_of_six_token_policies_under_one_issuer_are_every_combination) {
   }
 
   // Two to the sixth, being every non-empty combination plus the anonymous one
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views.size(), 64);
+  const auto path{test_path("views_of_six_token_policies_under_one_issuer_are_"
+                            "every_combination.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(gate.views().size(), 64);
 }
 
 TEST(views_of_two_issuer_groups_are_a_sum_rather_than_a_product) {
@@ -5292,15 +5320,16 @@ TEST(views_of_two_issuer_groups_are_a_sum_rather_than_a_product) {
 
   // Each group contributes its own combinations and nothing crosses between
   // them, so the total adds rather than multiplies
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views.size(), 1 + 15 + 15);
+  const auto path{test_path(
+      "views_of_two_issuer_groups_are_a_sum_rather_than_a_product.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(gate.views().size(), 1 + 15 + 15);
 }
 
 TEST(views_of_the_largest_combinable_group_are_every_combination) {
   const std::array<std::string_view, 1> paths{{"/one"}};
-  std::array<
-      sourcemeta::one::Authentication::Policy,
-      sourcemeta::one::Authentication::Table::MAXIMUM_COMBINABLE_POLICIES>
+  std::array<sourcemeta::one::Authentication::Policy, COMBINABLE_CEILING>
       policies{};
   std::vector<std::string> names;
   names.reserve(policies.size());
@@ -5316,19 +5345,17 @@ TEST(views_of_the_largest_combinable_group_are_every_combination) {
             .issuer = "https://idp.example.com/realms/staff"};
   }
 
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(
-      views.size(),
-      (std::size_t{1}
-       << sourcemeta::one::Authentication::Table::MAXIMUM_COMBINABLE_POLICIES));
-  EXPECT_EQ(views.at(0).name, "public");
+  const auto path{test_path(
+      "views_of_the_largest_combinable_group_are_every_combination.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(gate.views().size(), (std::size_t{1} << COMBINABLE_CEILING));
+  EXPECT_EQ(gate.views().at(0).name(), "public");
 }
 
 TEST(views_refuse_a_group_whose_combinations_cannot_be_produced) {
   const std::array<std::string_view, 1> paths{{"/one"}};
-  std::array<
-      sourcemeta::one::Authentication::Policy,
-      sourcemeta::one::Authentication::Table::MAXIMUM_COMBINABLE_POLICIES + 1>
+  std::array<sourcemeta::one::Authentication::Policy, COMBINABLE_CEILING + 1>
       policies{};
   std::vector<std::string> names;
   names.reserve(policies.size());
@@ -5344,19 +5371,16 @@ TEST(views_refuse_a_group_whose_combinations_cannot_be_produced) {
             .issuer = "https://idp.example.com/realms/staff"};
   }
 
+  const auto path{
+      test_path("views_refuse_a_group_whose_combinations_cannot_be_produced")};
   try {
-    const auto views{
-        sourcemeta::one::Authentication::Table::enumerate(policies)};
-    EXPECT_EQ(views.size(), 0);
+    save(policies, path, path, anywhere);
     FAIL();
   } catch (const sourcemeta::one::AuthenticationTooManyViewsError &error) {
     EXPECT_STREQ(error.what(),
                  "Too many authentication policies share an issuer");
     EXPECT_EQ(error.issuer(), "https://idp.example.com/realms/staff");
-    EXPECT_EQ(
-        error.count(),
-        sourcemeta::one::Authentication::Table::MAXIMUM_COMBINABLE_POLICIES +
-            1);
+    EXPECT_EQ(error.count(), COMBINABLE_CEILING + 1);
   }
 }
 
@@ -5379,8 +5403,11 @@ TEST(views_of_many_policies_across_issuers_are_never_refused) {
                                                            names.at(index)};
   }
 
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views.size(), 41);
+  const auto path{
+      test_path("views_of_many_policies_across_issuers_are_never_refused.bin")};
+  save(policies, path, path, anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(gate.views().size(), 41);
 }
 
 TEST(a_presented_key_decides_over_a_session) {
@@ -5579,17 +5606,20 @@ TEST(the_recorded_table_names_every_view_it_serves) {
   const auto table{gate.views()};
   EXPECT_EQ(table.size(), std::size_t{4});
   EXPECT_EQ(table.at(0).name(), "public");
-  EXPECT_EQ(table.at(0).policies(),
-            sourcemeta::one::Authentication::PolicySet{0});
   EXPECT_EQ(table.at(1).name(), "oncall");
-  EXPECT_EQ(table.at(1).policies(),
-            sourcemeta::one::Authentication::PolicySet{0b10});
   EXPECT_EQ(table.at(2).name(), "oncall+platform");
-  EXPECT_EQ(table.at(2).policies(),
-            sourcemeta::one::Authentication::PolicySet{0b11});
   EXPECT_EQ(table.at(3).name(), "platform");
-  EXPECT_EQ(table.at(3).policies(),
-            sourcemeta::one::Authentication::PolicySet{0b01});
+
+  // And which policies each of those names stands for is read from what the
+  // view reaches rather than from the set behind it
+  EXPECT_FALSE(gate.visible(at("/oncall/x"), table.at(0)));
+  EXPECT_TRUE(gate.visible(at("/oncall/x"), table.at(1)));
+  EXPECT_TRUE(gate.visible(at("/oncall/x"), table.at(2)));
+  EXPECT_FALSE(gate.visible(at("/oncall/x"), table.at(3)));
+  EXPECT_FALSE(gate.visible(at("/platform/x"), table.at(0)));
+  EXPECT_FALSE(gate.visible(at("/platform/x"), table.at(1)));
+  EXPECT_TRUE(gate.visible(at("/platform/x"), table.at(2)));
+  EXPECT_TRUE(gate.visible(at("/platform/x"), table.at(3)));
 }
 
 TEST(a_view_shows_what_it_governs_and_whatever_nobody_governs) {
@@ -6071,7 +6101,8 @@ TEST(save_rejects_more_policies_than_a_set_can_name) {
   std::vector<std::vector<std::string_view>> paths;
   std::vector<std::vector<std::string_view>> keys;
   std::vector<std::string> names;
-  constexpr auto total{sourcemeta::one::Authentication::MAXIMUM_POLICIES + 1};
+  // One past what a 64 bit mask has room to name
+  constexpr std::size_t total{65};
   for (std::size_t index{0}; index < total; index += 1) {
     names.push_back("policy-" + std::to_string(index));
     paths.push_back({"/scope"});

--- a/enterprise/unit/authentication/authentication_test.cc
+++ b/enterprise/unit/authentication/authentication_test.cc
@@ -51,9 +51,9 @@ save(const std::span<const sourcemeta::one::Authentication::Policy> policies,
      const std::filesystem::path &configuration,
      const std::filesystem::path &destination,
      const sourcemeta::one::Authentication::PathGuard &gateable) -> void {
-  sourcemeta::one::Authentication::write(
-      sourcemeta::one::Authentication::compile(policies, configuration,
-                                               gateable),
+  sourcemeta::one::Authentication::Table::write(
+      sourcemeta::one::Authentication::Table::compile(policies, configuration,
+                                                      gateable),
       destination);
 }
 
@@ -444,8 +444,9 @@ static auto session_for(const std::string_view policy_name,
   // signed once that is known and left here for the exchange to answer with
   const auto identity{std::make_shared<std::string>()};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(policies, test_path("sign_in"),
-                                               anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("sign_in"), anywhere)},
       [identity](sourcemeta::one::Authentication::ProviderRequest &&request)
           -> std::optional<sourcemeta::one::Authentication::ProviderResponse> {
         if (request.url ==
@@ -558,7 +559,8 @@ static auto stub_fetcher(std::map<std::string, std::string> responses,
 
 TEST(missing_artifact_denies_everything) {
   const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"},
+      sourcemeta::one::Authentication::Table{
+          std::filesystem::path{"/no/such/authentication.bin"}},
       stub_fetcher({}, nullptr)};
   EXPECT_FALSE(
       authentication.permits(at("/"), authentication.caller({.bearer = ""})));
@@ -576,7 +578,7 @@ TEST(malformed_artifact_denies_everything) {
   stream.close();
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(
       authentication.permits(at("/"), authentication.caller({.bearer = ""})));
   EXPECT_FALSE(authentication.permits(at("/acme/foo"),
@@ -597,7 +599,7 @@ TEST(structurally_corrupt_artifact_denies_everything) {
   stream.close();
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(
       authentication.permits(at("/"), authentication.caller({.bearer = ""})));
   EXPECT_FALSE(authentication.permits(at("/internal/foo"),
@@ -621,7 +623,7 @@ TEST(artifact_exceeding_the_policy_ceiling_denies_everything) {
   stream.close();
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(
       authentication.permits(at("/"), authentication.caller({.bearer = ""})));
   EXPECT_FALSE(authentication.permits(at("/acme/foo"),
@@ -647,7 +649,7 @@ TEST(corrupted_section_offset_denies_everything) {
   stream.close();
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(at("/internal/foo"),
                                       authentication.caller({.bearer = ""})));
   EXPECT_FALSE(
@@ -660,16 +662,17 @@ TEST(zero_policies_admits_every_path) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_TRUE(
       authentication.permits(at("/"), authentication.caller({.bearer = ""})));
   EXPECT_TRUE(
       authentication.permits(at(""), authentication.caller({.bearer = ""})));
   EXPECT_TRUE(authentication.permits(at("/acme/foo/bar"),
                                      authentication.caller({.bearer = ""})));
-  EXPECT_EQ(authentication.governing(at("/")), (std::vector<std::size_t>{}));
-  EXPECT_EQ(authentication.governing(at("/acme")),
-            (std::vector<std::size_t>{}));
+  EXPECT_EQ(authentication.table().governing(at("/")),
+            (std::vector<std::string_view>{}));
+  EXPECT_EQ(authentication.table().governing(at("/acme")),
+            (std::vector<std::string_view>{}));
 }
 
 TEST(uncovered_paths_are_public_around_a_gated_scope) {
@@ -685,7 +688,7 @@ TEST(uncovered_paths_are_public_around_a_gated_scope) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // The covered subtree is gated
   EXPECT_FALSE(authentication.permits(at("/internal"),
                                       authentication.caller({.bearer = ""})));
@@ -716,7 +719,7 @@ TEST(scope_matches_whole_segments_only) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // The scope gates its own segment
   EXPECT_FALSE(authentication.permits(at("/internal"),
                                       authentication.caller({.bearer = ""})));
@@ -755,7 +758,7 @@ TEST(distinct_policies_each_gate_their_scope) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(at("/alpha/one"),
                                       authentication.caller({.bearer = ""})));
   EXPECT_FALSE(authentication.permits(at("/beta/two"),
@@ -786,7 +789,7 @@ TEST(nested_prefixes_gate_their_subtrees) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(at("/internal"),
                                       authentication.caller({.bearer = ""})));
   EXPECT_FALSE(authentication.permits(at("/internal/other"),
@@ -822,7 +825,7 @@ TEST(nested_inner_key_widens_access) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // The inner path is covered by both, so either key admits it
   EXPECT_TRUE(authentication.permits(
       at("/internal/secret"), authentication.caller({.bearer = "wo-secret"})));
@@ -847,7 +850,7 @@ TEST(single_policy_with_multiple_prefixes) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(at("/internal/foo"),
                                       authentication.caller({.bearer = ""})));
   EXPECT_FALSE(authentication.permits(at("/vendor/bar"),
@@ -869,7 +872,7 @@ TEST(extensionless_policy_gates_every_representation) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // The resource, every representation of it, and its subtree are all governed
   EXPECT_FALSE(authentication.permits(at("/secret/data"),
                                       authentication.caller({.bearer = ""})));
@@ -911,7 +914,7 @@ TEST(extension_specific_policy_gates_only_that_representation) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // Only the named representation is gated
   EXPECT_FALSE(authentication.permits(at("/secret/data.json"),
                                       authentication.caller({.bearer = ""})));
@@ -940,7 +943,7 @@ TEST(extension_handling_is_confined_to_the_terminal_segment) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // The policy on /v1 gates its own subtree
   EXPECT_FALSE(
       authentication.permits(at("/v1"), authentication.caller({.bearer = ""})));
@@ -969,7 +972,7 @@ TEST(an_explicit_route_is_gated_on_the_target_as_it_arrived) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(
       sourcemeta::one::RouteTarget{"/private/secret"},
       authentication.caller({.bearer = "", .cookies = {}})));
@@ -1000,7 +1003,7 @@ TEST(apikey_admits_matching_credential) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_TRUE(authentication.permits(
       at("/internal/foo"), authentication.caller({.bearer = "secret-match"})));
   EXPECT_FALSE(authentication.permits(
@@ -1024,7 +1027,7 @@ TEST(apikey_with_multiple_keys_admits_any) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_TRUE(authentication.permits(
       at("/internal/foo"), authentication.caller({.bearer = "key-a"})));
   EXPECT_TRUE(authentication.permits(
@@ -1045,7 +1048,7 @@ TEST(apikey_with_unset_variable_denies) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(
       at("/internal/foo"), authentication.caller({.bearer = "anything"})));
   EXPECT_FALSE(authentication.permits(at("/internal/foo"),
@@ -1065,7 +1068,7 @@ TEST(apikey_with_an_empty_variable_denies) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // A variable an operator meant to hold a key but left blank gates the path
   // exactly as an unset one does, rather than opening it to everyone
   EXPECT_FALSE(authentication.permits(at("/internal/foo"),
@@ -1089,7 +1092,7 @@ TEST(apikey_ignores_an_empty_variable_beside_a_real_one) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // The blank one neither admits anybody nor keeps the key beside it from
   // working
   EXPECT_TRUE(authentication.permits(
@@ -1114,7 +1117,7 @@ TEST(sha256_policy_with_an_empty_variable_denies) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(at("/secret/foo"),
                                       authentication.caller({.bearer = ""})));
   EXPECT_FALSE(authentication.permits(
@@ -1140,7 +1143,7 @@ TEST(sha256_policy_admits_the_matching_credential) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_TRUE(authentication.permits(at("/secret/foo"),
                                      authentication.caller({.bearer = raw})));
   EXPECT_FALSE(authentication.permits(
@@ -1177,7 +1180,7 @@ TEST(mixed_algorithms_admit_either_key_with_identity_first) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // Either key type opens the path regardless of declaration order. The sha256
   // key must work even though the identity policy is checked first and fails
   EXPECT_TRUE(authentication.permits(
@@ -1213,7 +1216,7 @@ TEST(mixed_algorithms_admit_either_key_with_sha256_first) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // The identity key must work even though the sha256 policy is checked first
   EXPECT_TRUE(authentication.permits(at("/mixed/x"),
                                      authentication.caller({.bearer = raw})));
@@ -1256,7 +1259,7 @@ TEST(supports_the_maximum_number_of_policies) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // The keyless policies gate their scope with no key that can open it
   EXPECT_FALSE(authentication.permits(at("/p0/foo"),
                                       authentication.caller({.bearer = ""})));
@@ -1267,7 +1270,7 @@ TEST(supports_the_maximum_number_of_policies) {
                                      authentication.caller({.bearer = ""})));
 }
 
-TEST(governing_returns_policy_indices_in_declaration_order) {
+TEST(governing_names_the_policies_in_declaration_order) {
   const std::array<std::string_view, 1> root_paths{{"/"}};
   const std::array<std::string_view, 1> internal_paths{{"/internal"}};
   const std::array<std::string_view, 1> root_keys{{"ONE_TEST_KEY_GR"}};
@@ -1284,15 +1287,14 @@ TEST(governing_returns_policy_indices_in_declaration_order) {
   const auto path{test_path("governing.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_EQ(authentication.governing(at("/")), (std::vector<std::size_t>{0}));
-  EXPECT_EQ(authentication.governing(at("/vendor")),
-            (std::vector<std::size_t>{0}));
-  EXPECT_EQ(authentication.governing(at("/internal")),
-            (std::vector<std::size_t>{0, 1}));
-  EXPECT_EQ(authentication.governing(at("/internal/foo")),
-            (std::vector<std::size_t>{0, 1}));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(gate.governing(at("/")), (std::vector<std::string_view>{"root"}));
+  EXPECT_EQ(gate.governing(at("/vendor")),
+            (std::vector<std::string_view>{"root"}));
+  EXPECT_EQ(gate.governing(at("/internal")),
+            (std::vector<std::string_view>{"root", "internal"}));
+  EXPECT_EQ(gate.governing(at("/internal/foo")),
+            (std::vector<std::string_view>{"root", "internal"}));
 }
 
 TEST(governing_of_an_ungoverned_path_is_empty) {
@@ -1306,24 +1308,18 @@ TEST(governing_of_an_ungoverned_path_is_empty) {
   const auto path{test_path("governing_empty.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_EQ(authentication.governing(at("/vendor")),
-            (std::vector<std::size_t>{}));
-  EXPECT_EQ(authentication.governing(at("/internal")),
-            (std::vector<std::size_t>{0}));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(gate.governing(at("/vendor")), (std::vector<std::string_view>{}));
+  EXPECT_EQ(gate.governing(at("/internal")),
+            (std::vector<std::string_view>{"policy"}));
 }
 
 TEST(reference_through_a_broken_artifact_is_rejected) {
-  const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"},
-      stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/open/one"), at("/open/two")));
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/open/one"), at("/secret/two")));
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/secret/one"), at("/secret/two")));
+  const sourcemeta::one::Authentication::Table gate{
+      std::filesystem::path{"/no/such/authentication.bin"}};
+  EXPECT_FALSE(gate.reference_permitted(at("/open/one"), at("/open/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/open/one"), at("/secret/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/secret/one"), at("/secret/two")));
 }
 
 TEST(reference_to_a_public_schema_is_permitted) {
@@ -1337,12 +1333,9 @@ TEST(reference_to_a_public_schema_is_permitted) {
   const auto path{test_path("ref_to_public.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/secret/one"), at("/open/two")));
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/open/one"), at("/open/two")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_TRUE(gate.reference_permitted(at("/secret/one"), at("/open/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/open/one"), at("/open/two")));
 }
 
 TEST(public_schema_referencing_an_apikey_schema_is_rejected) {
@@ -1356,10 +1349,8 @@ TEST(public_schema_referencing_an_apikey_schema_is_rejected) {
   const auto path{test_path("ref_public_to_apikey.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/open/one"), at("/secret/two")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_FALSE(gate.reference_permitted(at("/open/one"), at("/secret/two")));
 }
 
 TEST(reference_within_the_same_policy_is_permitted) {
@@ -1373,12 +1364,11 @@ TEST(reference_within_the_same_policy_is_permitted) {
   const auto path{test_path("ref_same_policy.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(authentication.reference_permitted(at("/internal/one"),
-                                                 at("/internal/two")));
-  EXPECT_TRUE(authentication.reference_permitted(at("/internal/one"),
-                                                 at("/internal/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_TRUE(
+      gate.reference_permitted(at("/internal/one"), at("/internal/two")));
+  EXPECT_TRUE(
+      gate.reference_permitted(at("/internal/one"), at("/internal/one")));
 }
 
 TEST(reference_across_disjoint_policies_is_rejected) {
@@ -1399,12 +1389,9 @@ TEST(reference_across_disjoint_policies_is_rejected) {
   const auto path{test_path("ref_disjoint.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_FALSE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_from_a_narrower_to_a_wider_audience_is_permitted) {
@@ -1425,12 +1412,9 @@ TEST(reference_from_a_narrower_to_a_wider_audience_is_permitted) {
   const auto path{test_path("ref_narrow_to_wide.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/p/one"), at("/p/inner/two")));
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/p/inner/two"), at("/p/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_TRUE(gate.reference_permitted(at("/p/one"), at("/p/inner/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/p/inner/two"), at("/p/one")));
 }
 
 TEST(jwt_admits_a_valid_token_and_caches_the_key_set) {
@@ -1450,8 +1434,9 @@ TEST(jwt_admits_a_valid_token_and_caches_the_key_set) {
 
   const auto calls{std::make_shared<int>(0)};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
-                         calls)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
+                   calls)};
   EXPECT_TRUE(authentication.permits(
       at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
   EXPECT_FALSE(authentication.permits(
@@ -1481,8 +1466,9 @@ TEST(jwt_admits_a_token_whose_type_the_policy_requires) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
+                   nullptr)};
   EXPECT_TRUE(authentication.permits(
       at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
@@ -1507,8 +1493,9 @@ TEST(jwt_denies_a_token_whose_type_is_not_the_required_one) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
+                   nullptr)};
   EXPECT_FALSE(authentication.permits(
       at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
@@ -1531,8 +1518,9 @@ TEST(jwt_without_a_required_type_admits_any_type) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
+                   nullptr)};
   EXPECT_TRUE(authentication.permits(
       at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
@@ -1553,8 +1541,9 @@ TEST(jwt_denies_a_token_for_the_wrong_audience) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
+                   nullptr)};
   EXPECT_FALSE(authentication.permits(
       at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
@@ -1575,8 +1564,9 @@ TEST(jwt_denies_a_token_from_the_wrong_issuer) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
+                   nullptr)};
   EXPECT_FALSE(authentication.permits(
       at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
@@ -1597,8 +1587,9 @@ TEST(jwt_denies_a_disallowed_algorithm) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
+                   nullptr)};
   EXPECT_FALSE(authentication.permits(
       at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
@@ -1619,7 +1610,7 @@ TEST(jwt_denies_when_the_signing_key_is_absent) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path,
+      sourcemeta::one::Authentication::Table{path},
       stub_fetcher({{"https://idp.test/jwks", std::string{UNRELATED_KEYS}}},
                    nullptr)};
   EXPECT_FALSE(authentication.permits(
@@ -1642,7 +1633,7 @@ TEST(jwt_denies_when_the_key_set_cannot_be_fetched) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(
       at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
@@ -1664,8 +1655,9 @@ TEST(an_apikey_credential_never_triggers_a_jwt_fetch) {
 
   const auto calls{std::make_shared<int>(0)};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
-                         calls)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
+                   calls)};
   EXPECT_FALSE(authentication.permits(
       at("/secure/x"), authentication.caller({.bearer = "static-api-key"})));
   EXPECT_FALSE(authentication.permits(at("/secure/x"),
@@ -1690,16 +1682,17 @@ TEST(jwt_resolves_the_key_set_through_discovery) {
 
   const auto calls{std::make_shared<int>(0)};
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://acme.test/.well-known/openid-configuration",
-                           R"JSON({
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://acme.test/.well-known/openid-configuration",
+                     R"JSON({
               "issuer": "https://acme.test",
               "jwks_uri": "https://acme.test/keys",
               "response_types_supported": [ "code" ],
               "subject_types_supported": [ "public" ],
               "id_token_signing_alg_values_supported": [ "RS256" ]
             })JSON"},
-                          {"https://acme.test/keys", std::string{SIGNED_KEYS}}},
-                         calls)};
+                    {"https://acme.test/keys", std::string{SIGNED_KEYS}}},
+                   calls)};
   // Both the provider metadata and the key set it names are retrieved, and
   // the token then fails only on its issuer claim, which names a different
   // issuer than the policy trusts
@@ -1725,7 +1718,7 @@ TEST(jwt_without_a_discoverable_issuer_fails_closed) {
   save(policies, path, path, anywhere);
   const auto calls{std::make_shared<int>(0)};
   const sourcemeta::one::Authentication authentication{
-      path,
+      sourcemeta::one::Authentication::Table{path},
       stub_fetcher(
           {{"acme/.well-known/openid-configuration",
             R"JSON({ "issuer": "acme", "jwks_uri": "https://acme.test/keys" })JSON"},
@@ -1758,8 +1751,9 @@ TEST(mixed_apikey_and_jwt_policies_admit_either_credential) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
+                   nullptr)};
   // The static key opens the path
   EXPECT_TRUE(authentication.permits(
       at("/both/x"), authentication.caller({.bearer = "static-secret"})));
@@ -1787,8 +1781,9 @@ TEST(a_policy_naming_no_rule_admits_whoever_signs_in) {
             .client_secret_variable = "ONE_TEST_ADMIT_OPEN",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_admit_open"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_admit_open"), anywhere)},
       provider.fetcher()};
 
   EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
@@ -1825,8 +1820,9 @@ TEST(a_claim_that_never_arrived_is_asked_for_rather_than_refused) {
             .claims = CLAIMS_ONE_GROUP,
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_admit_partial"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_admit_partial"), anywhere)},
       provider.fetcher()};
 
   // It never arrived, so UserInfo is asked and answers
@@ -1866,8 +1862,9 @@ TEST(a_claim_that_never_arrived_and_is_nowhere_to_ask_refuses) {
             .claims = CLAIMS_ONE_GROUP,
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_admit_no_userinfo"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_admit_no_userinfo"), anywhere)},
       provider.fetcher()};
 
   EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
@@ -1901,8 +1898,9 @@ TEST(a_rule_that_refuses_settles_it_whatever_another_wants) {
             .email_domains = domains,
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_admit_both"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_admit_both"), anywhere)},
       provider.fetcher()};
 
   // Both hold, which is the control
@@ -1949,8 +1947,9 @@ TEST(an_address_the_provider_will_not_vouch_for_is_refused) {
             .email_domains = domains,
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_admit_unvouched"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_admit_unvouched"), anywhere)},
       provider.fetcher()};
 
   // The provider declined to vouch, which is an answer, so asking again cannot
@@ -1993,8 +1992,9 @@ TEST(a_second_answer_fills_gaps_without_overruling_the_token) {
             .claims = CLAIMS_ONE_GROUP,
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_combine_token"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_combine_token"), anywhere)},
       provider.fetcher()};
 
   // The token said something else about the very claim UserInfo would satisfy,
@@ -2040,8 +2040,9 @@ TEST(an_address_arrives_with_its_own_assertion_or_not_at_all) {
   Provider orphaned;
   orphaned.userinfo = R"JSON({ "sub": "a1b2", "email": "jane@acme.test" })JSON";
   const sourcemeta::one::Authentication unvouched{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("combine_pair"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("combine_pair"), anywhere)},
       orphaned.fetcher()};
   EXPECT_EQ(sign_in(unvouched, orphaned, "okta", "client",
                     R"JSON({ "sub": "a1b2", "email_verified": true })JSON")
@@ -2054,8 +2055,9 @@ TEST(an_address_arrives_with_its_own_assertion_or_not_at_all) {
   whole.userinfo = R"JSON({ "sub": "a1b2", "email": "jane@acme.test",
                             "email_verified": true })JSON";
   const sourcemeta::one::Authentication vouched{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("combine_whole"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("combine_whole"), anywhere)},
       whole.fetcher()};
   EXPECT_EQ(sign_in(vouched, whole, "okta", "client",
                     R"JSON({ "sub": "a1b2", "email_verified": true })JSON")
@@ -2082,8 +2084,9 @@ TEST(admitting_reads_two_answers_only_once_they_are_combined) {
             .email_domains = domains,
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_admit_split"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_admit_split"), anywhere)},
       provider.fetcher()};
 
   // The token carries the group and UserInfo carries the address, so only the
@@ -2122,8 +2125,9 @@ TEST(a_claim_answered_with_objects_is_named_where_an_operator_looks) {
             .claims = CLAIMS_ONE_GROUP,
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("shape_objects"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("shape_objects"), anywhere)},
       provider.fetcher()};
 
   const auto objects{sign_in(authentication, provider, "shapes", "client",
@@ -2154,8 +2158,9 @@ TEST(a_claim_answered_in_the_shape_a_rule_names_says_nothing) {
             .claims = CLAIMS_ONE_GROUP,
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("shape_strings"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("shape_strings"), anywhere)},
       provider.fetcher()};
 
   // It matched, so there is nothing to explain
@@ -2195,8 +2200,9 @@ TEST(a_scope_arriving_as_objects_is_refused_without_being_named) {
             .claims = CLAIMS_SCOPE,
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("shape_scope"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("shape_scope"), anywhere)},
       provider.fetcher()};
 
   const auto objects{sign_in(
@@ -2221,8 +2227,9 @@ TEST(a_callback_under_a_name_this_instance_does_not_serve_is_refused) {
             .client_secret_variable = "ONE_TEST_ADMIT_UNKNOWN",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_admit_unknown"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_admit_unknown"), anywhere)},
       provider.fetcher()};
 
   EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
@@ -2254,7 +2261,7 @@ TEST(oidc_policy_admits_no_presented_credential) {
   // would accept, and the provider is never contacted
   const auto calls{std::make_shared<int>(0)};
   const sourcemeta::one::Authentication authentication{
-      path,
+      sourcemeta::one::Authentication::Table{path},
       stub_fetcher({{"acme/.well-known/openid-configuration",
                      R"JSON({ "jwks_uri": "https://acme.test/keys" })JSON"},
                     {"https://acme.test/keys", std::string{SIGNED_KEYS}}},
@@ -2295,7 +2302,7 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_only_the_key) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
 
   const auto key_permitted{authentication.permits(
       at("/both/x"), authentication.caller({.bearer = "union-secret"}))};
@@ -2321,8 +2328,8 @@ TEST(oidc_policy_admits_its_session_cookie) {
   save(policies, path, path, anywhere);
 
   const auto calls{std::make_shared<int>(0)};
-  const sourcemeta::one::Authentication authentication{path,
-                                                       stub_fetcher({}, calls)};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, calls)};
 
   const auto sealed{session_for("okta", SESSION_SECRETS, "jane@acme.test")};
   const std::string cookies{"theme=dark; sourcemeta_one_session=" + sealed};
@@ -2362,7 +2369,7 @@ TEST(session_cookie_is_bound_to_the_policy_it_was_minted_for) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
 
   const auto sealed{session_for("okta", SESSION_SECRETS, "")};
 
@@ -2394,8 +2401,9 @@ TEST(forged_session_cookie_is_denied) {
             .client_secret_variable = "ONE_TEST_OIDC_FORGED",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("oidc_session_forged"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("oidc_session_forged"), anywhere)},
       stub_fetcher({}, nullptr)};
 
   // The control, which is a session this policy did mint
@@ -2445,7 +2453,7 @@ TEST(session_is_admitted_when_a_shadowing_cookie_precedes_it) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   const auto sealed{session_for("okta", SESSION_SECRETS, "")};
 
   // A parent domain can set a cookie the host also sets, and the header says
@@ -2474,7 +2482,7 @@ TEST(session_is_admitted_when_a_shadowing_cookie_follows_it) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   const auto sealed{session_for("okta", SESSION_SECRETS, "")};
 
   // Taking the last match would deny here, which is the shape that lets a
@@ -2501,7 +2509,7 @@ TEST(session_is_admitted_when_it_arrives_in_a_later_cookie_field) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   const auto sealed{session_for("okta", SESSION_SECRETS, "")};
 
   // A request may carry its cookies across several fields rather than one, so
@@ -2529,7 +2537,7 @@ TEST(session_is_admitted_when_it_arrives_in_an_earlier_cookie_field) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   const auto sealed{session_for("okta", SESSION_SECRETS, "")};
 
   // And neither field is the one that decides, so a later one carrying nothing
@@ -2568,7 +2576,7 @@ TEST(a_session_for_another_policy_does_not_end_the_search) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   const auto other{session_for("google", SESSION_SECRETS, "")};
   const auto mine{session_for("okta", SESSION_SECRETS, "")};
 
@@ -2602,7 +2610,7 @@ TEST(a_shadowing_cookie_alone_never_admits) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // Trying every value admits a caller if any one opens, and never because
   // several did not
   const std::string cookies{"sourcemeta_one_session=not-a-session; "
@@ -2639,7 +2647,7 @@ TEST(a_session_never_admits_under_a_policy_sharing_its_secret) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   const auto sealed{session_for("okta", SESSION_SECRETS, "")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
 
@@ -2670,8 +2678,9 @@ TEST(signing_out_asks_the_provider_that_established_the_session) {
             .client_secret_variable = "ONE_TEST_LOGOUT_A",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("logout_known"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("logout_known"), anywhere)},
       provider.fetcher()};
 
   const auto established{session_for("okta", SESSION_SECRETS, "jane")};
@@ -2702,8 +2711,9 @@ TEST(signing_out_with_a_session_naming_no_policy_here_asks_nobody) {
             .client_secret_variable = "ONE_TEST_LOGOUT_B",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("logout_unknown"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("logout_unknown"), anywhere)},
       provider.fetcher()};
 
   // A session another instance minted under a name this one never declared
@@ -2728,8 +2738,9 @@ TEST(a_transaction_never_admits_as_a_session) {
             .client_secret_variable = "ONE_TEST_PURPOSE_CLIENT",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("oidc_open_session_purpose"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("oidc_open_session_purpose"), anywhere)},
       stub_fetcher({{"https://acme.test/.well-known/openid-configuration",
                      R"JSON({
               "issuer": "https://acme.test",
@@ -2777,7 +2788,7 @@ TEST(session_cookie_without_a_configured_secret_is_denied) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
 
   const auto sealed{session_for("okta", SESSION_SECRETS, "")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
@@ -2801,8 +2812,9 @@ TEST(session_admitted_under_a_rotated_secret) {
             .client_secret_variable = "ONE_TEST_OIDC_ROTATED",
             .session_secrets = SESSION_SECRETS_ROTATED}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("oidc_session_rotated"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("oidc_session_rotated"), anywhere)},
       stub_fetcher({}, nullptr)};
 
   // A session established when the old secret was the only one is still
@@ -2839,8 +2851,9 @@ TEST(session_with_a_blank_configured_secret_is_denied) {
             .client_secret_variable = "ONE_TEST_OIDC_BLANK",
             .session_secrets = SESSION_SECRETS_BLANK}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("oidc_session_blank"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("oidc_session_blank"), anywhere)},
       stub_fetcher({}, nullptr)};
 
   // A blank secret would let anybody forge a session, so nothing verifies one,
@@ -2867,27 +2880,9 @@ TEST(save_creates_the_directory_it_writes_into) {
 
   EXPECT_TRUE(std::filesystem::exists(path));
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_TRUE(authentication.permits(
       at("/internal/foo"), authentication.caller({.bearer = "nested-secret"})));
-}
-
-TEST(save_rejects_a_nameless_policy) {
-  const std::array<std::string_view, 1> paths{{"/portal"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .credential = sourcemeta::one::Authentication::Policy::Interactive{
-            .issuer = "acme",
-            .client_id = "client",
-            .client_secret_variable = "ONE_TEST_OIDC_NAMELESS"}}}};
-  const auto path{test_path("oidc_nameless.bin")};
-  try {
-    save(policies, path, path, anywhere);
-    FAIL();
-  } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
-    EXPECT_STREQ(error.what(),
-                 "An authentication policy requires a name of its own");
-  }
 }
 
 TEST(an_artifact_whose_table_omits_the_anonymous_view_is_refused) {
@@ -2918,7 +2913,7 @@ TEST(an_artifact_whose_table_omits_the_anonymous_view_is_refused) {
   stream.close();
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // A refused artifact denies rather than serving anybody a tree it guessed at
   EXPECT_FALSE(authentication.permits(
       at("/machine/x"), authentication.caller({.bearer = "table-secret"})));
@@ -2926,52 +2921,10 @@ TEST(an_artifact_whose_table_omits_the_anonymous_view_is_refused) {
                                       authentication.caller({.bearer = ""})));
 }
 
-TEST(save_rejects_a_nameless_key_policy) {
-  const std::array<std::string_view, 1> paths{{"/machine"}};
-  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_NAMELESS"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .credential =
-            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
-  const auto path{test_path("key_nameless.bin")};
-  try {
-    save(policies, path, path, anywhere);
-    FAIL();
-  } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
-    EXPECT_STREQ(error.what(),
-                 "An authentication policy requires a name of its own");
-  }
-}
-
-TEST(save_rejects_two_policies_sharing_a_name) {
-  const std::array<std::string_view, 1> alpha_paths{{"/alpha"}};
-  const std::array<std::string_view, 1> beta_paths{{"/beta"}};
-  const std::array<std::string_view, 1> alpha_keys{{"ONE_TEST_KEY_SAME_A"}};
-  const std::array<std::string_view, 1> beta_keys{{"ONE_TEST_KEY_SAME_B"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = alpha_paths,
-        .name = "shared",
-        .credential =
-            sourcemeta::one::Authentication::Policy::ApiKey{.keys =
-                                                                alpha_keys}},
-       {.paths = beta_paths,
-        .name = "shared",
-        .credential = sourcemeta::one::Authentication::Policy::ApiKey{
-            .keys = beta_keys}}}};
-  const auto path{test_path("name_shared.bin")};
-  try {
-    save(policies, path, path, anywhere);
-    FAIL();
-  } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
-    EXPECT_STREQ(error.what(),
-                 "An authentication policy requires a name of its own");
-  }
-}
-
 TEST(save_writes_the_largest_table_a_configuration_can_declare) {
   constexpr std::size_t groups{4};
   constexpr auto per_group{
-      sourcemeta::one::Authentication::MAXIMUM_COMBINABLE_POLICIES};
+      sourcemeta::one::Authentication::Table::MAXIMUM_COMBINABLE_POLICIES};
   constexpr auto total{groups * per_group};
   std::vector<std::string> path_storage;
   std::vector<std::string> name_storage;
@@ -3025,8 +2978,9 @@ TEST(save_writes_the_largest_table_a_configuration_can_declare) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   EXPECT_EQ(authentication.caller({.bearer = ""}).view(), "public");
   // A name read back out of a table this size, rather than the entry that sits
   // first in it whatever was written after
@@ -3118,28 +3072,10 @@ TEST(save_accepts_a_separator_that_spells_no_other_combination) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_EQ(authentication.caller({.bearer = "separator-secret"}).view(),
             "alpha+beta");
   EXPECT_EQ(authentication.caller({.bearer = ""}).view(), "public");
-}
-
-TEST(save_rejects_a_policy_taking_the_anonymous_name) {
-  const std::array<std::string_view, 1> paths{{"/machine"}};
-  const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_RESERVED"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .name = "public",
-        .credential =
-            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
-  const auto path{test_path("name_reserved.bin")};
-  try {
-    save(policies, path, path, anywhere);
-    FAIL();
-  } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
-    EXPECT_STREQ(error.what(),
-                 "An authentication policy requires a name of its own");
-  }
 }
 
 TEST(union_of_an_apikey_and_an_oidc_policy_admits_key_or_session) {
@@ -3163,7 +3099,7 @@ TEST(union_of_an_apikey_and_an_oidc_policy_admits_key_or_session) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
 
   const auto key_permitted{authentication.permits(
       at("/both/x"), authentication.caller({.bearer = "union-key"}))};
@@ -3194,7 +3130,7 @@ TEST(session_cookie_does_not_open_an_apikey_path) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
 
   const auto sealed{session_for("okta", SESSION_SECRETS, "")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
@@ -3220,8 +3156,9 @@ TEST(a_login_starts_only_under_a_declared_name) {
             .client_secret_variable = "ONE_TEST_NAMED",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(policies, test_path("named"),
-                                               anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("named"), anywhere)},
       provider.fetcher()};
 
   EXPECT_EQ(authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")
@@ -3254,8 +3191,9 @@ TEST(what_a_provider_said_is_retrieved_once_and_reused) {
             .client_secret_variable = "ONE_TEST_OIDC_CACHE",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_oidc_cache"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_oidc_cache"), anywhere)},
       provider.fetcher()};
 
   EXPECT_EQ(authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")
@@ -3288,8 +3226,9 @@ TEST(a_provider_naming_no_authentication_method_gets_the_header) {
             .client_secret_variable = "ONE_TEST_OIDC_AUTH_SILENT",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_oidc_auth_silent"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_oidc_auth_silent"), anywhere)},
       provider.fetcher()};
 
   EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
@@ -3315,8 +3254,9 @@ TEST(a_provider_naming_the_header_gets_the_header) {
             .client_secret_variable = "ONE_TEST_OIDC_AUTH_BASIC",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_oidc_auth_basic"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_oidc_auth_basic"), anywhere)},
       provider.fetcher()};
 
   EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
@@ -3345,8 +3285,9 @@ TEST(a_provider_refusing_the_header_gets_the_body_instead) {
             .client_secret_variable = "ONE_TEST_OIDC_AUTH_POST",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_oidc_auth_post"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_oidc_auth_post"), anywhere)},
       provider.fetcher()};
 
   EXPECT_EQ(sign_in(authentication, provider, "okta", "client",
@@ -3371,14 +3312,16 @@ TEST(a_login_against_an_unreachable_provider_cannot_start) {
             .client_secret_variable = "ONE_TEST_OIDC_UNREACHABLE",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("one_test_oidc_unreachable"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("one_test_oidc_unreachable"), anywhere)},
       provider.fetcher()};
   Provider silent{provider};
   silent.reachable = false;
   const sourcemeta::one::Authentication unreachable{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("unreachable"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("unreachable"), anywhere)},
       silent.fetcher()};
 
   const auto outcome{
@@ -3405,8 +3348,9 @@ TEST(a_login_without_a_client_secret_cannot_start) {
             .client_secret_variable = "ONE_TEST_SECRET_UNSET",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("secret_unset"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("secret_unset"), anywhere)},
       provider.fetcher()};
 
   const auto outcome{
@@ -3436,8 +3380,9 @@ TEST(a_login_with_a_blank_client_secret_cannot_start) {
             .client_secret_variable = "ONE_TEST_SECRET_BLANK",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("secret_blank"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("secret_blank"), anywhere)},
       provider.fetcher()};
   const auto outcome{
       authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")};
@@ -3454,8 +3399,9 @@ TEST(a_login_with_a_blank_client_secret_cannot_start) {
             .client_secret_variable = "ONE_TEST_SECRET_SET",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication working{
-      sourcemeta::one::Authentication::compile(
-          configured, test_path("secret_set"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              configured, test_path("secret_set"), anywhere)},
       provider.fetcher()};
   EXPECT_EQ(working.login("okta", INSTANCE_URL, REDIRECT_URI, false, "").result,
             sourcemeta::one::Authentication::Outcome::Result::Redirect);
@@ -3473,8 +3419,9 @@ TEST(a_login_naming_no_secret_variable_cannot_start) {
             .client_id = "client",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("secret_unnamed"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("secret_unnamed"), anywhere)},
       provider.fetcher()};
 
   const auto outcome{
@@ -3494,8 +3441,9 @@ TEST(a_machine_policy_starts_no_login) {
         .credential =
             sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("machine_login"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("machine_login"), anywhere)},
       Provider{}.fetcher()};
 
   EXPECT_EQ(
@@ -3518,8 +3466,9 @@ TEST(a_login_asking_for_nowhere_returns_to_what_the_policy_governs) {
             .client_secret_variable = "ONE_TEST_DEFAULT_PATH",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("default_path"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("default_path"), anywhere)},
       provider.fetcher()};
 
   const auto completed{sign_in(authentication, provider, "okta", "client",
@@ -3533,7 +3482,9 @@ TEST(a_login_asking_for_nowhere_returns_to_what_the_policy_governs) {
 // is the same answer it gives to every other question
 TEST(a_login_through_a_broken_artifact_is_missing) {
   const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"}, {}};
+      sourcemeta::one::Authentication::Table{
+          std::filesystem::path{"/no/such/authentication.bin"}},
+      {}};
   EXPECT_EQ(authentication.login("okta", INSTANCE_URL, REDIRECT_URI, false, "")
                 .result,
             sourcemeta::one::Authentication::Outcome::Result::Missing);
@@ -3568,8 +3519,9 @@ TEST(a_session_is_bound_to_the_policy_whose_secret_sealed_it) {
             .client_secret_variable = "ONE_TEST_BIND_B",
             .session_secrets = other}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("bind_policies"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("bind_policies"), anywhere)},
       provider.fetcher()};
 
   const auto established{session_for("okta", SESSION_SECRETS, "jane")};
@@ -3599,8 +3551,9 @@ TEST(a_login_without_a_session_secret_cannot_start) {
             .client_secret_variable = "ONE_TEST_SEAL_NONE",
             .session_secrets = absent}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(policies, test_path("seal_none"),
-                                               anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("seal_none"), anywhere)},
       provider.fetcher()};
 
   const auto outcome{
@@ -3636,12 +3589,9 @@ TEST(reference_within_the_same_oidc_scope_is_permitted) {
   const auto path{test_path("oidc_ref_same.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_TRUE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_across_distinct_oidc_clients_is_rejected) {
@@ -3666,12 +3616,9 @@ TEST(reference_across_distinct_oidc_clients_is_rejected) {
   const auto path{test_path("oidc_ref_distinct.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_FALSE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_across_swapped_oidc_identities_is_rejected) {
@@ -3698,12 +3645,9 @@ TEST(reference_across_swapped_oidc_identities_is_rejected) {
   const auto path{test_path("oidc_ref_swapped.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_FALSE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_mixing_identities_across_oidc_policies_is_rejected) {
@@ -3739,10 +3683,8 @@ TEST(reference_mixing_identities_across_oidc_policies_is_rejected) {
   const auto path{test_path("oidc_ref_mixed.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/source/one"), at("/target/two")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_FALSE(gate.reference_permitted(at("/source/one"), at("/target/two")));
 }
 
 TEST(reference_between_oidc_scopes_distinguishes_claims) {
@@ -3769,14 +3711,11 @@ TEST(reference_between_oidc_scopes_distinguishes_claims) {
   const auto path{test_path("oidc_ref_claims.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+  const sourcemeta::one::Authentication::Table gate{path};
   // The same provider client admitting a narrower set of people is a different
   // audience, so neither direction reaches the other
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/open/one"), at("/gated/two")));
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/gated/two"), at("/open/one")));
+  EXPECT_FALSE(gate.reference_permitted(at("/open/one"), at("/gated/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/gated/two"), at("/open/one")));
 }
 
 TEST(reference_between_oidc_scopes_distinguishes_email_domains) {
@@ -3806,10 +3745,8 @@ TEST(reference_between_oidc_scopes_distinguishes_email_domains) {
   const auto path{test_path("oidc_ref_domains.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_FALSE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
 }
 
 TEST(reference_between_oidc_scopes_ignores_how_rules_were_written) {
@@ -3844,14 +3781,11 @@ TEST(reference_between_oidc_scopes_ignores_how_rules_were_written) {
   const auto path{test_path("oidc_ref_spelling.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+  const sourcemeta::one::Authentication::Table gate{path};
   // A domain names a host, so its case says nothing about who is admitted,
   // and neither does the order the rules were written in
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  EXPECT_TRUE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(admission_by_an_apikey_policy_identifies_the_principal) {
@@ -3867,7 +3801,7 @@ TEST(admission_by_an_apikey_policy_identifies_the_principal) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   const auto permitted{authentication.permits(
       at("/internal/foo"),
       authentication.caller({.bearer = "principal-secret"}))};
@@ -3890,8 +3824,9 @@ TEST(admission_by_a_jwt_policy_identifies_the_principal) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
+                   nullptr)};
   const auto permitted{authentication.permits(
       at("/secure/foo"), authentication.caller({.bearer = SIGNED_TOKEN}))};
   EXPECT_TRUE(permitted);
@@ -3919,8 +3854,9 @@ TEST(principal_identifies_the_admitting_policy_among_several) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{SIGNED_KEYS}}},
+                   nullptr)};
 
   const auto apikey_permitted{authentication.permits(
       at("/both/x"), authentication.caller({.bearer = "principal-mixed"}))};
@@ -3944,7 +3880,7 @@ TEST(anonymous_and_denied_verdicts_carry_no_principal) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
 
   // An uncovered path admits an anonymous caller
   const auto anonymous_permitted{authentication.permits(
@@ -3958,7 +3894,8 @@ TEST(anonymous_and_denied_verdicts_carry_no_principal) {
 
   // A broken artifact denies with no principal either
   const sourcemeta::one::Authentication missing{
-      std::filesystem::path{"/no/such/authentication.bin"},
+      sourcemeta::one::Authentication::Table{
+          std::filesystem::path{"/no/such/authentication.bin"}},
       stub_fetcher({}, nullptr)};
   const auto missing_permitted{missing.permits(
       at("/internal/foo"), missing.caller({.bearer = "principal-none"}))};
@@ -3981,16 +3918,12 @@ TEST(reference_rules_treat_a_jwt_scope_conservatively) {
   save(policies, path, path, anywhere);
 
   // Reference checks read only the policy, so no key set transport is needed
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+  const sourcemeta::one::Authentication::Table gate{path};
   // A public schema may not reference one behind the token scope
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/open/one"), at("/secure/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/open/one"), at("/secure/two")));
   // The token scope may reference a public schema, and itself
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/secure/one"), at("/open/two")));
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/secure/one"), at("/secure/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/secure/one"), at("/open/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/secure/one"), at("/secure/two")));
 }
 
 TEST(jwt_without_a_transport_denies_rather_than_crashes) {
@@ -4008,7 +3941,8 @@ TEST(jwt_without_a_transport_denies_rather_than_crashes) {
   const auto path{test_path("jwt_no_transport.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{path, {}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::Table{path}, {}};
   EXPECT_FALSE(authentication.permits(
       at("/secure/x"), authentication.caller({.bearer = SIGNED_TOKEN})));
 }
@@ -4038,10 +3972,11 @@ TEST(jwt_policies_sharing_an_issuer_use_their_own_key_set) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher(
-                {{"https://idp.test/primary", std::string{SIGNED_KEYS}},
-                 {"https://idp.test/secondary", std::string{UNRELATED_KEYS}}},
-                nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher(
+          {{"https://idp.test/primary", std::string{SIGNED_KEYS}},
+           {"https://idp.test/secondary", std::string{UNRELATED_KEYS}}},
+          nullptr)};
   // The primary path is populated first, which under a per-issuer cache would
   // have leaked its key set to the secondary path
   EXPECT_TRUE(authentication.permits(
@@ -4067,8 +4002,9 @@ TEST(jwt_claims_admit_only_a_token_carrying_a_named_value) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   EXPECT_TRUE(authentication.permits(
       at("/secure/x"),
       authentication.caller(
@@ -4099,8 +4035,9 @@ TEST(jwt_claims_admit_any_one_of_the_named_values) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   EXPECT_TRUE(authentication.permits(
       at("/secure/x"),
       authentication.caller(
@@ -4138,8 +4075,9 @@ TEST(jwt_claims_require_every_rule_it_declares) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   EXPECT_TRUE(authentication.permits(
       at("/secure/x"),
       authentication.caller(
@@ -4174,8 +4112,9 @@ TEST(jwt_claims_read_a_scope_as_a_space_delimited_set) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   EXPECT_TRUE(authentication.permits(
       at("/secure/x"),
       authentication.caller(
@@ -4221,8 +4160,9 @@ TEST(jwt_claims_deny_an_ordinary_rule_that_names_no_value) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   // The same reading the scope rule gets, on the path that defers the
   // comparison rather than making it here
   EXPECT_FALSE(authentication.permits(
@@ -4248,8 +4188,9 @@ TEST(jwt_claims_deny_a_scope_rule_that_names_no_value) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   // An allow list naming nothing admits nobody, rather than widening to
   // every token that carries any scope at all
   EXPECT_FALSE(authentication.permits(
@@ -4275,8 +4216,9 @@ TEST(jwt_claims_deny_a_scope_rule_this_cannot_read) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   // A value that is not a scope token denies, since passing it over would
   // leave a rule that admits every token carrying any scope
   EXPECT_FALSE(authentication.permits(
@@ -4302,8 +4244,9 @@ TEST(jwt_claims_scope_without_a_constraint_still_requires_a_scope) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   // Constraining no value asks only that a scope be carried, so any one does
   EXPECT_TRUE(authentication.permits(
       at("/secure/x"),
@@ -4335,8 +4278,9 @@ TEST(jwt_claims_match_a_group_object_on_its_identifier_alone) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   // The shape RFC 9068 Section 2.2.3.1 gives the claim by way of RFC 7643
   EXPECT_TRUE(authentication.permits(
       at("/secure/x"),
@@ -4369,8 +4313,9 @@ TEST(jwt_claims_never_match_a_value_that_is_not_a_string) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   EXPECT_FALSE(authentication.permits(
       at("/secure/x"),
       authentication.caller(
@@ -4401,8 +4346,9 @@ TEST(jwt_without_claims_admits_a_token_carrying_none) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   EXPECT_TRUE(authentication.permits(
       at("/secure/x"), authentication.caller({.bearer = token_with("{}")})));
 }
@@ -4452,8 +4398,9 @@ TEST(jwt_claims_that_do_not_parse_deny_everything) {
   }
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   // Rules that cannot be read are not passed over, since doing so would drop
   // the restriction and admit everyone the policy was meant to narrow
   EXPECT_FALSE(authentication.permits(
@@ -4490,19 +4437,15 @@ TEST(reference_between_jwt_scopes_distinguishes_claims) {
   const auto path{test_path("jwt_claims_reference.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+  const sourcemeta::one::Authentication::Table gate{path};
   // Two policies alike but for their rules admit different callers, so the
   // looser one may not reach what the stricter one guards
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/open/one"), at("/gated/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/open/one"), at("/gated/two")));
   // The reverse is refused too, exactly as a differing token type is. A scope
   // is one indivisible identity rather than a set compared piecewise, so the
   // cost is a build that has to say so, against disclosing a referent to
   // somebody the referrer never admitted
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/gated/two"), at("/open/one")));
+  EXPECT_FALSE(gate.reference_permitted(at("/gated/two"), at("/open/one")));
 }
 
 TEST(reference_between_jwt_scopes_ignores_the_order_rules_were_written_in) {
@@ -4531,15 +4474,11 @@ TEST(reference_between_jwt_scopes_ignores_the_order_rules_were_written_in) {
   const auto path{test_path("jwt_claims_reference_order.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+  const sourcemeta::one::Authentication::Table gate{path};
   // The rules arrive canonical, so two policies admitting the same callers
   // carry identical bytes and count as one audience in either direction
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  EXPECT_TRUE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_between_jwt_scopes_distinguishes_algorithms) {
@@ -4577,15 +4516,12 @@ TEST(reference_between_jwt_scopes_distinguishes_algorithms) {
   const auto path{test_path("jwt_reference_algorithms.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+  const sourcemeta::one::Authentication::Table gate{path};
   // Same issuer, audience, and key set but a different algorithm is a different
   // scope, so no token could satisfy the reference
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
   // An identical policy is the same scope
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/alpha/one"), at("/gamma/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/alpha/one"), at("/gamma/two")));
 }
 
 TEST(reference_between_jwt_scopes_ignores_algorithm_order) {
@@ -4618,12 +4554,9 @@ TEST(reference_between_jwt_scopes_ignores_algorithm_order) {
   const auto path{test_path("jwt_reference_algorithm_order.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_TRUE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_between_jwt_scopes_ignores_token_type_spelling) {
@@ -4654,12 +4587,9 @@ TEST(reference_between_jwt_scopes_ignores_token_type_spelling) {
   const auto path{test_path("jwt_reference_token_type_spelling.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_TRUE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_between_jwt_scopes_ignores_repeated_algorithms) {
@@ -4692,12 +4622,9 @@ TEST(reference_between_jwt_scopes_ignores_repeated_algorithms) {
   const auto path{test_path("jwt_reference_repeated_algorithms.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_TRUE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(a_token_type_that_is_the_bare_media_prefix_still_names_a_type) {
@@ -4728,12 +4655,9 @@ TEST(a_token_type_that_is_the_bare_media_prefix_still_names_a_type) {
   const auto path{test_path("jwt_token_type_bare_prefix.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_FALSE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(a_token_type_carrying_a_further_separator_keeps_its_prefix) {
@@ -4764,12 +4688,9 @@ TEST(a_token_type_carrying_a_further_separator_keeps_its_prefix) {
   const auto path{test_path("jwt_token_type_nested_separator.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_FALSE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_across_swapped_jwt_identities_is_rejected) {
@@ -4798,12 +4719,9 @@ TEST(reference_across_swapped_jwt_identities_is_rejected) {
   const auto path{test_path("jwt_reference_swapped.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_FALSE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 TEST(reference_mixing_identities_across_jwt_policies_is_rejected) {
@@ -4841,10 +4759,8 @@ TEST(reference_mixing_identities_across_jwt_policies_is_rejected) {
   const auto path{test_path("jwt_reference_mixed.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/source/one"), at("/target/two")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_FALSE(gate.reference_permitted(at("/source/one"), at("/target/two")));
 }
 
 TEST(reference_across_swapped_jwt_key_set_locations_is_rejected) {
@@ -4874,12 +4790,9 @@ TEST(reference_across_swapped_jwt_key_set_locations_is_rejected) {
   const auto path{test_path("jwt_reference_swapped_keys.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/alpha/one"), at("/beta/two")));
-  EXPECT_FALSE(
-      authentication.reference_permitted(at("/beta/two"), at("/alpha/one")));
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_FALSE(gate.reference_permitted(at("/alpha/one"), at("/beta/two")));
+  EXPECT_FALSE(gate.reference_permitted(at("/beta/two"), at("/alpha/one")));
 }
 
 // A configured policy path that only differs cosmetically still has to gate the
@@ -4899,7 +4812,7 @@ TEST(a_policy_path_declared_canonically_gates_its_location) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(at("/private/secret"),
                                       authentication.caller({.bearer = ""})));
   EXPECT_TRUE(authentication.permits(
@@ -4923,7 +4836,7 @@ TEST(a_policy_path_carrying_a_dot_segment_gates_its_location) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(at("/private/secret"),
                                       authentication.caller({.bearer = ""})));
   EXPECT_TRUE(authentication.permits(
@@ -4947,7 +4860,7 @@ TEST(a_policy_path_that_climbs_back_into_itself_gates_its_location) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(at("/private/secret"),
                                       authentication.caller({.bearer = ""})));
   EXPECT_TRUE(authentication.permits(
@@ -4971,7 +4884,7 @@ TEST(a_policy_path_carrying_a_repeated_separator_gates_its_location) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(at("/private/secret"),
                                       authentication.caller({.bearer = ""})));
   EXPECT_TRUE(authentication.permits(
@@ -4983,7 +4896,7 @@ TEST(a_policy_path_carrying_a_repeated_separator_gates_its_location) {
 }
 
 TEST(views_of_nothing_are_the_public_one_alone) {
-  const auto views{sourcemeta::one::Authentication::views({})};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate({})};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}}}));
 }
@@ -4997,7 +4910,7 @@ TEST(views_name_a_static_key_policy_on_its_own) {
         .credential =
             sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
 
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "vault", .policies = {0}}}));
@@ -5011,7 +4924,7 @@ TEST(views_name_an_interactive_policy_on_its_own) {
         .credential = sourcemeta::one::Authentication::Policy::Interactive{
             .issuer = "https://idp.example.com/realms/staff"}}}};
 
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "desk", .policies = {0}}}));
@@ -5025,7 +4938,7 @@ TEST(views_name_a_token_policy_on_its_own) {
         .credential = sourcemeta::one::Authentication::Policy::Token{
             .issuer = "https://idp.example.com/realms/staff"}}}};
 
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "machine", .policies = {0}}}));
@@ -5047,7 +4960,7 @@ TEST(views_combine_token_policies_that_name_one_issuer) {
 
   // A claim is a list and a rule is met by any of its values, so one token can
   // satisfy both
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "legal", .policies = {0}},
@@ -5071,7 +4984,7 @@ TEST(views_never_combine_token_policies_across_issuers) {
 
   // A token carries one issuer and is verified against it before any rule is
   // read, so nobody can ever hold both
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "partner", .policies = {1}},
@@ -5096,7 +5009,7 @@ TEST(views_never_combine_token_policies_testing_one_claim_across_issuers) {
 
   // The issuer is decisive and is read first, so testing the same claim for the
   // same value means nothing across them
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "legal", .policies = {0}},
@@ -5119,7 +5032,7 @@ TEST(views_never_combine_interactive_policies_under_one_issuer) {
 
   // A browser holds one session naming one policy, so sharing an issuer buys an
   // interactive caller nothing
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "first", .policies = {0}},
@@ -5143,7 +5056,7 @@ TEST(views_never_combine_static_key_policies) {
             .keys = second_keys}}}};
 
   // A caller presents one key, so it satisfies one of these whatever it holds
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "first", .policies = {0}},
@@ -5164,7 +5077,7 @@ TEST(views_spell_a_combination_the_same_however_it_was_declared) {
         .credential = sourcemeta::one::Authentication::Policy::Token{
             .issuer = "https://idp.example.com/realms/staff"}}}};
 
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "legal", .policies = {1}},
@@ -5190,7 +5103,7 @@ TEST(views_of_three_token_policies_under_one_issuer_are_every_combination) {
         .credential = sourcemeta::one::Authentication::Policy::Token{
             .issuer = "https://idp.example.com/realms/staff"}}}};
 
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "a", .policies = {0}},
@@ -5220,7 +5133,7 @@ TEST(views_mix_a_combining_group_with_policies_that_stand_alone) {
         .credential = sourcemeta::one::Authentication::Policy::Token{
             .issuer = "https://idp.example.com/realms/staff"}}}};
 
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "legal", .policies = {1}},
@@ -5238,7 +5151,7 @@ TEST(views_hold_the_public_one_even_when_every_path_is_governed) {
         .credential =
             sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
 
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}},
                        {.name = "everything", .policies = {0}}}));
@@ -5257,7 +5170,7 @@ TEST(views_of_six_token_policies_under_one_issuer_are_every_combination) {
   }
 
   // Two to the sixth, being every non-empty combination plus the anonymous one
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views.size(), 64);
 }
 
@@ -5277,14 +5190,15 @@ TEST(views_of_two_issuer_groups_are_a_sum_rather_than_a_product) {
 
   // Each group contributes its own combinations and nothing crosses between
   // them, so the total adds rather than multiplies
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views.size(), 1 + 15 + 15);
 }
 
 TEST(views_of_the_largest_combinable_group_are_every_combination) {
   const std::array<std::string_view, 1> paths{{"/one"}};
-  std::array<sourcemeta::one::Authentication::Policy,
-             sourcemeta::one::Authentication::MAXIMUM_COMBINABLE_POLICIES>
+  std::array<
+      sourcemeta::one::Authentication::Policy,
+      sourcemeta::one::Authentication::Table::MAXIMUM_COMBINABLE_POLICIES>
       policies{};
   std::vector<std::string> names;
   names.reserve(policies.size());
@@ -5300,17 +5214,19 @@ TEST(views_of_the_largest_combinable_group_are_every_combination) {
             .issuer = "https://idp.example.com/realms/staff"};
   }
 
-  const auto views{sourcemeta::one::Authentication::views(policies)};
-  EXPECT_EQ(views.size(),
-            (std::size_t{1}
-             << sourcemeta::one::Authentication::MAXIMUM_COMBINABLE_POLICIES));
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
+  EXPECT_EQ(
+      views.size(),
+      (std::size_t{1}
+       << sourcemeta::one::Authentication::Table::MAXIMUM_COMBINABLE_POLICIES));
   EXPECT_EQ(views.at(0).name, "public");
 }
 
 TEST(views_refuse_a_group_whose_combinations_cannot_be_produced) {
   const std::array<std::string_view, 1> paths{{"/one"}};
-  std::array<sourcemeta::one::Authentication::Policy,
-             sourcemeta::one::Authentication::MAXIMUM_COMBINABLE_POLICIES + 1>
+  std::array<
+      sourcemeta::one::Authentication::Policy,
+      sourcemeta::one::Authentication::Table::MAXIMUM_COMBINABLE_POLICIES + 1>
       policies{};
   std::vector<std::string> names;
   names.reserve(policies.size());
@@ -5327,15 +5243,18 @@ TEST(views_refuse_a_group_whose_combinations_cannot_be_produced) {
   }
 
   try {
-    const auto views{sourcemeta::one::Authentication::views(policies)};
+    const auto views{
+        sourcemeta::one::Authentication::Table::enumerate(policies)};
     EXPECT_EQ(views.size(), 0);
     FAIL();
   } catch (const sourcemeta::one::AuthenticationTooManyViewsError &error) {
     EXPECT_STREQ(error.what(),
                  "Too many authentication policies share an issuer");
     EXPECT_EQ(error.issuer(), "https://idp.example.com/realms/staff");
-    EXPECT_EQ(error.count(),
-              sourcemeta::one::Authentication::MAXIMUM_COMBINABLE_POLICIES + 1);
+    EXPECT_EQ(
+        error.count(),
+        sourcemeta::one::Authentication::Table::MAXIMUM_COMBINABLE_POLICIES +
+            1);
   }
 }
 
@@ -5358,7 +5277,7 @@ TEST(views_of_many_policies_across_issuers_are_never_refused) {
                                                            names.at(index)};
   }
 
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views.size(), 41);
 }
 
@@ -5387,7 +5306,7 @@ TEST(a_presented_key_decides_over_a_session) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   const auto sealed{session_for("okta", SESSION_SECRETS, "jane@acme.test")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
 
@@ -5434,7 +5353,7 @@ TEST(a_presented_key_that_opens_nothing_sets_a_session_aside) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   const auto sealed{session_for("okta", SESSION_SECRETS, "jane@acme.test")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
 
@@ -5465,7 +5384,7 @@ TEST(a_caller_presenting_nothing_is_served_the_anonymous_view) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_EQ(authentication.caller({.bearer = ""}).view(), "public");
   EXPECT_EQ(authentication.caller({.bearer = "retired-secret"}).view(),
             "public");
@@ -5500,8 +5419,9 @@ TEST(a_token_satisfying_two_policies_is_served_their_combined_view) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   EXPECT_EQ(authentication
                 .caller({.bearer = token_with(
                              R"JSON({ "groups": [ "platform" ] })JSON")})
@@ -5527,7 +5447,7 @@ TEST(a_token_satisfying_two_policies_is_served_their_combined_view) {
             "public");
 }
 
-TEST(the_recorded_table_names_a_view_at_every_index) {
+TEST(the_recorded_table_names_every_view_it_serves) {
   const std::array<std::string_view, 1> platform_paths{{"/platform"}};
   const std::array<std::string_view, 1> oncall_paths{{"/oncall"}};
   const std::array<sourcemeta::core::JWSAlgorithm, 1> algorithms{
@@ -5551,22 +5471,22 @@ TEST(the_recorded_table_names_a_view_at_every_index) {
   const auto path{test_path("recorded_table.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+  const sourcemeta::one::Authentication::Table gate{path};
   // The anonymous view first, then the rest by name, which is the order a build
   // fans its actions out in
-  EXPECT_EQ(authentication.view_count(), std::size_t{4});
-  EXPECT_EQ(authentication.view_at(0).name, "public");
-  EXPECT_EQ(authentication.view_at(0).policies,
+  const auto table{gate.views()};
+  EXPECT_EQ(table.size(), std::size_t{4});
+  EXPECT_EQ(table.at(0).name, "public");
+  EXPECT_EQ(table.at(0).policies,
             sourcemeta::one::Authentication::PolicySet{0});
-  EXPECT_EQ(authentication.view_at(1).name, "oncall");
-  EXPECT_EQ(authentication.view_at(1).policies,
+  EXPECT_EQ(table.at(1).name, "oncall");
+  EXPECT_EQ(table.at(1).policies,
             sourcemeta::one::Authentication::PolicySet{0b10});
-  EXPECT_EQ(authentication.view_at(2).name, "oncall+platform");
-  EXPECT_EQ(authentication.view_at(2).policies,
+  EXPECT_EQ(table.at(2).name, "oncall+platform");
+  EXPECT_EQ(table.at(2).policies,
             sourcemeta::one::Authentication::PolicySet{0b11});
-  EXPECT_EQ(authentication.view_at(3).name, "platform");
-  EXPECT_EQ(authentication.view_at(3).policies,
+  EXPECT_EQ(table.at(3).name, "platform");
+  EXPECT_EQ(table.at(3).policies,
             sourcemeta::one::Authentication::PolicySet{0b01});
 }
 
@@ -5594,43 +5514,43 @@ TEST(a_view_shows_what_it_governs_and_whatever_nobody_governs) {
   const auto path{test_path("view_visibility.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  // Indices as the table records them: anonymous, then oncall, their
-  // combination, and platform
-  EXPECT_EQ(authentication.view_at(0).name, "public");
-  EXPECT_EQ(authentication.view_at(1).name, "oncall");
-  EXPECT_EQ(authentication.view_at(2).name, "oncall+platform");
-  EXPECT_EQ(authentication.view_at(3).name, "platform");
+  const sourcemeta::one::Authentication::Table gate{path};
+  const auto anonymous{gate.view("public")};
+  const auto oncall{gate.view("oncall")};
+  const auto both{gate.view("oncall+platform")};
+  const auto platform{gate.view("platform")};
 
   // What nobody governs is shown to everybody, the anonymous view included
-  EXPECT_TRUE(authentication.visible(at("/open/x"), 0));
-  EXPECT_TRUE(authentication.visible(at("/open/x"), 1));
-  EXPECT_TRUE(authentication.visible(at("/open/x"), 2));
-  EXPECT_TRUE(authentication.visible(at("/open/x"), 3));
+  EXPECT_TRUE(gate.visible(at("/open/x"), anonymous));
+  EXPECT_TRUE(gate.visible(at("/open/x"), oncall));
+  EXPECT_TRUE(gate.visible(at("/open/x"), both));
+  EXPECT_TRUE(gate.visible(at("/open/x"), platform));
 
   // And a governed location only to a view satisfying something governing it
-  EXPECT_FALSE(authentication.visible(at("/platform/x"), 0));
-  EXPECT_FALSE(authentication.visible(at("/platform/x"), 1));
-  EXPECT_TRUE(authentication.visible(at("/platform/x"), 2));
-  EXPECT_TRUE(authentication.visible(at("/platform/x"), 3));
-  EXPECT_FALSE(authentication.visible(at("/oncall/x"), 0));
-  EXPECT_TRUE(authentication.visible(at("/oncall/x"), 1));
-  EXPECT_TRUE(authentication.visible(at("/oncall/x"), 2));
-  EXPECT_FALSE(authentication.visible(at("/oncall/x"), 3));
+  EXPECT_FALSE(gate.visible(at("/platform/x"), anonymous));
+  EXPECT_FALSE(gate.visible(at("/platform/x"), oncall));
+  EXPECT_TRUE(gate.visible(at("/platform/x"), both));
+  EXPECT_TRUE(gate.visible(at("/platform/x"), platform));
+  EXPECT_FALSE(gate.visible(at("/oncall/x"), anonymous));
+  EXPECT_TRUE(gate.visible(at("/oncall/x"), oncall));
+  EXPECT_TRUE(gate.visible(at("/oncall/x"), both));
+  EXPECT_FALSE(gate.visible(at("/oncall/x"), platform));
 }
 
 TEST(an_instance_that_read_no_artifact_shows_nothing) {
   const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"},
+      sourcemeta::one::Authentication::Table{
+          std::filesystem::path{"/no/such/authentication.bin"}},
       stub_fetcher({}, nullptr)};
   // It admits nobody, so it must not answer that everything is public either,
   // which is what knowing nothing about who governs what would otherwise mean
   EXPECT_FALSE(authentication.permits(at("/anywhere"),
                                       authentication.caller({.bearer = ""})));
-  EXPECT_EQ(authentication.view_count(), std::size_t{0});
-  EXPECT_FALSE(authentication.visible(at("/anywhere"), 0));
-  EXPECT_FALSE(authentication.visible(at("/"), 0));
+  EXPECT_TRUE(authentication.table().views().empty());
+  EXPECT_FALSE(authentication.table().visible(
+      at("/anywhere"), authentication.table().view("public")));
+  EXPECT_FALSE(authentication.table().visible(
+      at("/"), authentication.table().view("public")));
 }
 
 TEST(a_corrupt_artifact_shows_nothing) {
@@ -5641,14 +5561,15 @@ TEST(a_corrupt_artifact_shows_nothing) {
   stream.close();
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_FALSE(authentication.permits(at("/anywhere"),
                                       authentication.caller({.bearer = ""})));
-  EXPECT_EQ(authentication.view_count(), std::size_t{0});
-  EXPECT_FALSE(authentication.visible(at("/anywhere"), 0));
+  EXPECT_TRUE(authentication.table().views().empty());
+  EXPECT_FALSE(authentication.table().visible(
+      at("/anywhere"), authentication.table().view("public")));
 }
 
-TEST(an_index_naming_no_view_shows_nothing) {
+TEST(a_name_no_view_holds_is_served_as_anonymous) {
   setenv("ONE_TEST_KEY_VIEW_INDEX", "index-secret", 1);
   const std::array<std::string_view, 1> paths{{"/machine"}};
   const std::array<std::string_view, 1> keys{{"ONE_TEST_KEY_VIEW_INDEX"}};
@@ -5660,15 +5581,19 @@ TEST(an_index_naming_no_view_shows_nothing) {
   const auto path{test_path("visible_index.bin")};
   save(policies, path, path, anywhere);
 
-  const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
-  EXPECT_EQ(authentication.view_count(), std::size_t{2});
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(gate.views().size(), std::size_t{2});
   // A location nobody governs is shown under either view this declares
-  EXPECT_TRUE(authentication.visible(at("/open/x"), 0));
-  EXPECT_TRUE(authentication.visible(at("/open/x"), 1));
-  // And under no index beyond them, which a stale action would carry
-  EXPECT_FALSE(authentication.visible(at("/open/x"), 2));
-  EXPECT_FALSE(authentication.visible(at("/machine/x"), 2));
+  EXPECT_TRUE(gate.visible(at("/open/x"), gate.view("public")));
+  EXPECT_TRUE(gate.visible(at("/open/x"), gate.view("machine")));
+
+  // A build stamps a view's name on the actions it fans out, so a policy
+  // withdrawn since leaves a name this no longer holds. It is served what a
+  // caller holding nothing is served, rather than what the name used to reach
+  const auto withdrawn{gate.view("retired")};
+  EXPECT_EQ(withdrawn.name, "public");
+  EXPECT_TRUE(gate.visible(at("/open/x"), withdrawn));
+  EXPECT_FALSE(gate.visible(at("/machine/x"), withdrawn));
 }
 
 TEST(a_caller_presenting_nothing_belongs_to_no_policy) {
@@ -5685,7 +5610,7 @@ TEST(a_caller_presenting_nothing_belongs_to_no_policy) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_EQ(authentication.caller({.bearer = ""}).view(),
             sourcemeta::one::VIEW_PUBLIC);
 }
@@ -5703,7 +5628,7 @@ TEST(a_credential_opening_nothing_belongs_to_no_policy) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_EQ(authentication.caller({.bearer = "retired-secret"}).view(),
             sourcemeta::one::VIEW_PUBLIC);
 }
@@ -5731,7 +5656,7 @@ TEST(a_key_places_its_caller_in_the_policy_it_opens) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   EXPECT_EQ(authentication.caller({.bearer = "first-secret"}).view(), "first");
   EXPECT_EQ(authentication.caller({.bearer = "second-secret"}).view(),
             "second");
@@ -5750,7 +5675,7 @@ TEST(a_key_is_placed_without_reference_to_any_path) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // Admitted under the policy where it governs, so the gate has read the key
   const auto governed{
       authentication.permits(at("/deep/inside/somewhere/x"),
@@ -5799,7 +5724,7 @@ TEST(a_key_opening_two_policies_reaches_only_the_first_declared) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   // Two variables holding one value is the form the configuration cannot see,
   // and it is the only shape where being admitted and being shown could ever
   // have parted. A caller is read as the first policy their key opens, and what
@@ -5845,8 +5770,9 @@ TEST(a_token_belongs_to_every_policy_of_its_issuer_that_it_satisfies) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
-                         nullptr)};
+      sourcemeta::one::Authentication::Table{path},
+      stub_fetcher({{"https://idp.test/jwks", std::string{CLAIMS_KEYS}}},
+                   nullptr)};
   EXPECT_EQ(authentication
                 .caller({.bearer = token_with(
                              R"JSON({ "groups": [ "platform" ] })JSON")})
@@ -5897,7 +5823,7 @@ TEST(a_session_places_its_caller_in_the_policy_that_established_it) {
   save(policies, path, path, anywhere);
 
   const sourcemeta::one::Authentication authentication{
-      path, stub_fetcher({}, nullptr)};
+      sourcemeta::one::Authentication::Table{path}, stub_fetcher({}, nullptr)};
   const auto sealed{session_for("okta", SESSION_SECRETS, "jane@acme.test")};
   const std::string cookies{"sourcemeta_one_session=" + sealed};
 
@@ -5934,8 +5860,9 @@ TEST(a_compiled_table_reads_a_policy_without_a_mapping) {
             sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
 
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("compiled_only"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("compiled_only"), anywhere)},
       stub_fetcher({}, nullptr)};
 
   EXPECT_TRUE(authentication.permits(at("/open"), authentication.caller({})));
@@ -5964,8 +5891,9 @@ TEST(an_ungoverned_route_ignores_the_audience_it_requires) {
             sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
 
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("ungoverned_route"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("ungoverned_route"), anywhere)},
       stub_fetcher({}, nullptr)};
 
   const sourcemeta::one::RouteTarget target{"/self/v1/mcp"};
@@ -6008,8 +5936,9 @@ TEST(a_session_never_opens_as_a_transaction) {
             .client_secret_variable = "ONE_TEST_PURPOSE_BACK",
             .session_secrets = SESSION_SECRETS}}}};
   const sourcemeta::one::Authentication authentication{
-      sourcemeta::one::Authentication::compile(
-          policies, test_path("purpose_back"), anywhere),
+      sourcemeta::one::Authentication::Table{
+          sourcemeta::one::Authentication::Table::compile(
+              policies, test_path("purpose_back"), anywhere)},
       provider.fetcher()};
 
   // A session this instance established, obtained the way anybody obtains one

--- a/src/actions/action_schema_search_v1.h
+++ b/src/actions/action_schema_search_v1.h
@@ -43,9 +43,9 @@ public:
     const auto &authentication{dispatcher.authentication()};
     for (const auto &recorded : authentication.table().views()) {
       this->search_views_.emplace(
-          recorded.name,
+          recorded.name(),
           std::make_unique<sourcemeta::one::SearchView>(
-              base / "explorer" / recorded.name / "%" / "search.metapack"));
+              base / "explorer" / recorded.name() / "%" / "search.metapack"));
     }
 
     // The anonymous view is among the recorded ones, so this is a lookup

--- a/src/actions/action_schema_search_v1.h
+++ b/src/actions/action_schema_search_v1.h
@@ -41,8 +41,7 @@ public:
       sourcemeta::one::Router &dispatcher)
       : sourcemeta::one::RouterAction{base, router.base_url(), dispatcher} {
     const auto &authentication{dispatcher.authentication()};
-    for (std::size_t index{0}; index < authentication.view_count(); index++) {
-      const auto recorded{authentication.view_at(index)};
+    for (const auto &recorded : authentication.table().views()) {
       this->search_views_.emplace(
           recorded.name,
           std::make_unique<sourcemeta::one::SearchView>(

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -2,14 +2,13 @@
 
 #include <sourcemeta/core/io.h>
 
-#include <cassert>     // assert
-#include <chrono>      // std::chrono::sys_seconds
 #include <cstddef>     // std::byte, std::size_t
 #include <filesystem>  // std::filesystem::path
 #include <optional>    // std::optional, std::nullopt
 #include <span>        // std::span
 #include <string>      // std::string
 #include <string_view> // std::string_view
+#include <utility>     // std::move
 #include <vector>      // std::vector
 
 namespace sourcemeta::one {
@@ -18,19 +17,20 @@ namespace sourcemeta::one {
 // policy is an enterprise feature, rejected at index time, so this edition
 // never reads the artifact and admits every caller. The artifact is still
 // emitted, empty, to keep the build output identical in shape across editions
-struct Authentication::Impl {};
+struct Authentication::Table::Impl {};
 
 // This edition serves every path publicly, so the registry looks the same to
 // everybody and there is exactly one way to see it. The view is still named
 // rather than implied, which keeps the output one shape across editions
-auto Authentication::views(const std::span<const Authentication::Policy>)
+auto Authentication::Table::enumerate(
+    const std::span<const Authentication::Policy>)
     -> std::vector<Authentication::View> {
   std::vector<Authentication::View> result;
   result.push_back({.name = std::string{VIEW_PUBLIC}, .policies = {}});
   return result;
 }
 
-auto Authentication::compile(
+auto Authentication::Table::compile(
     const std::span<const Authentication::Policy> policies,
     const std::filesystem::path &configuration,
     const Authentication::PathGuard &) -> std::vector<std::byte> {
@@ -43,24 +43,33 @@ auto Authentication::compile(
   return {};
 }
 
-auto Authentication::write(const std::span<const std::byte> bytes,
-                           const std::filesystem::path &destination) -> void {
+auto Authentication::Table::write(const std::span<const std::byte> bytes,
+                                  const std::filesystem::path &destination)
+    -> void {
   sourcemeta::core::write_file(destination, bytes);
 }
 
-// NOLINTBEGIN(performance-unnecessary-value-param)
-Authentication::Authentication(const std::filesystem::path &,
-                               Authentication::Fetcher) {}
+Authentication::Table::Table(const std::filesystem::path &) {}
 
-Authentication::Authentication(const std::span<const std::byte>,
-                               Authentication::Fetcher) {}
-// NOLINTEND(performance-unnecessary-value-param)
+Authentication::Table::Table(const std::span<const std::byte>) {}
+
+Authentication::Table::~Table() = default;
+
+Authentication::Table::Table(Authentication::Table &&) noexcept = default;
+
+auto Authentication::Table::operator=(Authentication::Table &&) noexcept
+    -> Authentication::Table & = default;
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+Authentication::Authentication(Authentication::Table &&table, Fetcher)
+    : table_{std::move(table)} {}
+
+auto Authentication::table() const noexcept -> const Authentication::Table & {
+  return this->table_;
+}
 
 Authentication::~Authentication() = default;
 
-// This edition declares no policies, so there is nobody to be other than
-// anonymous and every caller is placed the same way. The view is still named
-// rather than implied, which keeps the output one shape across editions
 // This edition signs nobody in, so there is no login to start and no session
 // to end, and both answer as the endpoints that reach them already do
 auto Authentication::login(const std::string_view, const std::string_view,
@@ -91,6 +100,8 @@ auto Authentication::logout(const Credentials &, const std::string_view,
   return {.result = Authentication::Outcome::Result::Missing};
 }
 
+// This edition declares no policies, so there is nobody to be other than
+// anonymous and every caller is placed the same way
 auto Authentication::caller(const Credentials &) const
     -> Authentication::Caller {
   Authentication::Caller result;
@@ -113,29 +124,29 @@ auto Authentication::permits(const RouteTarget &,
 
 // One way to see the registry means one view, and nothing governs anything, so
 // every location is part of what that view shows
-auto Authentication::view_count() const -> std::size_t { return 1; }
+auto Authentication::Table::views() const
+    -> std::vector<Authentication::RecordedView> {
+  return {{.name = VIEW_PUBLIC, .policies = 0}};
+}
 
-auto Authentication::view_at([[maybe_unused]] const std::size_t index) const
+auto Authentication::Table::view(const std::string_view) const
     -> Authentication::RecordedView {
-  assert(index == 0);
   return {.name = VIEW_PUBLIC, .policies = 0};
 }
 
-// One view, so every location is part of what it shows, and any other index
-// names no view and is refused rather than shown
-auto Authentication::visible(const Authentication::Path &,
-                             const std::size_t view) const -> bool {
-  return view == 0;
+auto Authentication::Table::visible(const Authentication::Path &,
+                                    const Authentication::RecordedView &) const
+    -> bool {
+  return true;
 }
 
-auto Authentication::governing(const Authentication::Path &) const
-    -> std::vector<std::size_t> {
+auto Authentication::Table::governing(const Authentication::Path &) const
+    -> std::vector<std::string_view> {
   return {};
 }
 
-auto Authentication::reference_permitted(const Authentication::Path &,
-                                         const Authentication::Path &) const
-    -> bool {
+auto Authentication::Table::reference_permitted(
+    const Authentication::Path &, const Authentication::Path &) const -> bool {
   return true;
 }
 

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -24,8 +24,8 @@ struct Authentication::Table::Impl {};
 // rather than implied, which keeps the output one shape across editions
 auto Authentication::Table::enumerate(
     const std::span<const Authentication::Policy>)
-    -> std::vector<Authentication::View> {
-  std::vector<Authentication::View> result;
+    -> std::vector<Authentication::Table::View> {
+  std::vector<Authentication::Table::View> result;
   result.push_back({.name = std::string{VIEW_PUBLIC}, .policies = {}});
   return result;
 }

--- a/src/authentication/authentication.cc
+++ b/src/authentication/authentication.cc
@@ -126,12 +126,14 @@ auto Authentication::permits(const RouteTarget &,
 // every location is part of what that view shows
 auto Authentication::Table::views() const
     -> std::vector<Authentication::RecordedView> {
-  return {{.name = VIEW_PUBLIC, .policies = 0}};
+  return {this->view(VIEW_PUBLIC)};
 }
 
 auto Authentication::Table::view(const std::string_view) const
     -> Authentication::RecordedView {
-  return {.name = VIEW_PUBLIC, .policies = 0};
+  Authentication::RecordedView result;
+  result.name_ = VIEW_PUBLIC;
+  return result;
 }
 
 auto Authentication::Table::visible(const Authentication::Path &,

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -295,54 +295,128 @@ public:
     [[nodiscard]] auto operator==(const View &other) const -> bool = default;
   };
 
-  /// Every view over a registry declaring these policies, which is what
-  /// segments its output. A pure function of what was declared: the anonymous
-  /// view first, then the rest ordered by name.
+  // One view as the artifact records it: the directory its artifacts live
+  // under, and the policies a caller satisfies to be served from it
+  struct RecordedView {
+    std::string_view name;
+    PolicySet policies;
+  };
+
+  /// The compiled policy table: what a build wrote and what every question
+  /// about who governs what is answered from.
   ///
-  /// A credential carries one issuer and is checked against it before any
-  /// rule, so only token policies declared against the same issuer can be
-  /// satisfied together, and only those combine. Every other policy stands
-  /// alone, since a caller presents one key or holds one session.
-  ///
-  /// The count is one, plus one per policy that stands alone, plus two to the
-  /// power of each issuer group's size less one.
-  ///
-  /// Whether that many views is affordable is not decided here, since what they
-  /// cost is known where they are built rather than where they are named. What
-  /// is decided here is only that an enumeration doubling with every policy has
-  /// to stop somewhere, which the ceiling below picks a point for.
-  ///
-  /// Every policy name must be distinct, which is what keeps one view from
-  /// taking another's name.
-  [[nodiscard]] static auto views(std::span<const Policy> policies)
-      -> std::vector<View>;
+  /// A pure function of its bytes. It holds no client, reads no secret and
+  /// reaches no network, which is why whoever only needs these answers takes
+  /// one of these rather than the serving class that owns one.
+  class SOURCEMETA_ONE_AUTHENTICATION_EXPORT Table {
+  public:
+    // Build the artifact the gate reads, refusing any policy scoped to a path
+    // the guard does not recognise. The configuration names where a refusal
+    // came from
+    [[nodiscard]] static auto
+    compile(std::span<const Policy> policies,
+            const std::filesystem::path &configuration,
+            const PathGuard &gateable) -> std::vector<std::byte>;
 
-  // How many policies may name one issuer. The combinations over a group double
-  // with every policy added to it, so where to stop is a choice rather than a
-  // discovery: this sits far above anything a configuration has reason to
-  // declare and far below where enumerating them becomes a burden. Raising it
-  // is a decision about what a build should attempt, bounded only in that it
-  // can never reach the ceiling on policies, where the enumeration stops being
-  // expressible at all. What a number of views costs is decided where they are
-  // built rather than where they are named
-  static constexpr std::size_t MAXIMUM_COMBINABLE_POLICIES{16};
+    // Persist what was compiled, so that a later process can map it back
+    static auto write(std::span<const std::byte> bytes,
+                      const std::filesystem::path &destination) -> void;
 
-  // Build the artifact the gate reads, refusing any policy scoped to a path the
-  // guard does not recognise. The configuration names where a refusal came from
-  [[nodiscard]] static auto compile(std::span<const Policy> policies,
-                                    const std::filesystem::path &configuration,
-                                    const PathGuard &gateable)
-      -> std::vector<std::byte>;
+    // How many policies may name one issuer. The combinations over a group
+    // double with every policy added to it, so where to stop is a choice rather
+    // than a discovery: this sits far above anything a configuration has reason
+    // to declare and far below where enumerating them becomes a burden. Raising
+    // it is a decision about what a build should attempt, bounded only in that
+    // it can never reach the ceiling on policies, where the enumeration stops
+    // being expressible at all. What a number of views costs is decided where
+    // they are built rather than where they are named
+    static constexpr std::size_t MAXIMUM_COMBINABLE_POLICIES{16};
 
-  // Persist what was compiled, so that a later process can map it back
-  static auto write(std::span<const std::byte> bytes,
-                    const std::filesystem::path &destination) -> void;
+    /// Every view over a registry declaring these policies, which is what
+    /// segments its output. A pure function of what was declared: the anonymous
+    /// view first, then the rest ordered by name.
+    ///
+    /// A credential carries one issuer and is checked against it before any
+    /// rule, so only token policies declared against the same issuer can be
+    /// satisfied together, and only those combine. Every other policy stands
+    /// alone, since a caller presents one key or holds one session.
+    ///
+    /// The count is one, plus one per policy that stands alone, plus two to the
+    /// power of each issuer group's size less one.
+    ///
+    /// Whether that many views is affordable is not decided here, since what
+    /// they cost is known where they are built rather than where they are
+    /// named. What is decided here is only that an enumeration doubling with
+    /// every policy has to stop somewhere, which the ceiling below picks a
+    /// point for.
+    ///
+    /// Every policy name must be distinct, which is what keeps one view from
+    /// taking another's name.
+    [[nodiscard]] static auto enumerate(std::span<const Policy> policies)
+        -> std::vector<View>;
 
-  Authentication(const std::filesystem::path &path, Fetcher fetcher);
+    /// Map a table a build wrote. A missing, unreadable or malformed artifact
+    /// yields a table that governs nothing it could answer for, rather than one
+    /// that serves every path publicly.
+    explicit Table(const std::filesystem::path &path);
 
-  // Read a table compiled in this process rather than mapped from a file, so
-  // that what reads a policy set never depends on a filesystem to do it
-  Authentication(std::span<const std::byte> bytes, Fetcher fetcher);
+    /// Adopt a table compiled in this process rather than mapped from a file,
+    /// so that reading a policy set never depends on a filesystem to do it
+    explicit Table(std::span<const std::byte> bytes);
+
+    ~Table();
+
+    // The bytes are owned for the lifetime of the table, either as a mapping or
+    // as a copy, so one is handed on rather than duplicated
+    Table(Table &&) noexcept;
+    auto operator=(Table &&) noexcept -> Table &;
+    Table(const Table &) = delete;
+    auto operator=(const Table &) -> Table & = delete;
+
+    /// Every view this table serves, which is every copy of the view tree a
+    /// build of it produced, ordered as the artifact records them. A table that
+    /// could not be read serves none.
+    [[nodiscard]] auto views() const -> std::vector<RecordedView>;
+
+    /// The view served under a name. A name this table does not serve answers
+    /// the anonymous view, which is what a build stamped before a policy was
+    /// withdrawn leaves behind, and which reaches only what nobody governs.
+    [[nodiscard]] auto view(std::string_view name) const -> RecordedView;
+
+    /// Whether a view shows a path, which is the rule a build filters by and
+    /// the only place it is stated. A path nobody governs is shown to
+    /// everybody, and a governed one is shown to a view satisfying any policy
+    /// governing it, exactly as the gate admits a caller under any policy
+    /// covering the path they asked for.
+    [[nodiscard]] auto visible(const Path &path, const RecordedView &view) const
+        -> bool;
+
+    /// The names of the policies that govern a path, in the order they were
+    /// declared. A name is what a configuration and the artifact built from it
+    /// agree on, so a caller holding the configuration can find what it
+    /// declared without depending on the order it declared it in. The names
+    /// point into the artifact and stay valid for the lifetime of this table.
+    [[nodiscard]] auto governing(const Path &path) const
+        -> std::vector<std::string_view>;
+
+    /// Whether a schema at one path may reference a schema at another, which is
+    /// whether the second is reachable by everybody the first is.
+    [[nodiscard]] auto reference_permitted(const Path &referrer,
+                                           const Path &referent) const -> bool;
+
+  private:
+    friend Authentication;
+    // The implementation differs by edition and owns the memory-mapped
+    // artifact, so it is hidden behind a pointer to keep the binary format out
+    // of the shared interface
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+  };
+
+  /// Serve a table, which is what turns answering who governs what into
+  /// admitting somebody: the fetcher is how a provider is reached, and nothing
+  /// but this class ever holds one.
+  Authentication(Table &&table, Fetcher fetcher);
 
   ~Authentication();
 
@@ -351,6 +425,10 @@ public:
   Authentication(Authentication &&) = delete;
   auto operator=(const Authentication &) -> Authentication & = delete;
   auto operator=(Authentication &&) -> Authentication & = delete;
+
+  /// The table this serves, which answers everything derived from what a build
+  /// wrote rather than from what a request presented.
+  [[nodiscard]] auto table() const noexcept -> const Table &;
 
   /// Who is asking, read from what a request presented. This is the one place a
   /// credential is verified, so every question asked of the result afterwards
@@ -471,67 +549,10 @@ public:
                               const CallbackRequest &incoming,
                               const Credentials &credentials) const -> Outcome;
 
-  // One view as the artifact records it: the directory its artifacts live
-  // under, and the policies a caller satisfies to be served from it
-  struct RecordedView {
-    std::string_view name;
-    PolicySet policies;
-  };
-
-  /// How many views this instance serves, which is how many copies of the view
-  /// tree a build of it produced.
-  [[nodiscard]] auto view_count() const -> std::size_t;
-
-  /// The view an index names, ordered as the artifact records them, so that an
-  /// index here is the one a build stamped on the actions it fanned out. The
-  /// name points into the artifact and stays valid for the lifetime of this
-  /// instance.
-  [[nodiscard]] auto view_at(std::size_t index) const -> RecordedView;
-
-  /// Whether a view shows a path, which is the rule a build filters by and the
-  /// only place it is stated. A path nobody governs is shown to everybody, and
-  /// a governed one is shown to a view satisfying any policy governing it,
-  /// exactly as the gate admits a caller under any policy covering the path
-  /// they asked for.
-  ///
-  /// The view is named by its index rather than by the policies it comprises,
-  /// since that is what a build carries on the action it is filtering for, and
-  /// since a set and an index are both numbers that would otherwise be told
-  /// apart by nothing.
-  [[nodiscard]] auto visible(const Path &path, std::size_t view) const -> bool;
-
-  // The configuration declaration indices of the policies that govern a path,
-  // sorted ascending
-  [[nodiscard]] auto governing(const Path &path) const
-      -> std::vector<std::size_t>;
-
-  // What an interactive policy declares about its provider client. The views
-  // point into the artifact and remain valid for the lifetime of this
-  // instance
-  struct InteractivePolicy {
-    std::string_view issuer{};
-    std::string_view client_id{};
-    // The first registry path the policy governs
-    std::string_view default_path{};
-    // The claims a person must carry to be admitted, serialised as the member
-    // map of an OpenID Connect claims request parameter. Empty where the
-    // policy names no rule
-    std::string_view claims{};
-    // The email domains that admit a person. A login asks its provider for an
-    // address whenever this is non-empty, since a rule it cannot read admits
-    // nobody
-    std::vector<std::string_view> email_domains{};
-  };
-
-  [[nodiscard]] auto reference_permitted(const Path &referrer,
-                                         const Path &referent) const -> bool;
-
 private:
-  // The implementation differs by edition and owns the memory-mapped artifact,
-  // so it is hidden behind a pointer to keep the binary format out of the
-  // shared interface
-  struct Impl;
-  std::unique_ptr<Impl> impl_;
+  // The table this serves, held rather than borrowed so that nothing can
+  // outlive the artifact every answer is read from
+  Table table_;
 };
 
 } // namespace sourcemeta::one

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -33,13 +33,12 @@ namespace sourcemeta::one {
 inline constexpr std::string_view VIEW_PUBLIC{"public"};
 
 class SOURCEMETA_ONE_AUTHENTICATION_EXPORT Authentication {
-public:
-  static constexpr std::size_t MAXIMUM_POLICIES{64};
-
+private:
   // A set of policies, one bit per declaration index, which is why there can
   // only ever be as many policies as this has bits
   using PolicySet = std::uint64_t;
 
+public:
   /// Where a resource lives within an instance, in the single spelling every
   /// part of the system agrees on: no leading or trailing separator, no empty
   /// or relative segments, and lowercase throughout. The instance root is the
@@ -108,13 +107,6 @@ public:
   // Identity stores the key verbatim, every other algorithm stores it hashed
   enum class Algorithm : std::uint8_t { Identity = 0, Sha256 = 1 };
 
-  enum class Type : std::uint8_t { ApiKey = 0, JWT = 1, OIDC = 2 };
-
-  // What a sealed value is for. A value is only ever opened for the purpose it
-  // was sealed under, because the two derive different keys from the policy's
-  // secret, so one kind of value cannot be presented as the other
-  enum class Purpose : std::uint8_t { Session = 0, Transaction = 1 };
-
   // A policy gates a set of path prefixes. A path covered by no policy is
   // public.
   //
@@ -171,19 +163,6 @@ public:
     // that a view can be named after what it comprises
     std::string_view name{};
     std::variant<ApiKey, Token, Interactive> credential{ApiKey{}};
-
-    // Which of the three this is, which the artifact records so that reading a
-    // policy back does not depend on reading its parameters first
-    [[nodiscard]] auto type() const noexcept -> Type {
-      switch (this->credential.index()) {
-        case 1:
-          return Type::JWT;
-        case 2:
-          return Type::OIDC;
-        default:
-          return Type::ApiKey;
-      }
-    }
   };
 
   // What this asks a provider for. Every outbound call goes through one of
@@ -286,16 +265,6 @@ public:
   // knows what this instance serves
   using PathGuard = std::function<bool(std::string_view)>;
 
-  // One way the registry looks to somebody: the name its artifacts live under
-  // and the policies a caller of it satisfies. The anonymous view comprises
-  // none, which is what makes it the base every other view adds to
-  struct View {
-    std::string name;
-    std::vector<std::size_t> policies;
-
-    [[nodiscard]] auto operator==(const View &other) const -> bool = default;
-  };
-
   class Table;
 
   // One view as the artifact records it: the directory its artifacts live
@@ -310,10 +279,6 @@ public:
   public:
     [[nodiscard]] auto name() const noexcept -> std::string_view {
       return this->name_;
-    }
-
-    [[nodiscard]] auto policies() const noexcept -> PolicySet {
-      return this->policies_;
     }
 
   private:
@@ -342,39 +307,6 @@ public:
     // Persist what was compiled, so that a later process can map it back
     static auto write(const std::span<const std::byte> bytes,
                       const std::filesystem::path &destination) -> void;
-
-    // How many policies may name one issuer. The combinations over a group
-    // double with every policy added to it, so where to stop is a choice rather
-    // than a discovery: this sits far above anything a configuration has reason
-    // to declare and far below where enumerating them becomes a burden. Raising
-    // it is a decision about what a build should attempt, bounded only in that
-    // it can never reach the ceiling on policies, where the enumeration stops
-    // being expressible at all. What a number of views costs is decided where
-    // they are built rather than where they are named
-    static constexpr std::size_t MAXIMUM_COMBINABLE_POLICIES{16};
-
-    /// Every view over a registry declaring these policies, which is what
-    /// segments its output. A pure function of what was declared: the anonymous
-    /// view first, then the rest ordered by name.
-    ///
-    /// A credential carries one issuer and is checked against it before any
-    /// rule, so only token policies declared against the same issuer can be
-    /// satisfied together, and only those combine. Every other policy stands
-    /// alone, since a caller presents one key or holds one session.
-    ///
-    /// The count is one, plus one per policy that stands alone, plus two to the
-    /// power of each issuer group's size less one.
-    ///
-    /// Whether that many views is affordable is not decided here, since what
-    /// they cost is known where they are built rather than where they are
-    /// named. What is decided here is only that an enumeration doubling with
-    /// every policy has to stop somewhere, which the ceiling below picks a
-    /// point for.
-    ///
-    /// Every policy name must be distinct, which is what keeps one view from
-    /// taking another's name.
-    [[nodiscard]] static auto enumerate(const std::span<const Policy> policies)
-        -> std::vector<View>;
 
     /// Map a table a build wrote. A missing, unreadable or malformed artifact
     /// yields a table that governs nothing it could answer for, rather than one
@@ -427,6 +359,50 @@ public:
 
   private:
     friend Authentication;
+
+    // One way the registry looks to somebody: the name its artifacts live under
+    // and the policies a caller of it satisfies. The anonymous view comprises
+    // none, which is what makes it the base every other view adds to
+    struct View {
+      std::string name;
+      std::vector<std::size_t> policies;
+
+      [[nodiscard]] auto operator==(const View &other) const -> bool = default;
+    };
+
+    // How many policies may name one issuer. The combinations over a group
+    // double with every policy added to it, so where to stop is a choice rather
+    // than a discovery: this sits far above anything a configuration has reason
+    // to declare and far below where enumerating them becomes a burden. Raising
+    // it is a decision about what a build should attempt, bounded only in that
+    // it can never reach the ceiling on policies, where the enumeration stops
+    // being expressible at all. What a number of views costs is decided where
+    // they are built rather than where they are named
+    static constexpr std::size_t MAXIMUM_COMBINABLE_POLICIES{16};
+
+    /// Every view over a registry declaring these policies, which is what
+    /// segments its output. A pure function of what was declared: the anonymous
+    /// view first, then the rest ordered by name.
+    ///
+    /// A credential carries one issuer and is checked against it before any
+    /// rule, so only token policies declared against the same issuer can be
+    /// satisfied together, and only those combine. Every other policy stands
+    /// alone, since a caller presents one key or holds one session.
+    ///
+    /// The count is one, plus one per policy that stands alone, plus two to the
+    /// power of each issuer group's size less one.
+    ///
+    /// Whether that many views is affordable is not decided here, since what
+    /// they cost is known where they are built rather than where they are
+    /// named. What is decided here is only that an enumeration doubling with
+    /// every policy has to stop somewhere, which the ceiling below picks a
+    /// point for.
+    ///
+    /// Every policy name must be distinct, which is what keeps one view from
+    /// taking another's name.
+    [[nodiscard]] static auto enumerate(const std::span<const Policy> policies)
+        -> std::vector<View>;
+
     // The implementation differs by edition and owns the memory-mapped
     // artifact, so it is hidden behind a pointer to keep the binary format out
     // of the shared interface

--- a/src/authentication/include/sourcemeta/one/authentication.h
+++ b/src/authentication/include/sourcemeta/one/authentication.h
@@ -32,32 +32,6 @@ namespace sourcemeta::one {
 // server reads cannot disagree
 inline constexpr std::string_view VIEW_PUBLIC{"public"};
 
-// A route as the router matched it, taken by the spelling it arrived in rather
-// than by where it resolves to. A target reaching past a governed prefix is
-// still governed by it, which is why it is not canonicalised, and why it is not
-// a registry path
-class RouteTarget {
-public:
-  explicit RouteTarget(const std::string_view value) noexcept : value_{value} {}
-
-  [[nodiscard]] auto value() const noexcept -> std::string_view {
-    return this->value_;
-  }
-
-private:
-  std::string_view value_;
-};
-
-// Everything a request presented for authentication: the bearer value from
-// the authorization header and every cookie field it carried, either of which
-// may admit the caller under a covering policy. The cookie fields are kept as
-// they arrived rather than joined, since a request may carry more than one and
-// what a cookie means is decided by whoever reads it
-struct Credentials {
-  std::string_view bearer{};
-  std::span<const std::string_view> cookies{};
-};
-
 class SOURCEMETA_ONE_AUTHENTICATION_EXPORT Authentication {
 public:
   static constexpr std::size_t MAXIMUM_POLICIES{64};
@@ -111,6 +85,23 @@ public:
     Path() = default;
     explicit Path(std::string value) : value_{std::move(value)} {}
     std::string value_;
+  };
+
+  // A route as the router matched it, taken by the spelling it arrived in
+  // rather than by where it resolves to. A target reaching past a governed
+  // prefix is still governed by it, which is why it is not canonicalised, and
+  // why it is not a registry path
+  class RouteTarget {
+  public:
+    explicit RouteTarget(const std::string_view value) noexcept
+        : value_{value} {}
+
+    [[nodiscard]] auto value() const noexcept -> std::string_view {
+      return this->value_;
+    }
+
+  private:
+    std::string_view value_;
   };
 
   // How a presented credential is compared against a policy's stored keys.
@@ -221,6 +212,16 @@ public:
   using Fetcher =
       std::function<std::optional<ProviderResponse>(ProviderRequest &&)>;
 
+  // Everything a request presented for authentication: the bearer value from
+  // the authorization header and every cookie field it carried, either of which
+  // may admit the caller under a covering policy. The cookie fields are kept as
+  // they arrived rather than joined, since a request may carry more than one
+  // and what a cookie means is decided by whoever reads it
+  struct Credentials {
+    std::string_view bearer{};
+    std::span<const std::string_view> cookies{};
+  };
+
   // Who is asking, read from what a request presented exactly once. Everything
   // decided afterwards is a comparison against what this holds rather than a
   // second reading of a credential
@@ -295,11 +296,31 @@ public:
     [[nodiscard]] auto operator==(const View &other) const -> bool = default;
   };
 
+  class Table;
+
   // One view as the artifact records it: the directory its artifacts live
-  // under, and the policies a caller satisfies to be served from it
-  struct RecordedView {
-    std::string_view name;
-    PolicySet policies;
+  // under, and the policies a caller satisfies to be served from it.
+  //
+  // The set is not something a caller can state, only something a table
+  // answers with, because what it shows is decided by which policies a build
+  // recorded together rather than by whoever asks. A set assembled elsewhere
+  // would name a view no build ever wrote and be taken for one that admits
+  // whatever it happens to hold
+  class RecordedView {
+  public:
+    [[nodiscard]] auto name() const noexcept -> std::string_view {
+      return this->name_;
+    }
+
+    [[nodiscard]] auto policies() const noexcept -> PolicySet {
+      return this->policies_;
+    }
+
+  private:
+    friend Table;
+    friend Authentication;
+    std::string_view name_{};
+    PolicySet policies_{0};
   };
 
   /// The compiled policy table: what a build wrote and what every question
@@ -314,12 +335,12 @@ public:
     // the guard does not recognise. The configuration names where a refusal
     // came from
     [[nodiscard]] static auto
-    compile(std::span<const Policy> policies,
+    compile(const std::span<const Policy> policies,
             const std::filesystem::path &configuration,
             const PathGuard &gateable) -> std::vector<std::byte>;
 
     // Persist what was compiled, so that a later process can map it back
-    static auto write(std::span<const std::byte> bytes,
+    static auto write(const std::span<const std::byte> bytes,
                       const std::filesystem::path &destination) -> void;
 
     // How many policies may name one issuer. The combinations over a group
@@ -352,7 +373,7 @@ public:
     ///
     /// Every policy name must be distinct, which is what keeps one view from
     /// taking another's name.
-    [[nodiscard]] static auto enumerate(std::span<const Policy> policies)
+    [[nodiscard]] static auto enumerate(const std::span<const Policy> policies)
         -> std::vector<View>;
 
     /// Map a table a build wrote. A missing, unreadable or malformed artifact
@@ -362,7 +383,7 @@ public:
 
     /// Adopt a table compiled in this process rather than mapped from a file,
     /// so that reading a policy set never depends on a filesystem to do it
-    explicit Table(std::span<const std::byte> bytes);
+    explicit Table(const std::span<const std::byte> bytes);
 
     ~Table();
 
@@ -381,7 +402,7 @@ public:
     /// The view served under a name. A name this table does not serve answers
     /// the anonymous view, which is what a build stamped before a policy was
     /// withdrawn leaves behind, and which reaches only what nobody governs.
-    [[nodiscard]] auto view(std::string_view name) const -> RecordedView;
+    [[nodiscard]] auto view(const std::string_view name) const -> RecordedView;
 
     /// Whether a view shows a path, which is the rule a build filters by and
     /// the only place it is stated. A path nobody governs is shown to
@@ -462,9 +483,9 @@ public:
   /// caller was configured with. An empty requirement asks for nothing extra,
   /// and a caller that presented no token is unaffected, since only a token
   /// carries an audience to check.
-  [[nodiscard]] auto permits(const RouteTarget &target, const Caller &caller,
-                             std::string_view required_audience = {}) const
-      -> bool;
+  [[nodiscard]] auto
+  permits(const RouteTarget &target, const Caller &caller,
+          const std::string_view required_audience = {}) const -> bool;
 
   /// End the browser's session, and the provider's where it named a policy
   /// whose provider offers to end one.
@@ -478,8 +499,8 @@ public:
   /// route is a fact about the surface that received the request rather than
   /// about authentication. Nothing here composes a URL of its own.
   [[nodiscard]] auto logout(const Credentials &credentials,
-                            std::string_view instance_url,
-                            std::string_view return_to) const -> Outcome;
+                            const std::string_view instance_url,
+                            const std::string_view return_to) const -> Outcome;
 
   /// Start a login, sealing the transaction the callback will complete and
   /// naming where the provider should send the browser.
@@ -498,10 +519,11 @@ public:
   /// it names a route, and which routes exist is not something this knows. It
   /// is what the provider is told to come back to, and what the callback will
   /// be checked against.
-  [[nodiscard]] auto login(std::string_view policy,
-                           std::string_view instance_url,
-                           std::string_view redirect_uri, bool silent,
-                           std::string_view return_to) const -> Outcome;
+  [[nodiscard]] auto login(const std::string_view policy,
+                           const std::string_view instance_url,
+                           const std::string_view redirect_uri,
+                           const bool silent,
+                           const std::string_view return_to) const -> Outcome;
 
   /// Which interactive policy should be asked whether a lapsed sign-in still
   /// stands, for a caller that reached this path and nothing else.
@@ -543,9 +565,9 @@ public:
   /// The redirect URI must be the one the login was started with, since the
   /// provider checks it and so does this. It is passed in for the same reason
   /// it is passed to `login`: it names a route.
-  [[nodiscard]] auto callback(std::string_view policy,
-                              std::string_view instance_url,
-                              std::string_view redirect_uri,
+  [[nodiscard]] auto callback(const std::string_view policy,
+                              const std::string_view instance_url,
+                              const std::string_view redirect_uri,
                               const CallbackRequest &incoming,
                               const Credentials &credentials) const -> Outcome;
 

--- a/src/authentication/include/sourcemeta/one/authentication_error.h
+++ b/src/authentication/include/sourcemeta/one/authentication_error.h
@@ -85,6 +85,84 @@ private:
   std::size_t count_;
 };
 
+// Raised when an authentication policy carries no name, shares one with
+// another, or takes the name every caller holding nothing is served under. A
+// view is named after the policies it comprises, so any of the three leaves a
+// view naming somewhere else or nowhere
+class SOURCEMETA_ONE_AUTHENTICATION_EXPORT AuthenticationPolicyNameError
+    : public std::exception {
+public:
+  AuthenticationPolicyNameError(std::filesystem::path path, std::string name)
+      : path_{std::move(path)}, name_{std::move(name)} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return "An authentication policy requires a name of its own";
+  }
+
+  [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
+    return this->path_;
+  }
+
+  [[nodiscard]] auto name() const noexcept -> const std::string & {
+    return this->name_;
+  }
+
+private:
+  std::filesystem::path path_;
+  std::string name_;
+};
+
+// Raised when more policies are declared than one policy set has bits to name,
+// since each occupies one of them
+class SOURCEMETA_ONE_AUTHENTICATION_EXPORT AuthenticationTooManyPoliciesError
+    : public std::exception {
+public:
+  AuthenticationTooManyPoliciesError(std::filesystem::path path,
+                                     const std::size_t count)
+      : path_{std::move(path)}, count_{count} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return "Too many authentication policies";
+  }
+
+  [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
+    return this->path_;
+  }
+
+  [[nodiscard]] auto count() const noexcept -> std::size_t {
+    return this->count_;
+  }
+
+private:
+  std::filesystem::path path_;
+  std::size_t count_;
+};
+
+// Raised when a policy that signs people in names no secret to seal their
+// session with, which could neither mint one nor read one back
+class SOURCEMETA_ONE_AUTHENTICATION_EXPORT AuthenticationMissingSecretError
+    : public std::exception {
+public:
+  AuthenticationMissingSecretError(std::filesystem::path path, std::string name)
+      : path_{std::move(path)}, name_{std::move(name)} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return "An interactive authentication policy requires a session secret";
+  }
+
+  [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
+    return this->path_;
+  }
+
+  [[nodiscard]] auto name() const noexcept -> const std::string & {
+    return this->name_;
+  }
+
+private:
+  std::filesystem::path path_;
+  std::string name_;
+};
+
 // Raised when a policy is named exactly as the view over some combination of
 // others is spelled, which would serve two sets of policies from one directory
 class SOURCEMETA_ONE_AUTHENTICATION_EXPORT AuthenticationViewNameCollisionError

--- a/src/authentication/include/sourcemeta/one/authentication_error.h
+++ b/src/authentication/include/sourcemeta/one/authentication_error.h
@@ -85,33 +85,6 @@ private:
   std::size_t count_;
 };
 
-// Raised when an authentication policy carries no name, shares one with
-// another, or takes the name every caller holding nothing is served under. A
-// view is named after the policies it comprises, so any of the three leaves a
-// view naming somewhere else or nowhere
-class SOURCEMETA_ONE_AUTHENTICATION_EXPORT AuthenticationPolicyNameError
-    : public std::exception {
-public:
-  AuthenticationPolicyNameError(std::filesystem::path path, std::string name)
-      : path_{std::move(path)}, name_{std::move(name)} {}
-
-  [[nodiscard]] auto what() const noexcept -> const char * override {
-    return "An authentication policy requires a name of its own";
-  }
-
-  [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
-    return this->path_;
-  }
-
-  [[nodiscard]] auto name() const noexcept -> const std::string & {
-    return this->name_;
-  }
-
-private:
-  std::filesystem::path path_;
-  std::string name_;
-};
-
 // Raised when a policy is named exactly as the view over some combination of
 // others is spelled, which would serve two sets of policies from one directory
 class SOURCEMETA_ONE_AUTHENTICATION_EXPORT AuthenticationViewNameCollisionError

--- a/src/index/explorer.h
+++ b/src/index/explorer.h
@@ -116,9 +116,9 @@ static auto child_registry_path(const std::string &directory_registry_path,
          "/" + name;
 }
 
-static auto make_private(const sourcemeta::one::Authentication &authentication,
-                         const std::string &registry_path)
-    -> sourcemeta::core::JSON {
+static auto
+make_private(const sourcemeta::one::Authentication::Table &authentication,
+             const std::string &registry_path) -> sourcemeta::core::JSON {
   // Whether a policy governs the path, declared on it or inherited from above.
   // Every surface that says so reads this, so none of them can disagree about
   // what private means. The indexer composes the path from the content tree,
@@ -492,8 +492,8 @@ struct GENERATE_EXPLORER_SCHEMA_METADATA {
     result.assign("breadcrumb",
                   make_breadcrumb(resolver_entry.relative_path, false));
 
-    const sourcemeta::one::Authentication authentication{
-        action.dependencies.back(), {}};
+    const sourcemeta::one::Authentication::Table authentication{
+        action.dependencies.back()};
     result.assign("private",
                   make_private(authentication, result.at("path").to_string()));
 
@@ -818,25 +818,12 @@ struct GENERATE_MCP {
     {
       const sourcemeta::core::URITemplateRouterView router_view{
           action.dependencies.at(2)};
-      const sourcemeta::one::Authentication authentication{
-          action.dependencies.back(), {}};
+      const sourcemeta::one::Authentication::Table authentication{
+          action.dependencies.back()};
 
       // The artifact is written once per view and names the view it is for, so
-      // what it offers is settled here rather than worked out again per
-      // request. A name the table does not hold cannot happen, since both come
-      // from the same enumeration, and the anonymous view standing first is
-      // what a build would fall back to: it holds no policy, so it reaches
-      // only what nobody governs
-      std::size_t view{0};
-      assert(authentication.view_count() > 0);
-      assert(authentication.view_at(0).name == sourcemeta::one::VIEW_PUBLIC);
-      for (std::size_t candidate{0}; candidate < authentication.view_count();
-           candidate++) {
-        if (authentication.view_at(candidate).name == action.view) {
-          view = candidate;
-          break;
-        }
-      }
+      // what it offers is settled here rather than worked out again per request
+      const auto view{authentication.view(action.view)};
 
       sourcemeta::one::generate_mcp_tools(
           router_view,
@@ -999,8 +986,8 @@ struct GENERATE_EXPLORER_DIRECTORY_LIST {
       current = current.parent_path();
     }
 
-    const sourcemeta::one::Authentication authentication{
-        action.dependencies.back(), {}};
+    const sourcemeta::one::Authentication::Table authentication{
+        action.dependencies.back()};
     const std::string directory_registry_path{
         relative_path == "." ? std::string{"/"}
                              : "/" + relative_path.generic_string()};

--- a/src/index/generators.h
+++ b/src/index/generators.h
@@ -311,8 +311,8 @@ struct GENERATE_DEPENDENCIES {
     assert(result.unique());
 
     if (result.size() > 0) {
-      const sourcemeta::one::Authentication authentication{
-          action.dependencies.at(1), {}};
+      const sourcemeta::one::Authentication::Table authentication{
+          action.dependencies.at(1)};
       for (const auto &edge : result.as_array()) {
         const auto &referrer_uri{edge.at("from").to_string()};
         const auto &referent_uri{edge.at("to").to_string()};
@@ -1117,8 +1117,8 @@ struct GENERATE_AUTHENTICATION {
     // begins rather than at some expansion of it: a scope reaching into a
     // template would be honoured where the route is matched literally and
     // nowhere else, which is a gate that holds on one surface and not the next
-    sourcemeta::one::Authentication::write(
-        sourcemeta::one::Authentication::compile(
+    sourcemeta::one::Authentication::Table::write(
+        sourcemeta::one::Authentication::Table::compile(
             policies, configuration.path,
             [&routes, &configuration](const std::string_view path) {
               for (std::size_t index{0}; index < routes.size(); index++) {

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -105,17 +105,22 @@ static constexpr std::array<BuildHandlerFunction, sourcemeta::one::ACTION_COUNT>
 // before anything is planned, because what a build emits depends on it, and the
 // build writes it again with the path validation this skips: an invalid scope
 // still refuses the build, one step later than it would have
-static auto view_filter_from(const sourcemeta::one::Authentication &gate)
+static auto view_filter_from(
+    const sourcemeta::one::Authentication::Table &gate,
+    const std::span<const sourcemeta::one::Authentication::RecordedView> table)
     -> sourcemeta::one::ViewFilter {
-  return
-      [&gate](const std::size_t view, const std::string_view relative) -> bool {
-        std::string path;
-        path.reserve(relative.size() + 1);
-        path.push_back('/');
-        path.append(relative);
-        return gate.visible(
-            sourcemeta::one::Authentication::Path::relative(path), view);
-      };
+  return [&gate, table](const std::size_t view,
+                        const std::string_view relative) -> bool {
+    // A build names its views by position in the table it was handed, which is
+    // a fact about this build rather than about who governs what
+    assert(view < table.size());
+    std::string path;
+    path.reserve(relative.size() + 1);
+    path.push_back('/');
+    path.append(relative);
+    return gate.visible(sourcemeta::one::Authentication::Path::relative(path),
+                        table[view]);
+  };
 }
 
 static auto parse_numeric_option(const sourcemeta::core::Options &app,
@@ -634,10 +639,9 @@ static auto index_main(const std::string_view &program,
   }
   const sourcemeta::one::LeafSet leaves{leaves_storage};
 
-  // The views this build writes for, enumerated from what the configuration
-  // declares. The artifact records the same table for the server to read, so
-  // this is the naming rule applied a second time at index time rather than a
-  // second rule, and the two are the same function of the same policies
+  // The views this build writes for, read below from the table it compiles, so
+  // that the naming rule is applied once and a build and the server it feeds
+  // cannot come to different answers about what the views are
   std::vector<std::vector<std::string_view>> view_policy_paths;
   std::vector<std::vector<std::string_view>> view_policy_keys;
   std::vector<std::vector<std::string_view>> view_policy_session_secrets;
@@ -648,22 +652,23 @@ static auto index_main(const std::string_view &program,
           configuration, view_policy_paths, view_policy_keys,
           view_policy_session_secrets, view_policy_claims,
           view_policy_email_domains)};
-  const auto view_table{sourcemeta::one::Authentication::views(view_policies)};
+  const auto authentication_path{canonical_output / "authentication.bin"};
+  // The table this build just compiled is what the plan is filtered against, so
+  // it is read from memory rather than through the file it is also written to
+  const auto compiled{sourcemeta::one::Authentication::Table::compile(
+      view_policies, configuration.path,
+      [](const std::string_view) { return true; })};
+  sourcemeta::one::Authentication::Table::write(compiled, authentication_path);
+  const sourcemeta::one::Authentication::Table gate{compiled};
+
+  const auto view_table{gate.views()};
   std::vector<std::string_view> views;
   views.reserve(view_table.size());
   for (const auto &view : view_table) {
     views.push_back(view.name);
   }
 
-  const auto authentication_path{canonical_output / "authentication.bin"};
-  // The table this build just compiled is what the plan is filtered against, so
-  // it is read from memory rather than through the file it is also written to
-  const auto compiled{sourcemeta::one::Authentication::compile(
-      view_policies, configuration.path,
-      [](const std::string_view) { return true; })};
-  sourcemeta::one::Authentication::write(compiled, authentication_path);
-  const sourcemeta::one::Authentication gate{compiled, {}};
-  const auto visible{view_filter_from(gate)};
+  const auto visible{view_filter_from(gate, view_table)};
 
   auto produce_plan{sourcemeta::one::delta<sourcemeta::one::INDEX_RULES>(
       sourcemeta::one::BuildPhase::Produce, build_type, entries,
@@ -860,10 +865,6 @@ auto main(int argc, char *argv[]) noexcept -> int {
   } catch (const sourcemeta::one::AuthenticationTooManyViewsError &error) {
     std::print(stdout, "error: {}\n  at issuer {}\n  at count {}\n",
                error.what(), error.issuer(), error.count());
-    return EXIT_FAILURE;
-  } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
-    std::print(stdout, "error: {}\n  at name {}\n  at path {}\n", error.what(),
-               error.name(), error.path().string());
     return EXIT_FAILURE;
   } catch (const sourcemeta::one::AuthenticationViewNameCollisionError &error) {
     std::print(stdout, "error: {}\n  at name {}\n  at path {}\n", error.what(),

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -665,7 +665,7 @@ static auto index_main(const std::string_view &program,
   std::vector<std::string_view> views;
   views.reserve(view_table.size());
   for (const auto &view : view_table) {
-    views.push_back(view.name);
+    views.push_back(view.name());
   }
 
   const auto visible{view_filter_from(gate, view_table)};
@@ -865,6 +865,18 @@ auto main(int argc, char *argv[]) noexcept -> int {
   } catch (const sourcemeta::one::AuthenticationTooManyViewsError &error) {
     std::print(stdout, "error: {}\n  at issuer {}\n  at count {}\n",
                error.what(), error.issuer(), error.count());
+    return EXIT_FAILURE;
+  } catch (const sourcemeta::one::AuthenticationPolicyNameError &error) {
+    std::print(stdout, "error: {}\n  at name {}\n  at path {}\n", error.what(),
+               error.name(), error.path().string());
+    return EXIT_FAILURE;
+  } catch (const sourcemeta::one::AuthenticationTooManyPoliciesError &error) {
+    std::print(stdout, "error: {}\n  at count {}\n  at path {}\n", error.what(),
+               error.count(), error.path().string());
+    return EXIT_FAILURE;
+  } catch (const sourcemeta::one::AuthenticationMissingSecretError &error) {
+    std::print(stdout, "error: {}\n  at name {}\n  at path {}\n", error.what(),
+               error.name(), error.path().string());
     return EXIT_FAILURE;
   } catch (const sourcemeta::one::AuthenticationViewNameCollisionError &error) {
     std::print(stdout, "error: {}\n  at name {}\n  at path {}\n", error.what(),

--- a/src/router/artifact.cc
+++ b/src/router/artifact.cc
@@ -65,8 +65,8 @@ auto RouterAction::artifact_locate(const Authentication::Path &path,
   return canonical;
 }
 
-auto RouterAction::caller_from(const Credentials &credentials) const
-    -> Authentication::Caller {
+auto RouterAction::caller_from(const Authentication::Credentials &credentials)
+    const -> Authentication::Caller {
   return this->dispatcher_.authentication().caller(credentials);
 }
 

--- a/src/router/include/sourcemeta/one/router.h
+++ b/src/router/include/sourcemeta/one/router.h
@@ -247,7 +247,8 @@ public:
   // Place a caller from credentials this action is holding rather than from the
   // request it arrived on. A deferred body outlives its request, so what it
   // presented has to be owned and read again once the body is there
-  [[nodiscard]] auto caller_from(const Credentials &credentials) const
+  [[nodiscard]] auto
+  caller_from(const Authentication::Credentials &credentials) const
       -> Authentication::Caller;
 
   // The caching directive for served registry content. A response admitted

--- a/src/router/router.cc
+++ b/src/router/router.cc
@@ -67,7 +67,9 @@ Router::Router(const std::filesystem::path &base,
       // NOLINTNEXTLINE(modernize-avoid-c-arrays)
       slots_{std::make_unique<Slot[]>(router.size() + 1)},
       slots_size_{router.size() + 1},
-      authentication_{base / "authentication.bin", provider_fetcher()} {
+      authentication_{
+          sourcemeta::one::Authentication::Table{base / "authentication.bin"},
+          provider_fetcher()} {
   router.arguments(0, [this](const auto &key, const auto &value) -> void {
     if (key == "errorSchema") {
       this->default_error_schema_ = std::get<std::string_view>(value);

--- a/src/router/router.cc
+++ b/src/router/router.cc
@@ -151,8 +151,9 @@ auto Router::dispatch(
       this->authentication_.caller({.bearer = credential, .cookies = cookies})};
   if (identifier != 0 && request.method() != "options" &&
       !instance->is_authentication_exempt() &&
-      !this->authentication_.permits(RouteTarget{request.path()}, caller,
-                                     instance->required_audience())) {
+      !this->authentication_.permits(
+          Authentication::RouteTarget{request.path()}, caller,
+          instance->required_audience())) {
     if (instance->serve_renewal_page(request, response)) {
       return;
     }

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -29,9 +29,9 @@ save(const std::span<const sourcemeta::one::Authentication::Policy> policies,
      const std::filesystem::path &configuration,
      const std::filesystem::path &destination,
      const sourcemeta::one::Authentication::PathGuard &gateable) -> void {
-  sourcemeta::one::Authentication::write(
-      sourcemeta::one::Authentication::compile(policies, configuration,
-                                               gateable),
+  sourcemeta::one::Authentication::Table::write(
+      sourcemeta::one::Authentication::Table::compile(policies, configuration,
+                                                      gateable),
       destination);
 }
 
@@ -41,7 +41,9 @@ static auto test_path(const std::string &name) -> std::filesystem::path {
 
 TEST(admits_every_path_without_a_credential) {
   const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"}, {}};
+      sourcemeta::one::Authentication::Table{
+          std::filesystem::path{"/no/such/authentication.bin"}},
+      {}};
   EXPECT_TRUE(
       authentication.permits(at("/"), authentication.caller({.bearer = ""})));
   EXPECT_TRUE(
@@ -52,7 +54,9 @@ TEST(admits_every_path_without_a_credential) {
 
 TEST(admits_every_path_with_any_credential) {
   const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"}, {}};
+      sourcemeta::one::Authentication::Table{
+          std::filesystem::path{"/no/such/authentication.bin"}},
+      {}};
   EXPECT_TRUE(authentication.permits(
       at("/internal"), authentication.caller({.bearer = "anything"})));
   EXPECT_TRUE(authentication.permits(
@@ -66,7 +70,8 @@ TEST(save_emits_an_empty_artifact_that_admits_everything) {
   EXPECT_TRUE(std::filesystem::exists(path));
   EXPECT_EQ(std::filesystem::file_size(path), 0);
 
-  const sourcemeta::one::Authentication authentication{path, {}};
+  const sourcemeta::one::Authentication authentication{
+      sourcemeta::one::Authentication::Table{path}, {}};
   EXPECT_TRUE(
       authentication.permits(at("/"), authentication.caller({.bearer = ""})));
   EXPECT_TRUE(authentication.permits(at("/internal/foo"),
@@ -97,45 +102,51 @@ TEST(save_rejects_any_policy) {
 }
 
 TEST(permits_every_reference) {
-  const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_TRUE(authentication.reference_permitted(at("/one"), at("/two")));
-  EXPECT_TRUE(authentication.reference_permitted(at("/public/one"),
-                                                 at("/private/two")));
-  EXPECT_TRUE(
-      authentication.reference_permitted(at("/internal/a"), at("/internal/a")));
+  const sourcemeta::one::Authentication::Table gate{
+      std::filesystem::path{"/no/such/authentication.bin"}};
+  EXPECT_TRUE(gate.reference_permitted(at("/one"), at("/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/public/one"), at("/private/two")));
+  EXPECT_TRUE(gate.reference_permitted(at("/internal/a"), at("/internal/a")));
 }
 
 TEST(records_the_anonymous_view_alone) {
-  const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_EQ(authentication.view_count(), std::size_t{1});
-  EXPECT_EQ(authentication.view_at(0).name, "public");
-  EXPECT_EQ(authentication.view_at(0).policies,
+  const sourcemeta::one::Authentication::Table gate{
+      std::filesystem::path{"/no/such/authentication.bin"}};
+  const auto table{gate.views()};
+  EXPECT_EQ(table.size(), std::size_t{1});
+  EXPECT_EQ(table.at(0).name, "public");
+  EXPECT_EQ(table.at(0).policies,
             sourcemeta::one::Authentication::PolicySet{0});
 }
 
 TEST(shows_every_path_in_its_only_view) {
-  const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_TRUE(authentication.visible(at("/"), 0));
-  EXPECT_TRUE(authentication.visible(at(""), 0));
-  EXPECT_TRUE(authentication.visible(at("/internal/foo"), 0));
+  const sourcemeta::one::Authentication::Table gate{
+      std::filesystem::path{"/no/such/authentication.bin"}};
+  const auto anonymous{gate.view("public")};
+  EXPECT_TRUE(gate.visible(at("/"), anonymous));
+  EXPECT_TRUE(gate.visible(at(""), anonymous));
+  EXPECT_TRUE(gate.visible(at("/internal/foo"), anonymous));
 }
 
-TEST(shows_nothing_under_an_index_naming_no_view) {
-  const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"}, {}};
-  EXPECT_EQ(authentication.view_count(), std::size_t{1});
-  EXPECT_FALSE(authentication.visible(at("/"), 1));
-  EXPECT_FALSE(authentication.visible(at("/internal/foo"), 1));
+TEST(serves_a_name_no_view_holds_as_the_anonymous_one) {
+  const sourcemeta::one::Authentication::Table gate{
+      std::filesystem::path{"/no/such/authentication.bin"}};
+  const auto withdrawn{gate.view("retired")};
+  EXPECT_EQ(withdrawn.name, "public");
+  EXPECT_EQ(withdrawn.policies, sourcemeta::one::Authentication::PolicySet{0});
+  // Nothing is governed here, so the one view shows every location whichever
+  // name it was asked for
+  EXPECT_TRUE(gate.visible(at("/"), withdrawn));
+  EXPECT_TRUE(gate.visible(at("/internal/foo"), withdrawn));
 }
 
 TEST(serves_every_caller_the_anonymous_view) {
   const std::array<std::string_view, 1> cookies{
       {"sourcemeta_one_session=whatever"}};
   const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"}, {}};
+      sourcemeta::one::Authentication::Table{
+          std::filesystem::path{"/no/such/authentication.bin"}},
+      {}};
   EXPECT_EQ(authentication.caller({.bearer = ""}).view(), "public");
   EXPECT_EQ(authentication.caller({.bearer = "anything"}).view(), "public");
   EXPECT_EQ(authentication.caller({.bearer = "", .cookies = cookies}).view(),
@@ -146,7 +157,9 @@ TEST(serves_every_caller_the_anonymous_view) {
 // everywhere, which is the same answer they get for presenting nothing
 TEST(admits_a_caller_presenting_nothing_everywhere) {
   const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"}, {}};
+      sourcemeta::one::Authentication::Table{
+          std::filesystem::path{"/no/such/authentication.bin"}},
+      {}};
   EXPECT_TRUE(authentication.permits(at("/"), authentication.caller({})));
   EXPECT_TRUE(
       authentication.permits(at("/internal/foo"), authentication.caller({})));
@@ -156,7 +169,9 @@ TEST(admits_a_caller_presenting_a_credential_everywhere) {
   const std::array<std::string_view, 1> cookies{
       {"sourcemeta_one_session=whatever"}};
   const sourcemeta::one::Authentication authentication{
-      std::filesystem::path{"/no/such/authentication.bin"}, {}};
+      sourcemeta::one::Authentication::Table{
+          std::filesystem::path{"/no/such/authentication.bin"}},
+      {}};
   EXPECT_TRUE(authentication.permits(
       at("/internal/foo"), authentication.caller({.bearer = "anything"})));
   EXPECT_TRUE(authentication.permits(
@@ -168,7 +183,7 @@ TEST(admits_a_caller_presenting_a_credential_everywhere) {
 }
 
 TEST(views_of_nothing_are_the_public_one_alone) {
-  const auto views{sourcemeta::one::Authentication::views({})};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate({})};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}}}));
 }
@@ -182,7 +197,7 @@ TEST(views_of_a_static_key_policy_are_the_public_one_alone) {
         .credential =
             sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
 
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}}}));
 }
@@ -201,7 +216,7 @@ TEST(views_of_several_policies_are_the_public_one_alone) {
         .credential = sourcemeta::one::Authentication::Policy::Token{
             .issuer = "https://idp.example.com/realms/staff"}}}};
 
-  const auto views{sourcemeta::one::Authentication::views(policies)};
+  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
   EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
                        {.name = "public", .policies = {}}}));
 }

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -35,6 +35,19 @@ save(const std::span<const sourcemeta::one::Authentication::Policy> policies,
       destination);
 }
 
+// The names a table serves, which is what the naming rule below decides. What
+// each name stands for is read from what its view reaches rather than from the
+// set behind it, since that set is the artifact's own business
+static auto view_names(const sourcemeta::one::Authentication::Table &table)
+    -> std::vector<std::string_view> {
+  std::vector<std::string_view> result;
+  for (const auto &view : table.views()) {
+    result.push_back(view.name());
+  }
+
+  return result;
+}
+
 static auto test_path(const std::string &name) -> std::filesystem::path {
   return std::filesystem::path{AUTHENTICATION_TEST_DIRECTORY} / name;
 }
@@ -115,8 +128,8 @@ TEST(records_the_anonymous_view_alone) {
   const auto table{gate.views()};
   EXPECT_EQ(table.size(), std::size_t{1});
   EXPECT_EQ(table.at(0).name(), "public");
-  EXPECT_EQ(table.at(0).policies(),
-            sourcemeta::one::Authentication::PolicySet{0});
+  // And it holds nothing, which is what it reaching every location shows
+  EXPECT_TRUE(gate.visible(at("/internal/foo"), table.at(0)));
 }
 
 TEST(shows_every_path_in_its_only_view) {
@@ -133,8 +146,6 @@ TEST(serves_a_name_no_view_holds_as_the_anonymous_one) {
       std::filesystem::path{"/no/such/authentication.bin"}};
   const auto withdrawn{gate.view("retired")};
   EXPECT_EQ(withdrawn.name(), "public");
-  EXPECT_EQ(withdrawn.policies(),
-            sourcemeta::one::Authentication::PolicySet{0});
   // Nothing is governed here, so the one view shows every location whichever
   // name it was asked for
   EXPECT_TRUE(gate.visible(at("/"), withdrawn));
@@ -184,40 +195,9 @@ TEST(admits_a_caller_presenting_a_credential_everywhere) {
 }
 
 TEST(views_of_nothing_are_the_public_one_alone) {
-  const auto views{sourcemeta::one::Authentication::Table::enumerate({})};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}}}));
-}
-
-TEST(views_of_a_static_key_policy_are_the_public_one_alone) {
-  const std::array<std::string_view, 1> paths{{"/private"}};
-  const std::array<std::string_view, 1> keys{{"secret"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 1> policies{
-      {{.paths = paths,
-        .name = "vault",
-        .credential =
-            sourcemeta::one::Authentication::Policy::ApiKey{.keys = keys}}}};
-
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}}}));
-}
-
-TEST(views_of_several_policies_are_the_public_one_alone) {
-  const std::array<std::string_view, 1> first_paths{{"/legal"}};
-  const std::array<std::string_view, 1> second_paths{{"/tech"}};
-  const std::array<sourcemeta::one::Authentication::Policy, 2> policies{
-      {{.paths = first_paths,
-        .name = "legal",
-        .credential =
-            sourcemeta::one::Authentication::Policy::Token{
-                .issuer = "https://idp.example.com/realms/staff"}},
-       {.paths = second_paths,
-        .name = "tech",
-        .credential = sourcemeta::one::Authentication::Policy::Token{
-            .issuer = "https://idp.example.com/realms/staff"}}}};
-
-  const auto views{sourcemeta::one::Authentication::Table::enumerate(policies)};
-  EXPECT_EQ(views, (std::vector<sourcemeta::one::Authentication::View>{
-                       {.name = "public", .policies = {}}}));
+  const auto path{test_path("views_of_nothing_are_the_public_one_alone.bin")};
+  save(std::span<const sourcemeta::one::Authentication::Policy>{}, path, path,
+       anywhere);
+  const sourcemeta::one::Authentication::Table gate{path};
+  EXPECT_EQ(view_names(gate), (std::vector<std::string_view>{"public"}));
 }

--- a/test/unit/authentication/authentication_test.cc
+++ b/test/unit/authentication/authentication_test.cc
@@ -114,8 +114,8 @@ TEST(records_the_anonymous_view_alone) {
       std::filesystem::path{"/no/such/authentication.bin"}};
   const auto table{gate.views()};
   EXPECT_EQ(table.size(), std::size_t{1});
-  EXPECT_EQ(table.at(0).name, "public");
-  EXPECT_EQ(table.at(0).policies,
+  EXPECT_EQ(table.at(0).name(), "public");
+  EXPECT_EQ(table.at(0).policies(),
             sourcemeta::one::Authentication::PolicySet{0});
 }
 
@@ -132,8 +132,9 @@ TEST(serves_a_name_no_view_holds_as_the_anonymous_one) {
   const sourcemeta::one::Authentication::Table gate{
       std::filesystem::path{"/no/such/authentication.bin"}};
   const auto withdrawn{gate.view("retired")};
-  EXPECT_EQ(withdrawn.name, "public");
-  EXPECT_EQ(withdrawn.policies, sourcemeta::one::Authentication::PolicySet{0});
+  EXPECT_EQ(withdrawn.name(), "public");
+  EXPECT_EQ(withdrawn.policies(),
+            sourcemeta::one::Authentication::PolicySet{0});
   // Nothing is governed here, so the one view shows every location whichever
   // name it was asked for
   EXPECT_TRUE(gate.visible(at("/"), withdrawn));


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

