### PR TITLE
Adopt `SchemaFrame::Mode::Root` from Blaze

### DIFF
--- a/src/index/explorer.h
+++ b/src/index/explorer.h
@@ -11,6 +11,7 @@
 #include <sourcemeta/one/shared.h>
 
 #include <sourcemeta/blaze/foundation.h>
+#include <sourcemeta/blaze/frame.h>
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/mcp.h>
 #include <sourcemeta/core/semver.h>
@@ -399,11 +400,14 @@ struct GENERATE_EXPLORER_SCHEMA_METADATA {
         sourcemeta::one::metapack_read_json(action.dependencies.front())};
     assert(schema_data_option.has_value());
     const auto &schema_data{schema_data_option.value()};
-    const auto id{sourcemeta::blaze::identify(
-        schema_data, [&callback, &resolver](const auto identifier) {
-          return resolver(identifier, callback);
-        })};
-    assert(!id.empty());
+    sourcemeta::blaze::SchemaFrame frame{
+        sourcemeta::blaze::SchemaFrame::Mode::Root};
+    frame.analyse(schema_data, sourcemeta::blaze::schema_walker,
+                  [&callback, &resolver](const auto identifier) {
+                    return resolver(identifier, callback);
+                  });
+    assert(!frame.root().empty());
+    const auto &schema_location{frame.root_location().value().get()};
     auto result{sourcemeta::core::JSON::make_object()};
 
     result.assign("bytes", sourcemeta::core::JSON{static_cast<std::size_t>(
@@ -411,20 +415,13 @@ struct GENERATE_EXPLORER_SCHEMA_METADATA {
     result.assign("bytesBundled",
                   sourcemeta::core::JSON{
                       static_cast<std::size_t>(bundle_info.content_bytes)});
-    result.assign("identifier", sourcemeta::core::JSON{id});
+    result.assign("identifier", sourcemeta::core::JSON{frame.root()});
     result.assign("path", sourcemeta::core::JSON{
                               "/" + resolver_entry.relative_path.string()});
-    const auto base_dialect{sourcemeta::blaze::base_dialect(
-        schema_data, [&callback, &resolver](const auto identifier) {
-          return resolver(identifier, callback);
-        })};
-    assert(base_dialect.has_value());
     result.assign("baseDialect",
-                  sourcemeta::core::JSON{
-                      sourcemeta::blaze::to_string(base_dialect.value())});
-    const auto dialect{sourcemeta::blaze::dialect(schema_data)};
-    assert(!dialect.empty());
-    result.assign("dialect", sourcemeta::core::JSON{dialect});
+                  sourcemeta::core::JSON{sourcemeta::blaze::to_string(
+                      schema_location.base_dialect)});
+    result.assign("dialect", sourcemeta::core::JSON{schema_location.dialect});
 
     if (schema_data.is_object()) {
       const auto title{schema_data.try_at("title")};
@@ -440,11 +437,10 @@ struct GENERATE_EXPLORER_SCHEMA_METADATA {
       auto examples_array{sourcemeta::core::JSON::make_array()};
       const auto *examples{schema_data.try_at("examples")};
       if (examples && examples->is_array() && !examples->empty()) {
-        const auto vocabularies{sourcemeta::blaze::vocabularies(
-            [&callback, &resolver](const auto identifier) {
+        const auto &vocabularies{frame.vocabularies(
+            schema_location, [&callback, &resolver](const auto identifier) {
               return resolver(identifier, callback);
-            },
-            base_dialect.value(), dialect)};
+            })};
         const auto &walker_result{
             sourcemeta::blaze::schema_walker("examples", vocabularies)};
         if (walker_result.type ==

--- a/src/resolver/resolver.cc
+++ b/src/resolver/resolver.cc
@@ -263,23 +263,14 @@ auto Resolver::operator()(
 
   sourcemeta::blaze::SchemaFrame frame{
       sourcemeta::blaze::SchemaFrame::Mode::Locations};
-  const auto identifier_result{sourcemeta::blaze::identify(
-      schema,
-      [this](
-          const auto subidentifier) -> std::optional<sourcemeta::core::JSON> {
-        return this->operator()(subidentifier);
-      },
-      view->dialect)};
-  const auto has_identifier{!identifier_result.empty()};
   frame.analyse(
       schema, sourcemeta::blaze::schema_walker,
       [this](
           const auto subidentifier) -> std::optional<sourcemeta::core::JSON> {
         return this->operator()(subidentifier);
       },
-      view->dialect,
-      // Otherwise we will loop over all locations twice
-      has_identifier ? std::string_view{} : view->original_identifier);
+      view->dialect, view->original_identifier,
+      sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback);
 
   const auto ref_hash{schema.as_object().hash("$ref")};
   const auto dynamic_ref_hash{schema.as_object().hash("$dynamicRef")};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

