### PR TITLE
Give the same-origin path check a single home

### DIFF
--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -1,4 +1,5 @@
 #include <sourcemeta/one/authentication.h>
+#include <sourcemeta/one/shared_uri.h>
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/http.h>
@@ -176,27 +177,6 @@ auto Authentication::Table::enumerate(
 }
 
 namespace {
-
-// Whether a value is somewhere on this instance rather than somewhere else, so
-// that what a login sealed cannot become a redirect to another origin
-auto is_local_path(const std::string_view value) -> bool {
-  if (value.empty() || value.front() != '/') {
-    return false;
-  }
-
-  if (value.size() >= 2 && (value[1] == '/' || value[1] == '\\')) {
-    return false;
-  }
-
-  for (const auto character : value) {
-    const auto code{static_cast<unsigned char>(character)};
-    if (code <= 0x20 || code == 0x7f || character == '\\') {
-      return false;
-    }
-  }
-
-  return true;
-}
 
 // What redeeming an authorization code yields, of which only the identity token
 // decides anything. The access token comes along solely so that a claim missing

--- a/enterprise/authentication/authentication.cc
+++ b/enterprise/authentication/authentication.cc
@@ -1,5 +1,5 @@
 #include <sourcemeta/one/authentication.h>
-#include <sourcemeta/one/shared_uri.h>
+#include <sourcemeta/one/shared.h>
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/http.h>

--- a/enterprise/authentication/authentication_session.h
+++ b/enterprise/authentication/authentication_session.h
@@ -5,10 +5,10 @@
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/jose.h>
+#include <sourcemeta/core/numeric.h>
 
 #include <algorithm>   // std::max
 #include <array>       // std::array
-#include <charconv>    // std::from_chars, std::errc
 #include <chrono>      // std::chrono::sys_seconds, std::chrono::seconds
 #include <cstddef>     // std::size_t
 #include <cstdint>     // std::int64_t, std::uint64_t, std::uint8_t
@@ -162,22 +162,18 @@ inline auto digest_view(const std::array<std::uint8_t, 32> &digest)
 
 inline auto parse_expiry(const std::string_view input)
     -> std::optional<std::chrono::sys_seconds> {
-  if (input.empty()) {
-    return std::nullopt;
-  }
-
-  std::uint64_t count{0};
-  const auto *begin{input.data()};
-  const auto *end{input.data() + input.size()};
-  const auto result{std::from_chars(begin, end, count)};
-  if (result.ec != std::errc{} || result.ptr != end ||
-      count > static_cast<std::uint64_t>(
-                  std::numeric_limits<std::int64_t>::max())) {
+  // Seconds are held exactly rather than through a instant built from a
+  // floating point count, which stops representing every second well before
+  // the range a signed count covers
+  const auto count{sourcemeta::core::to_uint64_t(input)};
+  if (!count.has_value() ||
+      count.value() > static_cast<std::uint64_t>(
+                          std::numeric_limits<std::int64_t>::max())) {
     return std::nullopt;
   }
 
   return std::chrono::sys_seconds{
-      std::chrono::seconds{static_cast<std::int64_t>(count)}};
+      std::chrono::seconds{static_cast<std::int64_t>(count.value())}};
 }
 
 inline auto seal_value(const std::string_view payload,

--- a/src/authentication/CMakeLists.txt
+++ b/src/authentication/CMakeLists.txt
@@ -15,6 +15,8 @@ else()
     SOURCES authentication.cc path.cc)
 endif()
 
+target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::one::shared)
+
 # Paths are the key the policy trie is built from and looked up by, so
 # canonicalising them belongs to this module in both editions
 target_link_libraries(sourcemeta_one_authentication PRIVATE sourcemeta::core::text)

--- a/src/http/include/sourcemeta/one/http_helpers.h
+++ b/src/http/include/sourcemeta/one/http_helpers.h
@@ -9,6 +9,7 @@
 
 #include <sourcemeta/one/http_request.h>
 #include <sourcemeta/one/http_response.h>
+#include <sourcemeta/one/shared_uri.h>
 
 #include <algorithm>   // std::ranges::equal
 #include <cassert>     // assert
