### PR TITLE
Stop exposing pointer locations on the `locations` endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -722,7 +722,7 @@ GET /self/v1/api/schemas/health/{path}
 
 *This endpoint retrieves metadata about every URI associated with the JSON
 Schema located at the specified `{path}` parameter, including schema resources,
-subschemas, anchors, and more.*
+subschemas, and anchors.*
 
 ```
 GET /self/v1/api/schemas/locations/{path}

--- a/enterprise/e2e/auth/hurl/mcp-resources.all.hurl
+++ b/enterprise/e2e/auth/hurl/mcp-resources.all.hurl
@@ -92,7 +92,7 @@ jsonpath "$.result.resources[10].uri" == "{{base}}/self/v1/schemas/api/schemas/l
 jsonpath "$.result.resources[10].name" == "Sourcemeta One Schema Locations API Response"
 jsonpath "$.result.resources[10].description" == "The response format for the schema frame locations API endpoint"
 jsonpath "$.result.resources[10].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[10].size" == 2402
+jsonpath "$.result.resources[10].size" == 2391
 jsonpath "$.result.resources[10].annotations.priority" == 0
 jsonpath "$.result.resources[11].uri" == "{{base}}/self/v1/schemas/api/schemas/metadata/response"
 jsonpath "$.result.resources[11].name" == "Sourcemeta One Schema Metadata API Response"
@@ -540,7 +540,7 @@ jsonpath "$.result.resources[13].uri" == "{{base}}/self/v1/schemas/api/schemas/l
 jsonpath "$.result.resources[13].name" == "Sourcemeta One Schema Locations API Response"
 jsonpath "$.result.resources[13].description" == "The response format for the schema frame locations API endpoint"
 jsonpath "$.result.resources[13].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[13].size" == 2402
+jsonpath "$.result.resources[13].size" == 2391
 jsonpath "$.result.resources[13].annotations.priority" == 0
 jsonpath "$.result.resources[14].uri" == "{{base}}/self/v1/schemas/api/schemas/metadata/response"
 jsonpath "$.result.resources[14].name" == "Sourcemeta One Schema Metadata API Response"
@@ -971,7 +971,7 @@ jsonpath "$.result.resources[11].uri" == "{{base}}/self/v1/schemas/api/schemas/l
 jsonpath "$.result.resources[11].name" == "Sourcemeta One Schema Locations API Response"
 jsonpath "$.result.resources[11].description" == "The response format for the schema frame locations API endpoint"
 jsonpath "$.result.resources[11].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[11].size" == 2402
+jsonpath "$.result.resources[11].size" == 2391
 jsonpath "$.result.resources[11].annotations.priority" == 0
 jsonpath "$.result.resources[12].uri" == "{{base}}/self/v1/schemas/api/schemas/metadata/response"
 jsonpath "$.result.resources[12].name" == "Sourcemeta One Schema Metadata API Response"

--- a/enterprise/e2e/html/hurl/mcp-2025-11-25-get_schema_locations.all.hurl
+++ b/enterprise/e2e/html/hurl/mcp-2025-11-25-get_schema_locations.all.hurl
@@ -77,12 +77,12 @@ jsonpath "$.result.structuredContent.static['{{base}}/test/bare/01'].dialect" ==
 variable "text" jsonpath "$.static['{{base}}/test/bare/01'].dialect" == "https://json-schema.org/draft/2020-12/schema"
 jsonpath "$.result.structuredContent.static['{{base}}/test/bare/01'].baseDialect" == "https://json-schema.org/draft/2020-12/schema"
 variable "text" jsonpath "$.static['{{base}}/test/bare/01'].baseDialect" == "https://json-schema.org/draft/2020-12/schema"
-jsonpath "$.result.structuredContent.static['{{base}}/test/bare/01#/$id'].type" == "pointer"
-variable "text" jsonpath "$.static['{{base}}/test/bare/01#/$id'].type" == "pointer"
-jsonpath "$.result.structuredContent.static['{{base}}/test/bare/01#/$schema'].type" == "pointer"
-variable "text" jsonpath "$.static['{{base}}/test/bare/01#/$schema'].type" == "pointer"
-jsonpath "$.result.structuredContent.static['{{base}}/test/bare/01#/type'].type" == "pointer"
-variable "text" jsonpath "$.static['{{base}}/test/bare/01#/type'].type" == "pointer"
+jsonpath "$.result.structuredContent.static['{{base}}/test/bare/01#/$id']" not exists
+variable "text" jsonpath "$.static['{{base}}/test/bare/01#/$id']" not exists
+jsonpath "$.result.structuredContent.static['{{base}}/test/bare/01#/$schema']" not exists
+variable "text" jsonpath "$.static['{{base}}/test/bare/01#/$schema']" not exists
+jsonpath "$.result.structuredContent.static['{{base}}/test/bare/01#/type']" not exists
+variable "text" jsonpath "$.static['{{base}}/test/bare/01#/type']" not exists
 
 POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
 ```
