### PR TITLE
Use `base-compat` on Kraft for `procfs` support

### DIFF
--- a/enterprise/e2e/public/Kraftfile
+++ b/enterprise/e2e/public/Kraftfile
@@ -1,5 +1,5 @@
 spec: v0.6
-runtime: base:latest
+runtime: base-compat:latest
 rootfs: ./Dockerfile.kraft
 labels:
   cloud.unikraft.v1.instances/scale_to_zero.policy: "on"


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