@@ -197,10 +198,16 @@ inline auto json_error(const HTTPRequest &request, HTTPResponse &response,
   // https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.2
   // https://datatracker.ietf.org/doc/html/rfc6750#section-3
   if (status == sourcemeta::core::HTTP_STATUS_UNAUTHORIZED) {
-    // A value carrying CR or LF would split the response into headers of the
-    // caller's choosing, so an unusable extension is dropped rather than sent
+    // The extension arrives as a written out auth-param list, quotes included,
+    // and is spliced in as it stands. A control character in it would end the
+    // header early or leave a value RFC 9110 Section 11.6.1 does not admit
+    // inside a quoted-string, so an unusable extension is dropped rather than
+    // sent
     if (challenge.empty() ||
-        challenge.find_first_of("\r\n") != std::string_view::npos) {
+        std::ranges::any_of(challenge, [](const char character) -> bool {
+          const auto code{static_cast<unsigned char>(character)};
+          return code < 0x20 || code == 0x7f;
+        })) {
       response.write_header("WWW-Authenticate", "Bearer realm=\"registry\"");
     } else {
       std::string value{"Bearer realm=\"registry\", "};
@@ -224,28 +231,6 @@ inline auto json_error(const HTTPRequest &request, HTTPResponse &response,
 [[nodiscard]] inline auto prefers_html(const std::string_view accept) -> bool {
   return sourcemeta::core::http_match_accept(
              accept, {"application/json", "text/html"}) == "text/html";
-}
-
-// Whether a redirect target is a safe same-origin local path, so that a login
-// return cannot be turned into an open redirect to another origin. Only a
-// rooted path is accepted, and the protocol-relative and backslash-escaped
-// forms a browser would resolve against a different host are rejected, along
-// with the space and control characters that would make the target an invalid
-// URI-reference in the Location header
-[[nodiscard]] inline auto is_local_path(const std::string_view value) -> bool {
-  if (value.empty() || value.front() != '/') {
-    return false;
-  }
-  if (value.size() >= 2 && (value[1] == '/' || value[1] == '\\')) {
-    return false;
-  }
-  for (const auto character : value) {
-    const auto code{static_cast<unsigned char>(character)};
-    if (code <= 0x20 || code == 0x7f || character == '\\') {
-      return false;
-    }
-  }
-  return true;
 }
 
 // The single shape of an authentication denial on the HTTP surface, so

--- a/src/http/include/sourcemeta/one/http_helpers.h
+++ b/src/http/include/sourcemeta/one/http_helpers.h
@@ -200,13 +200,15 @@ inline auto json_error(const HTTPRequest &request, HTTPResponse &response,
   if (status == sourcemeta::core::HTTP_STATUS_UNAUTHORIZED) {
     // The extension arrives as a written out auth-param list, quotes included,
     // and is spliced in as it stands. A control character in it would end the
-    // header early or leave a value RFC 9110 Section 11.6.1 does not admit
+    // header early or leave a value RFC 9110 Section 5.6.4 does not admit
     // inside a quoted-string, so an unusable extension is dropped rather than
-    // sent
+    // sent. Horizontal tab is not one of those: Section 5.5 lets it sit in a
+    // field value wherever a space may, and it can close neither a header nor
+    // a quoted string
     if (challenge.empty() ||
         std::ranges::any_of(challenge, [](const char character) -> bool {
           const auto code{static_cast<unsigned char>(character)};
-          return code < 0x20 || code == 0x7f;
+          return (code < 0x20 && character != '\t') || code == 0x7f;
         })) {
       response.write_header("WWW-Authenticate", "Bearer realm=\"registry\"");
     } else {

--- a/src/http/include/sourcemeta/one/http_helpers.h
+++ b/src/http/include/sourcemeta/one/http_helpers.h
@@ -9,7 +9,7 @@
 
 #include <sourcemeta/one/http_request.h>
 #include <sourcemeta/one/http_response.h>
-#include <sourcemeta/one/shared_uri.h>
+#include <sourcemeta/one/shared.h>
 
 #include <algorithm>   // std::ranges::equal
 #include <cassert>     // assert

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -1,5 +1,5 @@
 sourcemeta_library(NAMESPACE sourcemeta PROJECT one NAME shared
-  PRIVATE_HEADERS encoding.h version.h
+  PRIVATE_HEADERS encoding.h uri.h version.h
   SOURCES version.cc configure.h.in)
 
 if(ONE_ENTERPRISE)

--- a/src/shared/include/sourcemeta/one/shared.h
+++ b/src/shared/include/sourcemeta/one/shared.h
@@ -5,6 +5,7 @@
 // between the indexer and the server
 
 #include <sourcemeta/one/shared_encoding.h>
+#include <sourcemeta/one/shared_uri.h>
 #include <sourcemeta/one/shared_version.h>
 
 #endif

--- a/src/shared/include/sourcemeta/one/shared_uri.h
+++ b/src/shared/include/sourcemeta/one/shared_uri.h
@@ -1,0 +1,32 @@
+#ifndef SOURCEMETA_ONE_SHARED_URI_H_
+#define SOURCEMETA_ONE_SHARED_URI_H_
+
+#include <string_view> // std::string_view
+
+namespace sourcemeta::one {
+
+// Whether a redirect target is a safe same-origin local path, so that a login
+// return cannot be turned into an open redirect to another origin. Only a
+// rooted path is accepted, and the protocol-relative and backslash-escaped
+// forms a browser would resolve against a different host are rejected, along
+// with the space and control characters that would make the target an invalid
+// URI-reference in the Location header
+[[nodiscard]] inline auto is_local_path(const std::string_view value) -> bool {
+  if (value.empty() || value.front() != '/') {
+    return false;
+  }
+  if (value.size() >= 2 && (value[1] == '/' || value[1] == '\\')) {
+    return false;
+  }
+  for (const auto character : value) {
+    const auto code{static_cast<unsigned char>(character)};
+    if (code <= 0x20 || code == 0x7f || character == '\\') {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace sourcemeta::one
+
+#endif


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