@@ -152,10 +152,10 @@ jsonpath "$.result.structuredContent.dynamic" exists
 variable "text" jsonpath "$.dynamic" exists
 jsonpath "$.result.structuredContent.static['{{base}}/test/object'].type" == "resource"
 variable "text" jsonpath "$.static['{{base}}/test/object'].type" == "resource"
-jsonpath "$.result.structuredContent.static['{{base}}/test/object#/title'].type" == "pointer"
-variable "text" jsonpath "$.static['{{base}}/test/object#/title'].type" == "pointer"
-jsonpath "$.result.structuredContent.static['{{base}}/test/object#/description'].type" == "pointer"
-variable "text" jsonpath "$.static['{{base}}/test/object#/description'].type" == "pointer"
+jsonpath "$.result.structuredContent.static['{{base}}/test/object#/title']" not exists
+variable "text" jsonpath "$.static['{{base}}/test/object#/title']" not exists
+jsonpath "$.result.structuredContent.static['{{base}}/test/object#/description']" not exists
+variable "text" jsonpath "$.static['{{base}}/test/object#/description']" not exists
 jsonpath "$.result.structuredContent.static['{{base}}/test/object#/properties/foo'].type" == "subschema"
 variable "text" jsonpath "$.static['{{base}}/test/object#/properties/foo'].type" == "subschema"
 

--- a/enterprise/e2e/html/hurl/mcp-2025-11-25-resources.all.hurl
+++ b/enterprise/e2e/html/hurl/mcp-2025-11-25-resources.all.hurl
@@ -532,7 +532,7 @@ jsonpath "$.result.resources[35].uri" == "{{base}}/self/v1/schemas/api/schemas/l
 jsonpath "$.result.resources[35].name" == "Sourcemeta One Schema Locations API Response"
 jsonpath "$.result.resources[35].description" == "The response format for the schema frame locations API endpoint"
 jsonpath "$.result.resources[35].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[35].size" == 2402
+jsonpath "$.result.resources[35].size" == 2391
 jsonpath "$.result.resources[35].annotations.priority" == 0
 jsonpath "$.result.resources[36].uri" == "{{base}}/self/v1/schemas/api/schemas/metadata/response"
 jsonpath "$.result.resources[36].name" == "Sourcemeta One Schema Metadata API Response"
@@ -1299,7 +1299,7 @@ jsonpath "$.result.resources[35].uri" == "{{base}}/self/v1/schemas/api/schemas/l
 jsonpath "$.result.resources[35].name" == "Sourcemeta One Schema Locations API Response"
 jsonpath "$.result.resources[35].description" == "The response format for the schema frame locations API endpoint"
 jsonpath "$.result.resources[35].mimeType" == "application/schema+json"
-jsonpath "$.result.resources[35].size" == 2402
+jsonpath "$.result.resources[35].size" == 2391
 jsonpath "$.result.resources[35].annotations.priority" == 0
 jsonpath "$.result.resources[36].uri" == "{{base}}/self/v1/schemas/api/schemas/metadata/response"
 jsonpath "$.result.resources[36].name" == "Sourcemeta One Schema Metadata API Response"

--- a/src/index/generators.h
+++ b/src/index/generators.h
@@ -366,7 +366,7 @@ struct GenerateFrameLocations {
           return resolver(identifier, callback);
         }};
     const sourcemeta::blaze::SchemaFrame frame{
-        sourcemeta::blaze::SchemaFrame::Mode::Pointers, contents,
+        sourcemeta::blaze::SchemaFrame::Mode::Locations, contents,
         sourcemeta::blaze::schema_walker, schema_resolver};
     auto result{sourcemeta::core::JSON::make_object()};
     result.assign("static", sourcemeta::core::JSON::make_object());

