### PR TITLE
Say enterprise in the name of the public schemas image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -252,7 +252,7 @@ jobs:
       - uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         id: meta
         with:
-          images: ghcr.io/${{ github.repository_owner }}/sourcemeta-schemas
+          images: ghcr.io/${{ github.repository_owner }}/sourcemeta-schemas-enterprise
           labels: |
             org.opencontainers.image.licenses=LicenseRef-Sourcemeta-Commercial
       - uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4

--- a/enterprise/e2e/public/Dockerfile.kraft
+++ b/enterprise/e2e/public/Dockerfile.kraft
@@ -1,4 +1,4 @@
-FROM ghcr.io/sourcemeta/sourcemeta-schemas:main AS builder
+FROM ghcr.io/sourcemeta/sourcemeta-schemas-enterprise:main AS builder
 FROM scratch
 COPY --from=builder /usr/bin/sourcemeta-one-server \
   /usr/bin/sourcemeta-one-server


### PR DESCRIPTION
As this image is also subjected to the commercial license.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