--- a/src/self/v1/schemas/api/schemas/locations/response.json
+++ b/src/self/v1/schemas/api/schemas/locations/response.json
@@ -43,7 +43,7 @@
       ],
       "properties": {
         "type": {
-          "enum": [ "resource", "anchor", "pointer", "subschema" ]
+          "enum": [ "resource", "anchor", "subschema" ]
         },
         "base": {
           "x-format-assertion": true,

--- a/test/e2e/headless/hurl/schemas-locations.all.hurl
+++ b/test/e2e/headless/hurl/schemas-locations.all.hurl
@@ -30,45 +30,9 @@ jsonpath "$.static['{{base}}/test/schemas/no-id'].position[0]" == 1
 jsonpath "$.static['{{base}}/test/schemas/no-id'].position[1]" == 1
 jsonpath "$.static['{{base}}/test/schemas/no-id'].position[2]" == 5
 jsonpath "$.static['{{base}}/test/schemas/no-id'].position[3]" == 1
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].base" == "{{base}}/test/schemas/no-id"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].baseDialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].dialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].parent" == ""
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].pointer" == "/$id"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].relativePointer" == "/$id"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].root" == "{{base}}/test/schemas/no-id"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].type" == "pointer"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].position" count == 4
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].position[0]" == 3
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].position[1]" == 3
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].position[2]" == 3
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$id'].position[3]" == 51
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].base" == "{{base}}/test/schemas/no-id"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].baseDialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].dialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].parent" == ""
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].pointer" == "/$schema"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].relativePointer" == "/$schema"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].root" == "{{base}}/test/schemas/no-id"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].type" == "pointer"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].position" count == 4
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].position[0]" == 2
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].position[1]" == 3
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].position[2]" == 2
-jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema'].position[3]" == 54
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].base" == "{{base}}/test/schemas/no-id"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].baseDialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].dialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].parent" == ""
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].pointer" == "/type"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].relativePointer" == "/type"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].root" == "{{base}}/test/schemas/no-id"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].type" == "pointer"
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].position" count == 4
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].position[0]" == 4
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].position[1]" == 3
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].position[2]" == 4
-jsonpath "$.static['{{base}}/test/schemas/no-id#/type'].position[3]" == 18
+jsonpath "$.static['{{base}}/test/schemas/no-id#/$id']" not exists
+jsonpath "$.static['{{base}}/test/schemas/no-id#/$schema']" not exists
+jsonpath "$.static['{{base}}/test/schemas/no-id#/type']" not exists
 
 POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
 ```

--- a/test/e2e/html/hurl/schemas-locations.all.hurl
+++ b/test/e2e/html/hurl/schemas-locations.all.hurl
@@ -30,45 +30,9 @@ jsonpath "$.static['{{base}}/test/v2.0/schema'].position[0]" == 1
 jsonpath "$.static['{{base}}/test/v2.0/schema'].position[1]" == 1
 jsonpath "$.static['{{base}}/test/v2.0/schema'].position[2]" == 5
 jsonpath "$.static['{{base}}/test/v2.0/schema'].position[3]" == 1
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].base" == "{{base}}/test/v2.0/schema"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].baseDialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].dialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].parent" == ""
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].pointer" == "/$id"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].relativePointer" == "/$id"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].root" == "{{base}}/test/v2.0/schema"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].type" == "pointer"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].position" count == 4
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].position[0]" == 3
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].position[1]" == 3
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].position[2]" == 3
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$id'].position[3]" == 49
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].base" == "{{base}}/test/v2.0/schema"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].baseDialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].dialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].parent" == ""
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].pointer" == "/$schema"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].relativePointer" == "/$schema"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].root" == "{{base}}/test/v2.0/schema"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].type" == "pointer"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].position" count == 4
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].position[0]" == 2
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].position[1]" == 3
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].position[2]" == 2
-jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema'].position[3]" == 54
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].base" == "{{base}}/test/v2.0/schema"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].baseDialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].dialect" == "http://json-schema.org/draft-07/schema#"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].parent" == ""
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].pointer" == "/type"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].relativePointer" == "/type"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].root" == "{{base}}/test/v2.0/schema"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].type" == "pointer"
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].position" count == 4
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].position[0]" == 4
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].position[1]" == 3
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].position[2]" == 4
-jsonpath "$.static['{{base}}/test/v2.0/schema#/type'].position[3]" == 19
+jsonpath "$.static['{{base}}/test/v2.0/schema#/$id']" not exists
+jsonpath "$.static['{{base}}/test/v2.0/schema#/$schema']" not exists
+jsonpath "$.static['{{base}}/test/v2.0/schema#/type']" not exists
 
 POST {{base}}/self/v1/api/schemas/evaluate{{schema_path}}
 ```


### PR DESCRIPTION
We were not supposed to do this to begin with.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/one/pull/1256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

